### PR TITLE
feat: functions to destroy SetVersionCapability and Delegations structs

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/aptos_coin.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_coin.move
@@ -223,8 +223,8 @@ module aptos_framework::aptos_coin {
         (burn_cap, mint_cap)
     }
 
-    /// Initializes the Delegations resource under `@aptos_framework`.
     #[test_only]
+    /// Initializes the Delegations resource under `@aptos_framework`.
     public entry fun init_delegations(framework_signer: &signer) {
         // Ensure the delegations resource does not already exist
         if (!exists<Delegations>(@aptos_framework)) {

--- a/aptos-move/framework/aptos-framework/sources/configs/version.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/version.move
@@ -76,6 +76,12 @@ module aptos_framework::version {
         }
     }
 
+    /// Destroy the SetVersionCapability resource from the given account.
+    public fun destroy_set_version_capability_from(account: &signer, from: address) acquires SetVersionCapability {
+        system_addresses::assert_aptos_framework(account);
+        let SetVersionCapability {} = move_from<SetVersionCapability>(from);
+    }
+
     /// Only called in tests and testnets. This allows the core resources account, which only exists in tests/testnets,
     /// to update the version.
     fun initialize_for_test(core_resources: &signer) {
@@ -111,5 +117,25 @@ module aptos_framework::version {
     ) acquires Version {
         initialize(&aptos_framework, 1);
         set_version(&random_account, 2);
+    }
+
+    #[test(aptos_framework = @aptos_framework, destination = @0x2)]
+    public entry fun test_destroy_set_version_capability(
+        aptos_framework: &signer,
+        destination: &signer,
+    ) acquires SetVersionCapability {
+        // Ensure the SetVersionCapability exists under the destination account
+        if (!exists<SetVersionCapability>(signer::address_of(destination))) {
+            move_to(destination, SetVersionCapability {});
+        };
+
+        // Confirm it now exists
+        assert!(exists<SetVersionCapability>(signer::address_of(destination)), 1);
+
+        // Destroy the SetVersionCapability resource
+        destroy_set_version_capability_from(aptos_framework, signer::address_of(destination));
+
+        // Confirm it's gone
+        assert!(!exists<SetVersionCapability>(signer::address_of(destination)), 2);
     }
 }


### PR DESCRIPTION
## Description
- Addresses https://github.com/movementlabsxyz/movement-migration/issues/36 
- Adds `version::destroy_set_version_capability_from` and `aptos_coin::destroy_delegations_from` along with unit tests

## Type of Change
- [ x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

- `movement move test --package-dir aptos-move/framework/aptos-framework`

## Key Areas to Review


## Checklist
- [x ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
