### PR TITLE
refactor: APT to MOVE

### DIFF
--- a/api/goldens/aptos_api__tests__transactions_test__test_get_transactions_output_genesis_transaction.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_get_transactions_output_genesis_transaction.json
@@ -10214,7 +10214,7 @@
           "type": "0x1::coin::CoinInfo<0x1::aptos_coin::AptosCoin>",
           "data": {
             "decimals": 8,
-            "name": "Aptos Coin",
+            "name": "Move Coin",
             "supply": {
               "vec": [
                 {
@@ -10233,7 +10233,7 @@
                 }
               ]
             },
-            "symbol": "APT"
+            "symbol": "MOVE"
           }
         },
         "type": "write_resource"
@@ -24701,7 +24701,7 @@
               "type": "0x1::coin::CoinInfo<0x1::aptos_coin::AptosCoin>",
               "data": {
                 "decimals": 8,
-                "name": "Aptos Coin",
+                "name": "Move Coin",
                 "supply": {
                   "vec": [
                     {
@@ -24720,7 +24720,7 @@
                     }
                   ]
                 },
-                "symbol": "APT"
+                "symbol": "MOVE"
               }
             },
             "type": "write_resource"

--- a/aptos-move/framework/aptos-framework/sources/aptos_coin.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_coin.move
@@ -41,8 +41,8 @@ module aptos_framework::aptos_coin {
 
         let (burn_cap, freeze_cap, mint_cap) = coin::initialize_with_parallelizable_supply<AptosCoin>(
             aptos_framework,
-            string::utf8(b"Aptos Coin"),
-            string::utf8(b"APT"),
+            string::utf8(b"Move Coin"),
+            string::utf8(b"MOVE"),
             8, // decimals
             true, // monitor_supply
         );

--- a/aptos-move/framework/aptos-framework/sources/aptos_coin.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_coin.spec.move
@@ -39,8 +39,8 @@ spec aptos_framework::aptos_coin {
 
         let addr = signer::address_of(aptos_framework);
         aborts_if addr != @aptos_framework;
-        aborts_if !string::spec_internal_check_utf8(b"Aptos Coin");
-        aborts_if !string::spec_internal_check_utf8(b"APT");
+        aborts_if !string::spec_internal_check_utf8(b"Move Coin");
+        aborts_if !string::spec_internal_check_utf8(b"MOVE");
         aborts_if exists<MintCapStore>(addr);
         aborts_if exists<coin::CoinInfo<AptosCoin>>(addr);
         aborts_if !exists<aggregator_factory::AggregatorFactory>(addr);

--- a/aptos-move/move-examples/fungible_asset/managed_fungible_asset/sources/managed_fungible_asset.move
+++ b/aptos-move/move-examples/fungible_asset/managed_fungible_asset/sources/managed_fungible_asset.move
@@ -347,12 +347,12 @@ module example_addr::managed_fungible_asset {
 
     #[test_only]
     fun create_test_mfa(creator: &signer): Object<Metadata> {
-        let constructor_ref = &object::create_named_object(creator, b"APT");
+        let constructor_ref = &object::create_named_object(creator, b"MOVE");
         initialize(
             constructor_ref,
             0,
-            utf8(b"Aptos Token"), /* name */
-            utf8(b"APT"), /* symbol */
+            utf8(b"Move Token"), /* name */
+            utf8(b"MOVE"), /* symbol */
             8, /* decimals */
             utf8(b"http://example.com/favicon.ico"), /* icon */
             utf8(b"http://example.com"), /* project */

--- a/types/src/account_config/resources/coin_info.rs
+++ b/types/src/account_config/resources/coin_info.rs
@@ -101,8 +101,8 @@ impl CoinInfoResource {
             integer: None,
         };
         Self {
-            name: "AptosCoin".to_string().into_bytes(),
-            symbol: "APT".to_string().into_bytes(),
+            name: "MoveCoin".to_string().into_bytes(),
+            symbol: "MOVE".to_string().into_bytes(),
             decimals: 8,
             supply: Some(aggregator),
         }

--- a/types/src/transaction/webauthn.rs
+++ b/types/src/transaction/webauthn.rs
@@ -766,7 +766,7 @@ mod tests {
                 "payeeOrigin": "https://localhost:4000",
                 "total": {
                   "value": "1.01",
-                  "currency": "APT"
+                  "currency": "MOVE"
                 },
                 "instrument": {
                   "icon": "https://aptoslabs.com/assets/favicon-2c9e23abc3a3f4c45038e8c784b0a4ecb9051baa.ico",


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
Refactor the name of the native coin from `APT` to `MOVE` and `Aptos Coin` to `Move Coin`

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
http://localhost:8080/v1/accounts/0x1/resources and confirming the `0x1::coin::CoinInfo` has the symbol `MOVE`

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
