### PR TITLE
Change some metrics names due to conflicts during the storage migration 

### DIFF
--- a/crates/aptos-drop-helper/src/metrics.rs
+++ b/crates/aptos-drop-helper/src/metrics.rs
@@ -8,7 +8,7 @@ use once_cell::sync::Lazy;
 
 pub static TIMER: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
-        "aptos_drop_helper_timer_seconds",
+        "aptos_drop_helper_timer_seconds_new",
         "Various timers for performance analysis.",
         &["helper_name", "name"],
         exponential_buckets(/*start=*/ 1e-9, /*factor=*/ 2.0, /*count=*/ 32).unwrap(),
@@ -18,7 +18,7 @@ pub static TIMER: Lazy<HistogramVec> = Lazy::new(|| {
 
 pub static GAUGE: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
-        "aptos_drop_helper_gauges",
+        "aptos_drop_helper_gauges_new",
         "Various gauges to help debugging.",
         &["helper_name", "name"],
     )

--- a/storage/aptosdb/src/metrics.rs
+++ b/storage/aptosdb/src/metrics.rs
@@ -12,7 +12,7 @@ use once_cell::sync::Lazy;
 pub static LEDGER_COUNTER: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         // metric name
-        "aptos_storage_ledger",
+        "aptos_storage_ledger_new",
         // metric description
         "Aptos storage ledger counters",
         // metric labels (dimensions)
@@ -23,7 +23,7 @@ pub static LEDGER_COUNTER: Lazy<IntGaugeVec> = Lazy::new(|| {
 
 pub static COMMITTED_TXNS: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
-        "aptos_storage_committed_txns",
+        "aptos_storage_committed_txns_new",
         "Aptos storage committed transactions"
     )
     .unwrap()
@@ -31,7 +31,7 @@ pub static COMMITTED_TXNS: Lazy<IntCounter> = Lazy::new(|| {
 
 pub static LATEST_TXN_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
-        "aptos_storage_latest_transaction_version",
+        "aptos_storage_latest_transaction_version_new",
         "Aptos storage latest transaction version"
     )
     .unwrap()
@@ -39,7 +39,7 @@ pub static LATEST_TXN_VERSION: Lazy<IntGauge> = Lazy::new(|| {
 
 pub static LEDGER_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
-        "aptos_storage_ledger_version",
+        "aptos_storage_ledger_version_new",
         "Version in the latest saved ledger info."
     )
     .unwrap()
@@ -47,19 +47,19 @@ pub static LEDGER_VERSION: Lazy<IntGauge> = Lazy::new(|| {
 
 pub static NEXT_BLOCK_EPOCH: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
-        "aptos_storage_next_block_epoch",
+        "aptos_storage_next_block_epoch_new",
         "ledger_info.next_block_epoch() for the latest saved ledger info."
     )
     .unwrap()
 });
 
 pub static STATE_ITEMS: Lazy<IntGauge> = Lazy::new(|| {
-    register_int_gauge!("aptos_storage_state_items", "Total number of state items.").unwrap()
+    register_int_gauge!("aptos_storage_state_items_new", "Total number of state items.").unwrap()
 });
 
 pub static TOTAL_STATE_BYTES: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
-        "aptos_storage_total_state_bytes",
+        "aptos_storage_total_state_bytes_new",
         "Total size in bytes of all state items."
     )
     .unwrap()
@@ -68,7 +68,7 @@ pub static TOTAL_STATE_BYTES: Lazy<IntGauge> = Lazy::new(|| {
 pub static PRUNER_WINDOW: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         // metric name
-        "aptos_storage_prune_window",
+        "aptos_storage_prune_window_new",
         // metric description
         "Aptos storage prune window",
         // metric labels (dimensions)
@@ -81,7 +81,7 @@ pub static PRUNER_WINDOW: Lazy<IntGaugeVec> = Lazy::new(|| {
 pub static PRUNER_VERSIONS: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         // metric name
-        "aptos_pruner_versions",
+        "aptos_pruner_versions_new",
         // metric description
         "Aptos pruner versions",
         // metric labels (dimensions)
@@ -95,7 +95,7 @@ pub static PRUNER_VERSIONS: Lazy<IntGaugeVec> = Lazy::new(|| {
 pub static PRUNER_BATCH_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         // metric name
-        "pruner_batch_size",
+        "pruner_batch_size_new",
         // metric description
         "Aptos pruner batch size",
         // metric labels (dimensions)
@@ -107,7 +107,7 @@ pub static PRUNER_BATCH_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
 pub static API_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         // metric name
-        "aptos_storage_api_latency_seconds",
+        "aptos_storage_api_latency_seconds_new",
         // metric description
         "Aptos storage api latency in seconds",
         // metric labels (dimensions)
@@ -120,7 +120,7 @@ pub static API_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
 pub static OTHER_TIMERS_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         // metric name
-        "aptos_storage_other_timers_seconds",
+        "aptos_storage_other_timers_seconds_new",
         // metric description
         "Various timers below public API level.",
         // metric labels (dimensions)
@@ -133,7 +133,7 @@ pub static OTHER_TIMERS_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
 pub static NODE_CACHE_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         // metric name
-        "aptos_storage_node_cache_seconds",
+        "aptos_storage_node_cache_seconds_new",
         // metric description
         "Latency of node cache.",
         // metric labels (dimensions)
@@ -147,7 +147,7 @@ pub static NODE_CACHE_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
 pub static ROCKSDB_PROPERTIES: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         // metric name
-        "aptos_rocksdb_properties",
+        "aptos_rocksdb_properties_new",
         // metric description
         "rocksdb integer properties",
         // metric labels (dimensions)
@@ -160,7 +160,7 @@ pub static ROCKSDB_PROPERTIES: Lazy<IntGaugeVec> = Lazy::new(|| {
 pub static ROCKSDB_SHARD_PROPERTIES: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         // metric name
-        "aptos_rocksdb_shard_properties",
+        "aptos_rocksdb_shard_properties_new",
         // metric description
         "sharded rocksdb integer properties",
         // metric labels (dimensions)
@@ -172,7 +172,7 @@ pub static ROCKSDB_SHARD_PROPERTIES: Lazy<IntGaugeVec> = Lazy::new(|| {
 // Async committer gauges:
 pub(crate) static LATEST_SNAPSHOT_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
-        "aptos_storage_latest_state_snapshot_version",
+        "aptos_storage_latest_state_snapshot_version_new",
         "The version of the most recent snapshot."
     )
     .unwrap()
@@ -180,7 +180,7 @@ pub(crate) static LATEST_SNAPSHOT_VERSION: Lazy<IntGauge> = Lazy::new(|| {
 
 pub(crate) static LATEST_CHECKPOINT_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
-        "aptos_storage_latest_state_checkpoint_version",
+        "aptos_storage_latest_state_checkpoint_version_new",
         "The version of the most recent committed checkpoint."
     )
     .unwrap()
@@ -190,7 +190,7 @@ pub(crate) static LATEST_CHECKPOINT_VERSION: Lazy<IntGauge> = Lazy::new(|| {
 
 pub(crate) static BACKUP_EPOCH_ENDING_EPOCH: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
-        "aptos_backup_handler_epoch_ending_epoch",
+        "aptos_backup_handler_epoch_ending_epoch_new",
         "Current epoch returned in an epoch ending backup."
     )
     .unwrap()
@@ -198,7 +198,7 @@ pub(crate) static BACKUP_EPOCH_ENDING_EPOCH: Lazy<IntGauge> = Lazy::new(|| {
 
 pub(crate) static BACKUP_TXN_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
-        "aptos_backup_handler_transaction_version",
+        "aptos_backup_handler_transaction_version_new",
         "Current version returned in a transaction backup."
     )
     .unwrap()
@@ -206,7 +206,7 @@ pub(crate) static BACKUP_TXN_VERSION: Lazy<IntGauge> = Lazy::new(|| {
 
 pub(crate) static BACKUP_STATE_SNAPSHOT_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
-        "aptos_backup_handler_state_snapshot_version",
+        "aptos_backup_handler_state_snapshot_version_new",
         "Version of requested state snapshot backup."
     )
     .unwrap()
@@ -214,7 +214,7 @@ pub(crate) static BACKUP_STATE_SNAPSHOT_VERSION: Lazy<IntGauge> = Lazy::new(|| {
 
 pub(crate) static BACKUP_STATE_SNAPSHOT_LEAF_IDX: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
-        "aptos_backup_handler_state_snapshot_leaf_index",
+        "aptos_backup_handler_state_snapshot_leaf_index_new",
         "Index of current leaf index returned in a state snapshot backup."
     )
     .unwrap()
@@ -222,7 +222,7 @@ pub(crate) static BACKUP_STATE_SNAPSHOT_LEAF_IDX: Lazy<IntGauge> = Lazy::new(|| 
 
 pub static BACKUP_TIMER: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
-        "aptos_backup_handler_timers_seconds",
+        "aptos_backup_handler_timers_seconds_new",
         "Various timers for performance analysis.",
         &["name"],
         exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 32).unwrap(),
@@ -232,7 +232,7 @@ pub static BACKUP_TIMER: Lazy<HistogramVec> = Lazy::new(|| {
 
 pub static CONCURRENCY_GAUGE: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
-        "aptos_storage_api_concurrency",
+        "aptos_storage_api_concurrency_new",
         "Call concurrency by API.",
         &["name"]
     )
@@ -240,13 +240,13 @@ pub static CONCURRENCY_GAUGE: Lazy<IntGaugeVec> = Lazy::new(|| {
 });
 
 pub static GAUGE: Lazy<IntGaugeVec> = Lazy::new(|| {
-    register_int_gauge_vec!("aptos_storage_gauge", "Various gauges", &["name"]).unwrap()
+    register_int_gauge_vec!("aptos_storage_gauge_new", "Various gauges", &["name"]).unwrap()
 });
 
 pub static COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         // metric name
-        "aptos_storage_counter",
+        "aptos_storage_counter_new",
         // metric description
         "Various counters for Aptos DB / storage.",
         // metric labels (dimensions)

--- a/storage/schemadb/src/metrics.rs
+++ b/storage/schemadb/src/metrics.rs
@@ -11,7 +11,7 @@ use once_cell::sync::Lazy;
 pub static APTOS_SCHEMADB_SEEK_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         // metric name
-        "aptos_schemadb_seek_latency_seconds",
+        "aptos_schemadb_seek_latency_seconds_new",
         // metric description
         "Aptos schemadb seek latency in seconds",
         // metric labels (dimensions)
@@ -24,7 +24,7 @@ pub static APTOS_SCHEMADB_SEEK_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|
 pub static APTOS_SCHEMADB_ITER_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         // metric name
-        "aptos_schemadb_iter_latency_seconds",
+        "aptos_schemadb_iter_latency_seconds_new",
         // metric description
         "Aptos schemadb iter latency in seconds",
         // metric labels (dimensions)
@@ -37,7 +37,7 @@ pub static APTOS_SCHEMADB_ITER_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|
 pub static APTOS_SCHEMADB_ITER_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         // metric name
-        "aptos_schemadb_iter_bytes",
+        "aptos_schemadb_iter_bytes_new",
         // metric description
         "Aptos schemadb iter size in bytes",
         // metric labels (dimensions)
@@ -49,7 +49,7 @@ pub static APTOS_SCHEMADB_ITER_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
 pub static APTOS_SCHEMADB_GET_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         // metric name
-        "aptos_schemadb_get_latency_seconds",
+        "aptos_schemadb_get_latency_seconds_new",
         // metric description
         "Aptos schemadb get latency in seconds",
         // metric labels (dimensions)
@@ -62,7 +62,7 @@ pub static APTOS_SCHEMADB_GET_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(||
 pub static APTOS_SCHEMADB_GET_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         // metric name
-        "aptos_schemadb_get_bytes",
+        "aptos_schemadb_get_bytes_new",
         // metric description
         "Aptos schemadb get call returned data size in bytes",
         // metric labels (dimensions)
@@ -74,7 +74,7 @@ pub static APTOS_SCHEMADB_GET_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
 pub static APTOS_SCHEMADB_BATCH_COMMIT_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         // metric name
-        "aptos_schemadb_batch_commit_latency_seconds",
+        "aptos_schemadb_batch_commit_latency_seconds_new",
         // metric description
         "Aptos schemadb schema batch commit latency in seconds",
         // metric labels (dimensions)
@@ -87,7 +87,7 @@ pub static APTOS_SCHEMADB_BATCH_COMMIT_LATENCY_SECONDS: Lazy<HistogramVec> = Laz
 pub static APTOS_SCHEMADB_BATCH_COMMIT_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         // metric name
-        "aptos_schemadb_batch_commit_bytes",
+        "aptos_schemadb_batch_commit_bytes_new",
         // metric description
         "Aptos schemadb schema batch commit size in bytes",
         // metric labels (dimensions)
@@ -99,7 +99,7 @@ pub static APTOS_SCHEMADB_BATCH_COMMIT_BYTES: Lazy<HistogramVec> = Lazy::new(|| 
 pub static APTOS_SCHEMADB_PUT_BYTES_SAMPLED: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         // metric name
-        "aptos_schemadb_put_bytes_sampled",
+        "aptos_schemadb_put_bytes_sampled_new",
         // metric description
         "Aptos schemadb put call puts data size in bytes (sampled)",
         // metric labels (dimensions)
@@ -110,7 +110,7 @@ pub static APTOS_SCHEMADB_PUT_BYTES_SAMPLED: Lazy<HistogramVec> = Lazy::new(|| {
 
 pub static APTOS_SCHEMADB_DELETES_SAMPLED: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
-        "aptos_storage_deletes_sampled",
+        "aptos_storage_deletes_sampled_new",
         "Aptos storage delete calls (sampled)",
         &["cf_name"]
     )

--- a/storage/scratchpad/src/sparse_merkle/metrics.rs
+++ b/storage/scratchpad/src/sparse_merkle/metrics.rs
@@ -11,7 +11,7 @@ use once_cell::sync::Lazy;
 
 pub static TIMER: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
-        "aptos_scratchpad_smt_timer_seconds",
+        "aptos_scratchpad_smt_timer_seconds_new",
         "Various timers for performance analysis.",
         &["name"],
         exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 22).unwrap(),
@@ -21,7 +21,7 @@ pub static TIMER: Lazy<HistogramVec> = Lazy::new(|| {
 
 pub static GENERATION: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
-        "aptos_scratchpad_smt_generation",
+        "aptos_scratchpad_smt_generation_new",
         "Various generations to help debugging.",
         &["name"],
     )


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR is related to problems in https://github.com/movementlabsxyz/movement-migration/pull/33.
The `movement` repo has dependencies from the `aptos-core` repo. When used in conjunction with crates from this repository, this results in metrics being registered twice, causing the process to panic.

A temporary workaround for this problem is to rename the metrics until a better solution is found.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
