### PR TITLE
Downgrade bigdecimal dependency to 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,7 +1839,7 @@ dependencies = [
  "aptos-types",
  "async-trait",
  "bcs 0.1.6 (git+https://github.com/movementlabsxyz/bcs.git?rev=bc16d2d39cabafaabd76173dd1b04b2aa170cf0c)",
- "bigdecimal",
+ "bigdecimal 0.3.1",
  "chrono",
  "diesel",
  "diesel_migrations",
@@ -5108,6 +5108,18 @@ dependencies = [
 
 [[package]]
 name = "bigdecimal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
+dependencies = [
+ "num-bigint 0.4.4",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "bigdecimal"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06619be423ea5bb86c95f087d5707942791a08a85530df0db2209a3ecfb8bc9"
@@ -6855,17 +6867,17 @@ checksum = "3ae2a35373c5c74340b79ae6780b498b2b183915ec5dacf263aac5a099bf485a"
 
 [[package]]
 name = "diesel"
-version = "2.2.4"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe8e2e68695bd615d7e4f3227c0727b151330d3e253b525086c348d055d5e"
+checksum = "04001f23ba8843dc315804fa324000376084dfb1c30794ff68dd279e6e5696d5"
 dependencies = [
- "bigdecimal",
+ "bigdecimal 0.4.2",
  "bitflags 2.6.0",
  "byteorder",
  "chrono",
  "diesel_derives",
  "itoa",
- "num-bigint 0.2.6",
+ "num-bigint 0.4.4",
  "num-integer",
  "num-traits",
  "pq-sys",
@@ -7699,7 +7711,7 @@ checksum = "e29e5681dc8556fb9df1409e95eae050e12e8776394313da3546dcb8cf390c73"
 dependencies = [
  "az",
  "bytemuck",
- "half 1.8.2",
+ "half 2.2.1",
  "typenum",
 ]
 
@@ -8765,7 +8777,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -12696,7 +12708,7 @@ dependencies = [
  "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=338f9a1bcc06f62ce4a4994f1642b9a61b631ee0)",
  "async-trait",
  "bcs 0.1.6 (git+https://github.com/movementlabsxyz/bcs.git?rev=bc16d2d39cabafaabd76173dd1b04b2aa170cf0c)",
- "bigdecimal",
+ "bigdecimal 0.4.2",
  "bitflags 2.6.0",
  "canonical_json",
  "chrono",
@@ -16228,7 +16240,7 @@ dependencies = [
  "errno",
  "js-sys",
  "libc",
- "rustix 0.37.27",
+ "rustix 0.38.28",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
  "winapi 0.3.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -484,7 +484,7 @@ backtrace = "0.3.58"
 bcs = { git = "https://github.com/movementlabsxyz/bcs.git", rev = "bc16d2d39cabafaabd76173dd1b04b2aa170cf0c" }
 better_any = "0.1.1"
 bellman = { version = "0.13.1", default-features = false }
-bigdecimal = { version = "0.4.0", features = ["serde"] }
+bigdecimal = { version = "0.3", features = ["serde"] }
 version-compare = "0.1.1"
 bitvec = "1.0.1"
 blake2 = "0.10.4"
@@ -533,7 +533,7 @@ derivation-path = "0.2.0"
 derive_builder = "0.20.0"
 determinator = "0.12.0"
 derive_more = "0.99.11"
-diesel = "2.2.3"
+diesel = "2.2.7"
 diesel-async = { version = "0.5", features = [
     "async-connection-wrapper",
     "postgres",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -484,6 +484,7 @@ backtrace = "0.3.58"
 bcs = { git = "https://github.com/movementlabsxyz/bcs.git", rev = "bc16d2d39cabafaabd76173dd1b04b2aa170cf0c" }
 better_any = "0.1.1"
 bellman = { version = "0.13.1", default-features = false }
+# Bumped down to 0.3 due to https://github.com/diesel-rs/diesel/issues/4477
 bigdecimal = { version = "0.3", features = ["serde"] }
 version-compare = "0.1.1"
 bitvec = "1.0.1"


### PR DESCRIPTION
Fixes #132

A temporary fix to get movement CLI to compile, until https://github.com/diesel-rs/diesel/issues/4477 is fixed.
