### PR TITLE
`FinalityView`, a `DbReader` wrapper to represent a finalized state

### DIFF
--- a/api/src/accounts.rs
+++ b/api/src/accounts.rs
@@ -67,12 +67,7 @@ impl AccountsApi {
         self.context
             .check_api_output_enabled("Get account", &accept_type)?;
 
-        let context = self.context.clone();
-        api_spawn_blocking(move || {
-            let account = Account::new(context, address.0, ledger_version.0, None, None)?;
-            account.account(&accept_type)
-        })
-        .await
+        self.get_account_inner(accept_type, address.0, ledger_version.0).await
     }
 
     /// Get account resources
@@ -175,6 +170,22 @@ impl AccountsApi {
                 limit.0,
             )?;
             account.modules(&accept_type)
+        })
+        .await
+    }
+}
+
+impl AccountsApi {
+    pub async fn get_account_inner(
+        &self,
+        accept_type: AcceptType,
+        address: Address,
+        ledger_version: Option<U64>,
+    ) -> BasicResultWith404<AccountData> {
+        let context = self.context.clone();
+        api_spawn_blocking(move || {
+            let account = Account::new(context, address, ledger_version, None, None)?;
+            account.account(&accept_type)
         })
         .await
     }

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -837,15 +837,11 @@ impl TransactionsApi {
                 .context("Failed to join task to read transaction by hash")?
                 .context("Failed to read transaction by hash from DB")?;
         Ok(match from_db {
-            None => {
-                let res = self
+            None => self
                 .context
                 .get_pending_transaction_by_hash(hash)
                 .await?
-                .map(|t| t.into());
-                println!("pending_transaction: {:?}", res);
-                res
-            },
+                .map(|t| t.into()),
             _ => from_db.map(|t| t.into()),
         })
     }

--- a/peer-monitoring-service/server/src/tests.rs
+++ b/peer-monitoring-service/server/src/tests.rs
@@ -622,7 +622,6 @@ impl MockClient {
 /// Initializes the Aptos logger for tests
 pub fn initialize_logger() {
     aptos_logger::Logger::builder()
-        .is_async(false)
         .level(Level::Debug)
         .build();
 }

--- a/state-sync/data-streaming-service/src/tests/utils.rs
+++ b/state-sync/data-streaming-service/src/tests/utils.rs
@@ -1041,7 +1041,6 @@ async fn determine_target_ledger_info(
 /// Initializes the Aptos logger for tests
 pub fn initialize_logger() {
     aptos_logger::Logger::builder()
-        .is_async(false)
         .level(Level::Info)
         .build();
 }

--- a/state-sync/storage-service/server/src/tests/utils.rs
+++ b/state-sync/storage-service/server/src/tests/utils.rs
@@ -507,7 +507,6 @@ pub async fn get_transactions_with_proof(
 /// Initializes the Aptos logger for tests
 pub fn initialize_logger() {
     aptos_logger::Logger::builder()
-        .is_async(false)
         .level(Level::Debug)
         .build();
 }

--- a/storage/storage-interface/src/finality_view.rs
+++ b/storage/storage-interface/src/finality_view.rs
@@ -1,6 +1,12 @@
 use std::sync::RwLock;
 
-use aptos_types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
+use aptos_crypto::HashValue;
+use aptos_types::{
+    aggregate_signature::AggregateSignature,
+    block_info::BlockInfo,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    transaction::Version,
+};
 
 use crate::{AptosDbError, DbReader, Result};
 
@@ -21,15 +27,27 @@ impl<Db> FinalityView<Db> {
 }
 
 impl<Db: DbReader> FinalityView<Db> {
-    /// Updates the view for the latest finalized block at the specified height.
+    /// Updates the information on the latest finalized block at the specified height.
     pub fn set_finalized_block_height(&self, height: u64) -> Result<()> {
-        let (start_ver, _, _) = self.reader.get_block_info_by_height(height)?;
-        let ledger_info = match self.reader.get_epoch_ending_ledger_info(start_ver) {
-            Ok(li) => li,
-            Err(AptosDbError::NotFound(_)) => self.reader.get_latest_ledger_info()?,
-            Err(e) => return Err(e),
-        };
-
+        let (_start_ver, end_ver, block_event) = self.reader.get_block_info_by_height(height)?;
+        let block_hash = block_event.hash()?;
+        let block_info = BlockInfo::new(
+            block_event.epoch(),
+            block_event.round(),
+            block_hash,
+            self.reader.get_accumulator_root_hash(end_ver)?,
+            end_ver,
+            block_event.proposed_time(),
+            None,
+        );
+        // FinalityView is created for Movement, where we don't use the consensus hash
+        // or the ledger info signatures. So we leave them empty here and can still construct
+        // a valid ledger info for the view.
+        // In a more general implementation, this API could accept LedgerInfoWithSignatures
+        // which is either preserved from an earlier version, or fudged like in our case.
+        let ledger_info = LedgerInfo::new(block_info, HashValue::zero());
+        let aggregate_signature = AggregateSignature::empty();
+        let ledger_info = LedgerInfoWithSignatures::new(ledger_info, aggregate_signature);
         let mut fin_legder_info = self.finalized_ledger_info.write().unwrap();
         *fin_legder_info = Some(ledger_info);
         Ok(())
@@ -77,6 +95,9 @@ mod tests {
 
     #[test]
     fn test_get_latest_ledger_info() -> anyhow::Result<()> {
+        // If the mock is changed to be stateful, this should be ref-counted
+        // and shared with the view.
+        let mock = MockDbReaderWriter;
         let view = FinalityView::new(MockDbReaderWriter);
 
         let ledger_info = view.get_latest_ledger_info_option()?;
@@ -86,13 +107,28 @@ mod tests {
         // Set the finalized ledger info
         view.set_finalized_block_height(blockheight)?;
 
+        // Capture the block event once
+        let (_start_ver, end_ver, block_event) =
+            mock.get_block_info_by_height(blockheight)?;
+        let block_hash = block_event.hash()?; // Used to verify hash is generated
+
+        let block_info = BlockInfo::new(
+            block_event.epoch(),
+            block_event.round(),
+            block_hash,
+            HashValue::zero(),
+            end_ver,
+            block_event.proposed_time(),
+            None,
+        );
+        let ledger_info = LedgerInfo::new(block_info, HashValue::zero());
+        let expected_ledger_info =
+            LedgerInfoWithSignatures::new(ledger_info, AggregateSignature::empty());
+
         // Get the latest ledger info after setting it
         let ledger_info = view.get_latest_ledger_info_option()?.unwrap();
 
-        assert_eq!(
-            ledger_info.ledger_info().commit_info().id(),
-            HashValue::new([1; HashValue::LENGTH]),
-        );
+        assert_eq!(ledger_info, expected_ledger_info);
 
         Ok(())
     }

--- a/storage/storage-interface/src/finality_view.rs
+++ b/storage/storage-interface/src/finality_view.rs
@@ -31,7 +31,6 @@ impl<Db: DbReader> FinalityView<Db> {
     pub fn set_finalized_block_height(&self, height: u64) -> Result<()> {
         let (_start_ver, end_ver, block_event) = self.reader.get_block_info_by_height(height)?;
         let block_hash = block_event.hash()?;
-        dbg!(block_hash);
         let block_info = BlockInfo::new(
             block_event.epoch(),
             block_event.round(),

--- a/storage/storage-interface/src/finality_view.rs
+++ b/storage/storage-interface/src/finality_view.rs
@@ -70,6 +70,7 @@ mod tests {
     use std::sync::Arc;
 
     use aptos_crypto::HashValue;
+    use aptos_types::state_store::{state_key::StateKey, TStateView as _};
 
     use super::*;
     use crate::{mock::MockDbReaderWriter, state_view::LatestDbStateCheckpointView as _};
@@ -123,9 +124,12 @@ mod tests {
     fn test_latest_state_checkpoint_view() -> anyhow::Result<()> {
         let view = Arc::new(FinalityView::new(MockDbReaderWriter));
         let reader: Arc<dyn DbReader> = view.clone();
-        view.set_finalized_block_height(0)?;
-        let _latest_state_view = reader.latest_state_checkpoint_view()?;
-        // TODO: get some states available from the mock
+        view.set_finalized_block_height(1)?;
+        let latest_state_view = reader.latest_state_checkpoint_view()?;
+        // TODO: modify mock so we get different states for different versions
+        let key = StateKey::raw(vec![1]);
+        let value = latest_state_view.get_state_value(&key)?.unwrap();
+        assert_eq!(value.bytes(), &vec![1]);
         Ok(())
     }
 }

--- a/storage/storage-interface/src/finality_view.rs
+++ b/storage/storage-interface/src/finality_view.rs
@@ -27,8 +27,8 @@ impl<Db> FinalityView<Db> {
 }
 
 impl<Db: DbReader> FinalityView<Db> {
-    /// Updates the information on the latest finalized block's ledger.
-    pub fn set_finalized_ledger_info(&self, height: u64) -> Result<()> {
+    /// Updates the information on the latest finalized block at the specified height.
+    pub fn set_finalized_block_height(&self, height: u64) -> Result<()> {
         let (_start_ver, end_ver, block_event) = self.reader.get_block_info_by_height(height)?;
         let block_hash = block_event.hash()?;
         dbg!(block_hash);
@@ -111,7 +111,7 @@ mod tests {
         let blockheight = 1;
 
         // Set the finalized ledger info
-        view.set_finalized_ledger_info(blockheight).unwrap();
+        view.set_finalized_block_height(blockheight).unwrap();
 
         // Capture the block event once
         let (_start_ver, end_ver, block_event) =
@@ -143,7 +143,7 @@ mod tests {
         let res = view.get_latest_version();
         assert!(res.is_err());
         let blockheight = 1;
-        view.set_finalized_ledger_info(blockheight).unwrap();
+        view.set_finalized_block_height(blockheight).unwrap();
         let version = view.get_latest_version().unwrap();
         assert_eq!(version, 1);
     }
@@ -153,7 +153,7 @@ mod tests {
         let view = FinalityView::new(MockDbReaderWriter);
         let version = view.get_latest_state_checkpoint_version().unwrap();
         assert_eq!(version, None);
-        view.set_finalized_ledger_info(1).unwrap();
+        view.set_finalized_block_height(1).unwrap();
         let version = view.get_latest_state_checkpoint_version().unwrap();
         assert_eq!(version, Some(1));
     }

--- a/storage/storage-interface/src/finality_view.rs
+++ b/storage/storage-interface/src/finality_view.rs
@@ -99,23 +99,23 @@ mod tests {
     use crate::mock::MockDbReaderWriter;
 
     #[test]
-    fn test_get_latest_ledger_info() {
+    fn test_get_latest_ledger_info() -> anyhow::Result<()> {
         // If the mock is changed to be stateful, this should be ref-counted
         // and shared with the view.
         let mock = MockDbReaderWriter;
         let view = FinalityView::new(MockDbReaderWriter);
 
-        let ledger_info = view.get_latest_ledger_info_option().unwrap();
+        let ledger_info = view.get_latest_ledger_info_option()?;
         assert_eq!(ledger_info, None);
         let blockheight = 1;
 
         // Set the finalized ledger info
-        view.set_finalized_block_height(blockheight).unwrap();
+        view.set_finalized_block_height(blockheight)?;
 
         // Capture the block event once
         let (_start_ver, end_ver, block_event) =
-            mock.get_block_info_by_height(blockheight).unwrap();
-        let block_hash = block_event.hash().unwrap(); // Used to verify hash is generated
+            mock.get_block_info_by_height(blockheight)?;
+        let block_hash = block_event.hash()?; // Used to verify hash is generated
 
         let block_info = BlockInfo::new(
             block_event.epoch(),
@@ -131,29 +131,33 @@ mod tests {
             LedgerInfoWithSignatures::new(ledger_info, AggregateSignature::empty());
 
         // Get the latest ledger info after setting it
-        let ledger_info = view.get_latest_ledger_info_option().unwrap().unwrap();
+        let ledger_info = view.get_latest_ledger_info_option()?.unwrap();
 
         assert_eq!(ledger_info, expected_ledger_info);
+
+        Ok(())
     }
 
     #[test]
-    fn test_get_latest_version() {
+    fn test_get_latest_version() -> anyhow::Result<()> {
         let view = FinalityView::new(MockDbReaderWriter);
         let res = view.get_latest_version();
         assert!(res.is_err());
         let blockheight = 1;
-        view.set_finalized_block_height(blockheight).unwrap();
-        let version = view.get_latest_version().unwrap();
+        view.set_finalized_block_height(blockheight)?;
+        let version = view.get_latest_version()?;
         assert_eq!(version, 1);
+        Ok(())
     }
 
     #[test]
-    fn test_get_latest_state_checkpoint_version() {
+    fn test_get_latest_state_checkpoint_version() -> Result<()> {
         let view = FinalityView::new(MockDbReaderWriter);
-        let version = view.get_latest_state_checkpoint_version().unwrap();
+        let version = view.get_latest_state_checkpoint_version()?;
         assert_eq!(version, None);
-        view.set_finalized_block_height(1).unwrap();
-        let version = view.get_latest_state_checkpoint_version().unwrap();
+        view.set_finalized_block_height(1)?;
+        let version = view.get_latest_state_checkpoint_version()?;
         assert_eq!(version, Some(1));
+        Ok(())
     }
 }

--- a/storage/storage-interface/src/finality_view.rs
+++ b/storage/storage-interface/src/finality_view.rs
@@ -1,12 +1,6 @@
 use std::sync::RwLock;
 
-use aptos_crypto::HashValue;
-use aptos_types::{
-    aggregate_signature,
-    block_info::BlockInfo,
-    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
-    transaction::Version,
-};
+use aptos_types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
 
 use crate::{AptosDbError, DbReader, Result};
 
@@ -27,27 +21,15 @@ impl<Db> FinalityView<Db> {
 }
 
 impl<Db: DbReader> FinalityView<Db> {
-    /// Updates the information on the latest finalized block at the specified height.
+    /// Updates the view for the latest finalized block at the specified height.
     pub fn set_finalized_block_height(&self, height: u64) -> Result<()> {
-        let (_start_ver, end_ver, block_event) = self.reader.get_block_info_by_height(height)?;
-        let block_hash = block_event.hash()?;
-        let block_info = BlockInfo::new(
-            block_event.epoch(),
-            block_event.round(),
-            block_hash,
-            self.reader.get_accumulator_root_hash(end_ver)?,
-            end_ver,
-            block_event.proposed_time(),
-            None,
-        );
-        // FinalityView is created for Movement, where we don't use the consensus hash
-        // or the ledger info signatures. So we leave them empty here and can still construct
-        // a valid ledger info for the view.
-        // In a more general implementation, this API could accept LedgerInfoWithSignatures
-        // which is either preserved from an earlier version, or fudged like in our case.
-        let ledger_info = LedgerInfo::new(block_info, HashValue::zero());
-        let aggregate_signature = aggregate_signature::AggregateSignature::empty();
-        let ledger_info = LedgerInfoWithSignatures::new(ledger_info, aggregate_signature);
+        let (start_ver, _, _) = self.reader.get_block_info_by_height(height)?;
+        let ledger_info = match self.reader.get_epoch_ending_ledger_info(start_ver) {
+            Ok(li) => li,
+            Err(AptosDbError::NotFound(_)) => self.reader.get_latest_ledger_info()?,
+            Err(e) => return Err(e),
+        };
+
         let mut fin_legder_info = self.finalized_ledger_info.write().unwrap();
         *fin_legder_info = Some(ledger_info);
         Ok(())
@@ -87,16 +69,13 @@ impl<Db: DbReader> DbReader for FinalityView<Db> {
 mod tests {
     use std::sync::Arc;
 
-    use aptos_types::{aggregate_signature::AggregateSignature, ledger_info::LedgerInfo};
+    use aptos_crypto::HashValue;
 
     use super::*;
     use crate::{mock::MockDbReaderWriter, state_view::LatestDbStateCheckpointView as _};
 
     #[test]
     fn test_get_latest_ledger_info() -> anyhow::Result<()> {
-        // If the mock is changed to be stateful, this should be ref-counted
-        // and shared with the view.
-        let mock = MockDbReaderWriter;
         let view = FinalityView::new(MockDbReaderWriter);
 
         let ledger_info = view.get_latest_ledger_info_option()?;
@@ -106,28 +85,13 @@ mod tests {
         // Set the finalized ledger info
         view.set_finalized_block_height(blockheight)?;
 
-        // Capture the block event once
-        let (_start_ver, end_ver, block_event) =
-            mock.get_block_info_by_height(blockheight)?;
-        let block_hash = block_event.hash()?; // Used to verify hash is generated
-
-        let block_info = BlockInfo::new(
-            block_event.epoch(),
-            block_event.round(),
-            block_hash,
-            HashValue::zero(),
-            end_ver,
-            block_event.proposed_time(),
-            None,
-        );
-        let ledger_info = LedgerInfo::new(block_info, HashValue::zero());
-        let expected_ledger_info =
-            LedgerInfoWithSignatures::new(ledger_info, AggregateSignature::empty());
-
         // Get the latest ledger info after setting it
         let ledger_info = view.get_latest_ledger_info_option()?.unwrap();
 
-        assert_eq!(ledger_info, expected_ledger_info);
+        assert_eq!(
+            ledger_info.ledger_info().commit_info().id(),
+            HashValue::new([1; HashValue::LENGTH]),
+        );
 
         Ok(())
     }

--- a/storage/storage-interface/src/finality_view.rs
+++ b/storage/storage-interface/src/finality_view.rs
@@ -30,10 +30,12 @@ impl<Db: DbReader> FinalityView<Db> {
     /// Updates the information on the latest finalized block's ledger.
     pub fn set_finalized_ledger_info(&self, height: u64) -> Result<()> {
         let (_start_ver, end_ver, block_event) = self.reader.get_block_info_by_height(height)?;
+        let block_hash = block_event.hash()?;
+        dbg!(block_hash);
         let block_info = BlockInfo::new(
             block_event.epoch(),
             block_event.round(),
-            block_event.hash()?,
+            block_hash,
             self.reader.get_accumulator_root_hash(end_ver)?,
             end_ver,
             block_event.proposed_time(),
@@ -99,6 +101,9 @@ mod tests {
 
     #[test]
     fn test_get_latest_ledger_info() {
+        // If the mock is changed to be stateful, this should be ref-counted
+        // and shared with the view.
+        let mock = MockDbReaderWriter;
         let view = FinalityView::new(MockDbReaderWriter);
 
         let ledger_info = view.get_latest_ledger_info_option().unwrap();
@@ -110,7 +115,7 @@ mod tests {
 
         // Capture the block event once
         let (_start_ver, end_ver, block_event) =
-            view.get_block_info_by_height(blockheight).unwrap();
+            mock.get_block_info_by_height(blockheight).unwrap();
         let block_hash = block_event.hash().unwrap(); // Used to verify hash is generated
 
         let block_info = BlockInfo::new(
@@ -129,46 +134,7 @@ mod tests {
         // Get the latest ledger info after setting it
         let ledger_info = view.get_latest_ledger_info_option().unwrap().unwrap();
 
-        // We assert every field except the hash because there is no way
-        // to predict an expected hash value
-        assert_eq!(
-            ledger_info.ledger_info().commit_info().epoch(),
-            expected_ledger_info.ledger_info().commit_info().epoch()
-        );
-        assert_eq!(
-            ledger_info.ledger_info().commit_info().round(),
-            expected_ledger_info.ledger_info().commit_info().round()
-        );
-        assert_eq!(
-            ledger_info.ledger_info().commit_info().version(),
-            expected_ledger_info.ledger_info().commit_info().version()
-        );
-        assert_eq!(
-            ledger_info.ledger_info().commit_info().timestamp_usecs(),
-            expected_ledger_info
-                .ledger_info()
-                .commit_info()
-                .timestamp_usecs()
-        );
-        assert_eq!(
-            ledger_info.ledger_info().commit_info().executed_state_id(),
-            expected_ledger_info
-                .ledger_info()
-                .commit_info()
-                .executed_state_id()
-        );
-        assert_eq!(
-            ledger_info.ledger_info().commit_info().next_epoch_state(),
-            expected_ledger_info
-                .ledger_info()
-                .commit_info()
-                .next_epoch_state()
-        );
-        assert_eq!(
-            ledger_info.ledger_info().consensus_data_hash(),
-            expected_ledger_info.ledger_info().consensus_data_hash()
-        );
-        assert_eq!(ledger_info.signatures(), expected_ledger_info.signatures());
+        assert_eq!(ledger_info, expected_ledger_info);
     }
 
     #[test]
@@ -187,9 +153,6 @@ mod tests {
         let view = FinalityView::new(MockDbReaderWriter);
         let version = view.get_latest_state_checkpoint_version().unwrap();
         assert_eq!(version, None);
-        let fin_ledger_info =
-            LedgerInfoWithSignatures::new(LedgerInfo::dummy(), AggregateSignature::empty());
-        let blockheight = 1;
         view.set_finalized_ledger_info(1).unwrap();
         let version = view.get_latest_state_checkpoint_version().unwrap();
         assert_eq!(version, Some(1));

--- a/storage/storage-interface/src/finality_view.rs
+++ b/storage/storage-interface/src/finality_view.rs
@@ -1,0 +1,73 @@
+use std::sync::RwLock;
+
+use aptos_types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
+
+use crate::{AptosDbError, DbReader, Result};
+
+/// A wrapper over [`DbReader`], representing ledger at the end of a block
+/// as the latest ledger and its version as the latest transaction version.
+pub struct FinalityView<Db> {
+    reader: Db,
+    finalized_ledger_info: RwLock<Option<LedgerInfoWithSignatures>>,
+}
+
+impl<Db> FinalityView<Db> {
+    pub fn new(reader: Db) -> Self {
+        Self {
+            reader,
+            finalized_ledger_info: RwLock::new(None),
+        }
+    }
+}
+
+impl<Db: DbReader> FinalityView<Db> {
+    /// Updates the information on the latest finalized block's ledger.
+    pub fn set_finalized_ledger_info(&self, ledger_info: LedgerInfoWithSignatures) -> Result<()> {
+        // Sanity checks: finalization should not be set on an empty database,
+        // the finality version should not exceed the latest committed.
+        match self.reader.get_latest_state_checkpoint_version()? {
+            None => return Err(AptosDbError::Other("no ledger states to finalize".into())),
+            Some(ver) => {
+                let fin_version = ledger_info.ledger_info().version();
+                if fin_version > ver {
+                    return Err(AptosDbError::Other(format!(
+                        "finality version {fin_version} exceeds committed version {ver}"
+                    )));
+                }
+            },
+        }
+
+        let mut fin_legder_info = self.finalized_ledger_info.write().unwrap();
+        *fin_legder_info = Some(ledger_info);
+        Ok(())
+    }
+}
+
+impl<Db: DbReader> DbReader for FinalityView<Db> {
+    fn get_read_delegatee(&self) -> &dyn DbReader {
+        &self.reader
+    }
+
+    fn get_latest_ledger_info_option(&self) -> Result<Option<LedgerInfoWithSignatures>> {
+        let fin_ledger_info = self.finalized_ledger_info.read().unwrap();
+        Ok(fin_ledger_info.clone())
+    }
+
+    fn get_latest_version(&self) -> Result<Version> {
+        let fin_ledger_info = self.finalized_ledger_info.read().unwrap();
+        fin_ledger_info
+            .as_ref()
+            .map(|li| li.ledger_info().version())
+            .ok_or_else(|| AptosDbError::NotFound("finalized version".into()))
+    }
+
+    fn get_latest_state_checkpoint_version(&self) -> Result<Option<Version>> {
+        let fin_ledger_info = self.finalized_ledger_info.read().unwrap();
+        let version = fin_ledger_info
+            .as_ref()
+            .map(|li| li.ledger_info().version());
+        Ok(version)
+    }
+
+    // TODO: override any other methods needed to maintain the illusion.
+}

--- a/storage/storage-interface/src/finality_view.rs
+++ b/storage/storage-interface/src/finality_view.rs
@@ -93,10 +93,12 @@ impl<Db: DbReader> DbReader for FinalityView<Db> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use aptos_types::{aggregate_signature::AggregateSignature, ledger_info::LedgerInfo};
 
     use super::*;
-    use crate::mock::MockDbReaderWriter;
+    use crate::{mock::MockDbReaderWriter, state_view::LatestDbStateCheckpointView as _};
 
     #[test]
     fn test_get_latest_ledger_info() -> anyhow::Result<()> {
@@ -158,6 +160,16 @@ mod tests {
         view.set_finalized_block_height(1)?;
         let version = view.get_latest_state_checkpoint_version()?;
         assert_eq!(version, Some(1));
+        Ok(())
+    }
+
+    #[test]
+    fn test_latest_state_checkpoint_view() -> anyhow::Result<()> {
+        let view = Arc::new(FinalityView::new(MockDbReaderWriter));
+        let reader: Arc<dyn DbReader> = view.clone();
+        view.set_finalized_block_height(0)?;
+        let _latest_state_view = reader.latest_state_checkpoint_view()?;
+        // TODO: get some states available from the mock
         Ok(())
     }
 }

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -484,6 +484,12 @@ pub trait DbReader: Send + Sync {
     }
 }
 
+impl<T: ?Sized + DbReader> DbReader for Arc<T> {
+    fn get_read_delegatee(&self) -> &dyn DbReader {
+        self
+    }
+}
+
 impl MoveStorage for &dyn DbReader {
     fn fetch_resource_by_version(
         &self,

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -484,9 +484,9 @@ pub trait DbReader: Send + Sync {
     }
 }
 
-impl<T: ?Sized + DbReader> DbReader for Arc<T> {
+impl DbReader for Arc<dyn DbReader> {
     fn get_read_delegatee(&self) -> &dyn DbReader {
-        self
+        &**self
     }
 }
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -45,6 +45,7 @@ pub mod block_info;
 pub mod cached_state_view;
 pub mod errors;
 mod executed_trees;
+pub mod finality_view;
 mod metrics;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod mock;

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -5,6 +5,7 @@
 //! This module provides mock dbreader for tests.
 
 use crate::{errors::AptosDbError, DbReader, DbWriter, Result};
+use aptos_crypto::HashValue;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::AccountResource,
@@ -65,6 +66,30 @@ impl DbReader for MockDbReaderWriter {
         Ok(self
             .get_state_value_by_version(state_key, version)?
             .map(|value| (version, value)))
+    }
+
+    fn get_block_info_by_height(
+        &self,
+        height: u64,
+    ) -> Result<(Version, Version, aptos_types::account_config::NewBlockEvent)> {
+        Ok((
+            0,
+            1,
+            aptos_types::account_config::NewBlockEvent::new(
+                AccountAddress::random(),
+                0,
+                0,
+                height,
+                vec![],
+                AccountAddress::random(),
+                vec![],
+                0,
+            ),
+        ))
+    }
+
+    fn get_accumulator_root_hash(&self, version: Version) -> Result<HashValue> {
+        Ok(HashValue::zero())
     }
 }
 

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -8,20 +8,15 @@ use crate::{errors::AptosDbError, DbReader, DbWriter, Result};
 use aptos_crypto::HashValue;
 use aptos_types::{
     account_address::AccountAddress,
-    account_config::{AccountResource, NewBlockEvent},
+    account_config::AccountResource,
     account_state::AccountState,
-    aggregate_signature::AggregateSignature,
-    block_info::BlockInfo,
-    epoch_state::EpochState,
     event::EventHandle,
-    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     proof::SparseMerkleProofExt,
     state_store::{
         state_key::{StateKey, StateKeyInner},
         state_value::StateValue,
     },
     transaction::Version,
-    validator_verifier::ValidatorVerifier,
 };
 use move_core_types::move_resource::MoveResource;
 
@@ -73,37 +68,14 @@ impl DbReader for MockDbReaderWriter {
             .map(|value| (version, value)))
     }
 
-    fn get_epoch_ending_ledger_info(&self, known_version: u64) -> Result<LedgerInfoWithSignatures> {
-        if known_version == 0 {
-            let next_epoch_state = EpochState {
-                epoch: 1,
-                verifier: ValidatorVerifier::new(vec![]),
-            };
-            let block_info = BlockInfo::new(
-                0,
-                0,
-                HashValue::new([1; HashValue::LENGTH]),
-                HashValue::zero(),
-                1,
-                1717757545265,
-                Some(next_epoch_state),
-            );
-            Ok(LedgerInfoWithSignatures::new(
-                LedgerInfo::new(block_info, HashValue::zero()),
-                AggregateSignature::empty(),
-            ))
-        } else {
-            Err(AptosDbError::NotFound(format!(
-                "mock ledger info for version {known_version}"
-            )))
-        }
-    }
-
-    fn get_block_info_by_height(&self, height: u64) -> Result<(Version, Version, NewBlockEvent)> {
+    fn get_block_info_by_height(
+        &self,
+        height: u64,
+    ) -> Result<(Version, Version, aptos_types::account_config::NewBlockEvent)> {
         Ok((
             0,
             1,
-            NewBlockEvent::new(
+            aptos_types::account_config::NewBlockEvent::new(
                 AccountAddress::ONE,
                 0,
                 0,

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -76,19 +76,19 @@ impl DbReader for MockDbReaderWriter {
             0,
             1,
             aptos_types::account_config::NewBlockEvent::new(
-                AccountAddress::random(),
+                AccountAddress::ONE,
                 0,
                 0,
                 height,
                 vec![],
-                AccountAddress::random(),
+                AccountAddress::TWO,
                 vec![],
                 0,
             ),
         ))
     }
 
-    fn get_accumulator_root_hash(&self, version: Version) -> Result<HashValue> {
+    fn get_accumulator_root_hash(&self, _version: Version) -> Result<HashValue> {
         Ok(HashValue::zero())
     }
 }


### PR DESCRIPTION
### Description

To provide the API view on the finalized blockchain state, add a wrapper that can be set with a `LedgerInfoWithSignatures` to designate and validate some ledger version as the "latest".

### Test Plan

Test behavior of the customized `DbReader` methods of the `FinalityView` wrapper before and after the finalized ledger info is set.
