### PR TITLE
Don't rely on `tokio_unstable` config flag

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,17 +15,15 @@ xclippy = [
 x = "run --package aptos-cargo-cli --bin aptos-cargo-cli --"
 
 [build]
-rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes"]
+rustflags = ["-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes"]
 
 # TODO(grao): Figure out whether we should enable othaer cpu features, and whether we should use a different way to configure them rather than list every single one here.
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["--cfg", "tokio_unstable", "-C", "link-arg=-fuse-ld=lld", "-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes", "-C", "target-feature=+sse4.2"]
+rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes", "-C", "target-feature=+sse4.2"]
 
 # 64 bit MSVC
 [target.x86_64-pc-windows-msvc]
 rustflags = [
-  "--cfg",
-  "tokio_unstable",
   "-C",
   "force-frame-pointers=yes",
   "-C",

--- a/crates/aptos-runtimes/src/lib.rs
+++ b/crates/aptos-runtimes/src/lib.rs
@@ -44,7 +44,6 @@ where
             format!("{}-{}", thread_name_clone, id)
         })
         .on_thread_start(on_thread_start)
-        .disable_lifo_slot()
         // Limit concurrent blocking tasks from spawn_blocking(), in case, for example, too many
         // Rest API calls overwhelm the node.
         .max_blocking_threads(MAX_BLOCKING_THREADS)


### PR DESCRIPTION
## Description
Tokio does not guarantee semver stability of unstable features, so it's a bad idea to use this flag. It's also annoying to have to override rustflags everywhere.
Remove the `tokio_unstable` flag from local cargo config and change the affected code to not use unstable features.

## Type of Change
- Refactoring

## Which Components or Systems Does This Change Impact?
- Aptos Framework
- Aptos CLI/SDK
- Developer Infrastructure

## How Has This Been Tested?
`cargo check -p movement` should build, while `.cargo/config.toml` has been modified to not pass `--cfg tokio_unstable` to rustc.

## Key Areas to Review
Whether the changes in runtime behavior could be harmful. I don't think so, it's a perf tweak and before we have proof this degrades performance, I think all such tweaks are fair game to remove.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation
