### PR TITLE
aptos-db: `revert_commit` reordering and improvements

### DIFF
--- a/storage/aptosdb/src/db/include/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_writer.rs
@@ -237,9 +237,6 @@ impl DbWriter for AptosDB {
         )?;
         truncate_state_merkle_db(&self.state_store.state_merkle_db, target_version)?;
 
-        // Reset buffered state after truncation
-        state_lock.reset();
-
         // Revert block index if event index is skipped.
         if self.skip_index_and_usage {
             let batch = SchemaBatch::new();
@@ -248,6 +245,9 @@ impl DbWriter for AptosDB {
                 .truncate_block_info(target_version, &batch)?;
             self.ledger_db.metadata_db().write_schemas(batch)?;
         }
+
+        // Reset buffered state after truncation
+        state_lock.reset();
 
         Ok(())
     }

--- a/storage/aptosdb/src/db/include/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_writer.rs
@@ -220,6 +220,10 @@ impl DbWriter for AptosDB {
         let latest_version = self.get_latest_ledger_info_version()?;
         let target_version = ledger_info_with_sigs.ledger_info().version();
 
+        // Update in-memory state first, as this is what
+        // concurrent readers would use for the latest ledger info.
+        self.pre_revert(latest_version, &ledger_info_with_sigs);
+
         // Update the provided ledger info and the overall commit progress
         let new_root_hash = ledger_info_with_sigs.commit_info().executed_state_id();
         self.commit_ledger_info(target_version, new_root_hash, Some(&ledger_info_with_sigs))?;

--- a/storage/aptosdb/src/db/include/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_writer.rs
@@ -216,7 +216,7 @@ impl DbWriter for AptosDB {
             .try_lock()
             .expect("Concurrent committing detected.");
 
-        let latest_version = self.get_latest_ledger_info_version()?;
+        let latest_version = self.get_synced_version()?;
         let target_version = ledger_info_with_sigs.ledger_info().version();
 
         // Update in-memory state first, as this is what

--- a/storage/aptosdb/src/event_store/mod.rs
+++ b/storage/aptosdb/src/event_store/mod.rs
@@ -341,24 +341,6 @@ impl EventStore {
         }
         Ok(())
     }
-
-    pub(crate) fn delete_event_accumulator(
-        &self,
-        version: Version,
-        db_batch: &SchemaBatch,
-    ) -> anyhow::Result<()> {
-        let mut iter = self
-            .event_db
-            .iter::<EventAccumulatorSchema>()?;
-        iter.seek(&(version, Position::from_inorder_index(0)))?;
-        while let Some(((ver, position), _)) = iter.next().transpose()? {
-            if ver != version {
-                return Ok(());
-            }
-            db_batch.delete::<EventAccumulatorSchema>(&(version, position))?;
-        }
-        Ok(())
-    }
 }
 
 struct EventHashReader<'a> {

--- a/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
+++ b/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
@@ -309,9 +309,10 @@ impl LedgerMetadataDb {
     /// Delete committed block info indices starting from the specified version.
     pub(crate) fn truncate_block_info(
         &self,
-        from_version: Version,
+        target_version: Version,
         batch: &SchemaBatch,
     ) -> Result<()> {
+        let from_version = target_version + 1;
         let mut iter = self
             .db
             .iter::<BlockByVersionSchema>()?;

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -687,24 +687,6 @@ impl StateStore {
         )
     }
 
-    pub fn revert_value_sets(
-        &self,
-        _first_version: Version,
-        _last_version: Version,
-        _ledger_batch: &SchemaBatch,
-        _sharded_state_kv_batches: &ShardedStateKvSchemaBatch,
-        _state_kv_metadata_batch: &SchemaBatch,
-        _put_state_value_indices: bool,
-    ) -> Result<()> {
-        // TODO: add tombstone entries to StaleStateValueIndexSchema
-        // TODO: revert usage statistics
-        // TODO: remove matching KV pairs from StateValueSchema
-        // TODO: remove matching state value indices from StateValueIndexSchema
-        // while the upstream uses them.
-
-        Ok(())
-    }
-
     pub fn put_state_values(
         &self,
         value_state_sets: Vec<&ShardedStateUpdates>,


### PR DESCRIPTION
### Description

Change the order of database updates when reverting to a past version in the `revert_commit` implementation.
Remove KV data from some important schemas, document debt on removing data from others.

### Test Plan

`cargo test -p aptos-db`

There are very minimal tests covering `revert_commit`, will try to verify that more values were reverted.