### PR TITLE
Faucet Instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5957,9 +5957,9 @@ checksum = "3ae2a35373c5c74340b79ae6780b498b2b183915ec5dacf263aac5a099bf485a"
 
 [[package]]
 name = "diesel"
-version = "2.1.4"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62c6fcf842f17f8c78ecf7c81d75c5ce84436b41ee07e03f490fbb5f5a8731d8"
+checksum = "d98235fdc2f355d330a8244184ab6b4b33c28679c0b4158f63138e51d6cf7e88"
 dependencies = [
  "bigdecimal",
  "bitflags 2.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -466,7 +466,7 @@ debug-ignore = { version = "1.0.3", features = ["serde"] }
 derivative = "2.2.0"
 determinator = "0.12.0"
 derive_more = "0.99.11"
-diesel = "2.1.1"
+diesel = "=2.1.1"
 diesel-async = { version = "0.4", features = ["postgres", "tokio"] }
 diesel_migrations = { version = "2.1.0", features = ["postgres"] }
 digest = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -466,7 +466,7 @@ debug-ignore = { version = "1.0.3", features = ["serde"] }
 derivative = "2.2.0"
 determinator = "0.12.0"
 derive_more = "0.99.11"
-diesel = "2.1"
+diesel = "2.1.1"
 diesel-async = { version = "0.4", features = ["postgres", "tokio"] }
 diesel_migrations = { version = "2.1.0", features = ["postgres"] }
 digest = "0.9.0"

--- a/crates/aptos-faucet/core/src/server/run.rs
+++ b/crates/aptos-faucet/core/src/server/run.rs
@@ -323,7 +323,7 @@ impl Run {
 #[derive(Clone, Debug, Parser)]
 pub struct RunSimple {
     #[clap(flatten)]
-    api_connection_config: ApiConnectionConfig,
+    pub api_connection_config: ApiConnectionConfig,
 
     /// What address to listen on.
     #[clap(long, default_value = "0.0.0.0")]

--- a/crates/indexer/src/models/move_tables.rs
+++ b/crates/indexer/src/models/move_tables.rs
@@ -7,6 +7,7 @@ use crate::{
     util::{hash_str, standardize_address},
 };
 use aptos_api_types::{DeleteTableItem, WriteTableItem};
+use aptos_logger::debug;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
@@ -56,6 +57,10 @@ impl TableItem {
         transaction_version: i64,
         transaction_block_height: i64,
     ) -> (Self, CurrentTableItem) {
+        debug!(
+            "Decoding WriteTableItem: {:?}",
+            write_table_item
+        );
         (
             Self {
                 transaction_version,


### PR DESCRIPTION
### Description
Simply makes `api_connection_config` public so that the `suzuka` and `monza` faucets can use `config.toml` to overwrite the appropriate parameters. 

### Test Plan
- Unit tests passing in this repo.
- e2e tests here: https://github.com/movementlabsxyz/movement/pull/93
