### PR TITLE
fix: remove false assertion for movement networks

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -699,8 +699,6 @@ module aptos_framework::aptos_governance {
     public fun get_signer_testnet_only(
         core_resources: &signer, signer_address: address): signer acquires GovernanceResponsbility {
         system_addresses::assert_core_resource(core_resources);
-        // Core resources account only has mint capability in tests/testnets.
-        assert!(aptos_coin::has_mint_capability(core_resources), error::unauthenticated(EUNAUTHORIZED));
         get_signer(signer_address)
     }
 


### PR DESCRIPTION
## Description 
The assertion will always fail as it will no longer be true that the core_resources account has the mint capability. We remove it so that subsequent calls to this function will not abort. 

- Removes the assertion (not true for our movement network)

This failure was caught during the framework upgrade testing today. 

## Testing 
All move framework unit tests are passing. 