### PR TITLE
fix: increase txn expiration

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/governed_gas_pool.md
+++ b/aptos-move/framework/aptos-framework/doc/governed_gas_pool.md
@@ -18,6 +18,7 @@
 -  [Function `deposit_from`](#0x1_governed_gas_pool_deposit_from)
 -  [Function `deposit_from_fungible_store`](#0x1_governed_gas_pool_deposit_from_fungible_store)
 -  [Function `deposit_gas_fee`](#0x1_governed_gas_pool_deposit_gas_fee)
+-  [Function `deposit_gas_fee_v2`](#0x1_governed_gas_pool_deposit_gas_fee_v2)
 -  [Function `get_balance`](#0x1_governed_gas_pool_get_balance)
 -  [Specification](#@Specification_1)
     -  [Function `initialize`](#@Specification_1_initialize)
@@ -411,12 +412,39 @@ Deposits gas fees into the governed gas pool.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_gas_fee">deposit_gas_fee</a>(gas_payer: <b>address</b>, gas_fee: u64) <b>acquires</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_GovernedGasPool">GovernedGasPool</a> {
-    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operations_default_to_fa_apt_store_enabled">features::operations_default_to_fa_apt_store_enabled</a>()) {
+    // get the sender <b>to</b> preserve the signature but do nothing
+    <a href="governed_gas_pool.md#0x1_governed_gas_pool_governed_gas_pool_address">governed_gas_pool_address</a>();
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_governed_gas_pool_deposit_gas_fee_v2"></a>
+
+## Function `deposit_gas_fee_v2`
+
+Deposits gas fees into the governed gas pool.
+@param gas_payer The address of the account that paid the gas fees.
+@param gas_fee The amount of gas fees to be deposited.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_gas_fee_v2">deposit_gas_fee_v2</a>(gas_payer: <b>address</b>, gas_fee: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_gas_fee_v2">deposit_gas_fee_v2</a>(gas_payer: <b>address</b>, gas_fee: u64) <b>acquires</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_GovernedGasPool">GovernedGasPool</a> {
+   <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operations_default_to_fa_apt_store_enabled">features::operations_default_to_fa_apt_store_enabled</a>()) {
         <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_from_fungible_store">deposit_from_fungible_store</a>(gas_payer, gas_fee);
     } <b>else</b> {
         <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_from">deposit_from</a>&lt;AptosCoin&gt;(gas_payer, gas_fee);
     };
-
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/transaction_validation.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_validation.md
@@ -649,7 +649,7 @@ Called by the Adapter
     <b>if</b> (amount_to_burn &gt; storage_fee_refunded) {
         <b>let</b> burn_amount = amount_to_burn - storage_fee_refunded;
         <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_governed_gas_pool_enabled">features::governed_gas_pool_enabled</a>()) {
-            <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_gas_fee">governed_gas_pool::deposit_gas_fee</a>(gas_payer, burn_amount);
+            <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_gas_fee_v2">governed_gas_pool::deposit_gas_fee_v2</a>(gas_payer, burn_amount);
         } <b>else</b> {
             <a href="transaction_fee.md#0x1_transaction_fee_burn_fee">transaction_fee::burn_fee</a>(gas_payer, burn_amount);
         }

--- a/crates/transaction-emitter-lib/src/args.rs
+++ b/crates/transaction-emitter-lib/src/args.rs
@@ -122,7 +122,7 @@ pub struct EmitArgs {
     #[clap(long)]
     pub target_tps: Option<usize>,
 
-    #[clap(long, default_value_t = 30)]
+    #[clap(long, default_value_t = 120)]
     pub txn_expiration_time_secs: u64,
 
     /// Time to run --emit-tx for in seconds.

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -194,7 +194,7 @@ impl Default for EmitJobRequest {
             init_gas_price_multiplier: 2,
             mint_to_root: false,
             skip_minting_accounts: false,
-            txn_expiration_time_secs: 60,
+            txn_expiration_time_secs: 120,
             init_expiration_multiplier: 3.0,
             init_retry_interval: Duration::from_secs(10),
             num_accounts_mode: NumAccountsMode::TransactionsPerAccount(20),


### PR DESCRIPTION
## Description
Txs are expiring before expiration due to the Celestia bottleneck. 

- Increases expiration to two minutes to allow for Celestia to process. 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
