### PR TITLE
fix: centralize aptos-indexer-processors deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,7 +1862,7 @@ dependencies = [
  "aptos-indexer-grpc-server-framework",
  "aptos-indexer-grpc-utils",
  "aptos-metrics-core",
- "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=77a36245400250e7d8a854360194288d078681bc)",
+ "aptos-moving-average",
  "aptos-protos 1.3.0",
  "async-trait",
  "clap 4.5.13",
@@ -1889,7 +1889,7 @@ dependencies = [
  "aptos-indexer-grpc-server-framework",
  "aptos-indexer-grpc-utils",
  "aptos-metrics-core",
- "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=77a36245400250e7d8a854360194288d078681bc)",
+ "aptos-moving-average",
  "aptos-protos 1.3.0",
  "aptos-transaction-filter",
  "async-trait",
@@ -1917,7 +1917,7 @@ dependencies = [
  "aptos-indexer-grpc-server-framework",
  "aptos-indexer-grpc-utils",
  "aptos-metrics-core",
- "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=77a36245400250e7d8a854360194288d078681bc)",
+ "aptos-moving-average",
  "async-trait",
  "clap 4.5.13",
  "futures",
@@ -1951,7 +1951,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-mempool-notifications",
  "aptos-metrics-core",
- "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=77a36245400250e7d8a854360194288d078681bc)",
+ "aptos-moving-average",
  "aptos-proptest-helpers",
  "aptos-protos 1.3.0",
  "aptos-runtimes",
@@ -2596,14 +2596,6 @@ dependencies = [
  "sha3 0.9.1",
  "smallvec",
  "tempfile",
-]
-
-[[package]]
-name = "aptos-moving-average"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?branch=mikhail/upstream-bcs#00132c0d205a7a49f54f10842bcdbaabc503dca0"
-dependencies = [
- "chrono",
 ]
 
 [[package]]
@@ -12698,13 +12690,13 @@ dependencies = [
 [[package]]
 name = "processor"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?branch=mikhail/upstream-bcs#00132c0d205a7a49f54f10842bcdbaabc503dca0"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=77a36245400250e7d8a854360194288d078681bc#77a36245400250e7d8a854360194288d078681bc"
 dependencies = [
  "ahash 0.8.11",
  "allocative",
  "allocative_derive",
  "anyhow",
- "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?branch=mikhail/upstream-bcs)",
+ "aptos-moving-average",
  "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=338f9a1bcc06f62ce4a4994f1642b9a61b631ee0)",
  "async-trait",
  "bcs 0.1.6 (git+https://github.com/movementlabsxyz/bcs.git?rev=bc16d2d39cabafaabd76173dd1b04b2aa170cf0c)",
@@ -14279,7 +14271,7 @@ dependencies = [
 [[package]]
 name = "server-framework"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?branch=mikhail/upstream-bcs#00132c0d205a7a49f54f10842bcdbaabc503dca0"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=77a36245400250e7d8a854360194288d078681bc#77a36245400250e7d8a854360194288d078681bc"
 dependencies = [
  "anyhow",
  "aptos-system-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=338f9a1bcc06f62ce4a4994f1642b9a61b631ee0)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -468,6 +468,8 @@ ark-serialize = "0.4.0"
 ark-std = { version = "0.4.0", features = ["getrandom"] }
 
 aptos-moving-average = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "77a36245400250e7d8a854360194288d078681bc" }
+processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "77a36245400250e7d8a854360194288d078681bc", default-features = false }
+server-framework = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "77a36245400250e7d8a854360194288d078681bc", default-features = false }
 
 assert_approx_eq = "1.1.0"
 assert_unordered = "0.3.5"

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -81,7 +81,7 @@ pathsearch = { workspace = true }
 poem = { workspace = true }
 # We set default-features to false so we don't onboard the libpq dep. See more here:
 # https://github.com/aptos-labs/aptos-core/pull/12568
-processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", branch = "mikhail/upstream-bcs", default-features = false }
+processor = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }
 self_update = { git = "https://github.com/banool/self_update.git", rev = "8306158ad0fd5b9d4766a3c6bf967e7ef0ea5c4b", features = [
@@ -91,7 +91,7 @@ self_update = { git = "https://github.com/banool/self_update.git", rev = "830615
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-server-framework = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", branch = "mikhail/upstream-bcs" }
+server-framework = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
Bring all dependencies on the `aptos-indexer-processors` GitHub repository together in the workspace `Cargo.toml` and set the revision consistently.