### PR TITLE
feat: annotate some functions in `object.move` as `#[view]`

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/object.md
+++ b/aptos-move/framework/aptos-framework/doc/object.md
@@ -624,7 +624,7 @@ Exceeds maximum nesting for an object transfer.
 
 
 
-<a id="0x1_object_ENOT_OBJECT_OWNER"></a>
+<a id="0x1_object_ENOT_"></a>
 
 The caller does not have ownership permissions
 

--- a/aptos-move/framework/aptos-framework/sources/object.move
+++ b/aptos-move/framework/aptos-framework/sources/object.move
@@ -644,6 +644,7 @@ module aptos_framework::object {
         borrow_global<ObjectCore>(object.inner).allow_ungated_transfer
     }
 
+    #[view]
     /// Return the current owner.
     public fun owner<T: key>(object: Object<T>): address acquires ObjectCore {
         assert!(
@@ -653,11 +654,13 @@ module aptos_framework::object {
         borrow_global<ObjectCore>(object.inner).owner
     }
 
+    #[view]    
     /// Return true if the provided address is the current owner.
     public fun is_owner<T: key>(object: Object<T>, owner: address): bool acquires ObjectCore {
         owner(object) == owner
     }
 
+    #[view]
     /// Return true if the provided address has indirect or direct ownership of the provided object.
     public fun owns<T: key>(object: Object<T>, owner: address): bool acquires ObjectCore {
         let current_address = object_address(&object);
@@ -687,6 +690,7 @@ module aptos_framework::object {
         true
     }
 
+    #[view]
     /// Returns the root owner of an object. As objects support nested ownership, it can be useful
     /// to determine the identity of the starting point of ownership.
     public fun root_owner<T: key>(object: Object<T>): address acquires ObjectCore {


### PR DESCRIPTION
## Description
- Add the `#[view]` annotation to several ownership-related functions in `aptos_framework::object` module. 
- Enable off-chain querying of object ownership status.
- Requested by eco partner.
- Similar to https://github.com/aptos-labs/aptos-core/pull/15996

The following functions have been annotated with `#[view]`:

- `owner`
- `is_owner`
- `owns`
- `root_owner`


## Type of Change
- [x ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
