### PR TITLE
Allow rewards percentage to be 0

### DIFF
--- a/aptos-move/vm-genesis/Cargo.toml
+++ b/aptos-move/vm-genesis/Cargo.toml
@@ -36,5 +36,4 @@ proptest-derive = { workspace = true }
 
 [features]
 default = []
-aptos = [] # for excluding upstream code
 fuzzing = ["aptos-types/fuzzing", "move-core-types/fuzzing", "move-vm-types/fuzzing"]


### PR DESCRIPTION
## Description

Follow-up to the quick fix of #44.
Instead of fixing up the reward rate in computation, let the `GenesisConfig` field `rewards_apy_percentage` to be set to 0.

Also test that the Movement configuration – practically endless epoch and zero reward rate – works for genesis without division by zero or a validation failure.