### PR TITLE
Update bridge framework tests

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/bridge.rs
+++ b/aptos-move/e2e-move-tests/src/tests/bridge.rs
@@ -162,7 +162,7 @@ fn test_counterparty() {
 #[test]
 // The relayer has received a message from the source chain of a successful lock
 // Bridge operator calls `lock_bridge_transfer_assets` on the destination chain 
-// `abort_bridge_transfer` can be called by anyone after th 
+// After timelock expires, bridge operator calls `abort_bridge_transfer` 
 fn test_abort() {
     let mut harness = MoveHarness::new();
 

--- a/aptos-move/framework/aptos-framework/doc/atomic_bridge.md
+++ b/aptos-move/framework/aptos-framework/doc/atomic_bridge.md
@@ -2785,10 +2785,10 @@ The amount is burnt from the initiator
 
 ## Function `complete_bridge_transfer`
 
-Bridge operator can complete the transfer
+Anyone with the bridge transfer ID and pre-image can complete the transfer on the source chain
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_complete_bridge_transfer">complete_bridge_transfer</a>(caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_complete_bridge_transfer">complete_bridge_transfer</a>(_caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -2798,11 +2798,10 @@ Bridge operator can complete the transfer
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_complete_bridge_transfer">complete_bridge_transfer</a>(
-    caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    _caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
 ) {
-    assert_is_caller_operator(caller);
     <b>let</b> (_, _) = <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete_transfer">atomic_bridge_store::complete_transfer</a>&lt;<b>address</b>, EthereumAddress&gt;(bridge_transfer_id, create_hashlock(pre_image));
 
     <a href="event.md#0x1_event_emit">event::emit</a>(

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -289,7 +289,7 @@ pub enum EntryFunctionCall {
         bridge_transfer_id: Vec<u8>,
     },
 
-    /// Bridge operator can complete the transfer
+    /// Anyone with the bridge transfer ID and pre-image can complete the transfer on the source chain
     AtomicBridgeInitiatorCompleteBridgeTransfer {
         bridge_transfer_id: Vec<u8>,
         pre_image: Vec<u8>,
@@ -2397,7 +2397,7 @@ pub fn atomic_bridge_counterparty_abort_bridge_transfer(
     ))
 }
 
-/// Bridge operator can complete the transfer
+/// Anyone with the bridge transfer ID and pre-image can complete the transfer on the source chain
 pub fn atomic_bridge_initiator_complete_bridge_transfer(
     bridge_transfer_id: Vec<u8>,
     pre_image: Vec<u8>,


### PR DESCRIPTION
## Description

In `aptos-move/e2e-move-tests/src/tests/bridge.rs`:
- Update `test_counterparty` so anyone with the pre-image can call `atomic_bridge_counterparty::complete_bridge_transfer`
- Update `test_initiator` so initiator calls `atomic_bridge_initiator::complete_bridge_transfer`
- Add `test_refund` and `test_abort`

In `aptos-move/framework/aptos-framework/sources/atomic_bridge.move`:
- Remove `assert_is_caller_operator(caller);` from `atomic_bridge_initiator::complete_bridge_transfer` (see the corresponding `fun` in our audited module: https://github.com/movementlabsxyz/movement/blob/main/protocol-units/bridge/move-modules/sources/atomic_bridge_initiator.move)
- Remove `test_complete_bridge_transfer_by_sender`
- Add `test_complete_bridge_transfer_timelock_expired`

## Type of Change
- [ x] New feature
- [ x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
- Move unit tests: `movement move test`
- Rust E2E tests: `cargo test bridge` 

## Key Areas to Review
- If there is some security reason why only the bridge operator should be allowed to call `atomic_bridge_initiator::complete_bridge_transfer`, then we should update our audited modules. However, I don't see why it would be an issue, if the counterparty lock and abort calls are restricted to the operator.

## Checklist
- [ x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ x] I tested both happy and unhappy path of the functionality
- [ x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
