### PR TITLE
chore: update movement cli for testnet, a few other small cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ test_indexer_grpc/*
 
 # ignore boogie bpl
 boogie.bpl
+
+# ingore movement or aptos configs
+**/config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -139,5 +139,7 @@ test_indexer_grpc/*
 # ignore boogie bpl
 boogie.bpl
 
-# ingore movement or aptos configs
+# ingore .movement or .aptos dirs and configs
+**/.movement
+**/.aptos
 **/config.yaml

--- a/aptos-move/framework/aptos-framework/doc/atomic_bridge.md
+++ b/aptos-move/framework/aptos-framework/doc/atomic_bridge.md
@@ -1,4 +1,303 @@
 
+<a id="0x1_atomic_bridge"></a>
+
+# Module `0x1::atomic_bridge`
+
+
+
+-  [Resource `AptosCoinBurnCapability`](#0x1_atomic_bridge_AptosCoinBurnCapability)
+-  [Resource `AptosCoinMintCapability`](#0x1_atomic_bridge_AptosCoinMintCapability)
+-  [Resource `AptosFABurnCapabilities`](#0x1_atomic_bridge_AptosFABurnCapabilities)
+-  [Resource `AptosFAMintCapabilities`](#0x1_atomic_bridge_AptosFAMintCapabilities)
+-  [Constants](#@Constants_0)
+-  [Function `initialize`](#0x1_atomic_bridge_initialize)
+-  [Function `store_aptos_coin_burn_cap`](#0x1_atomic_bridge_store_aptos_coin_burn_cap)
+-  [Function `store_aptos_coin_mint_cap`](#0x1_atomic_bridge_store_aptos_coin_mint_cap)
+-  [Function `mint`](#0x1_atomic_bridge_mint)
+-  [Function `burn`](#0x1_atomic_bridge_burn)
+
+
+<pre><code><b>use</b> <a href="aptos_coin.md#0x1_aptos_coin">0x1::aptos_coin</a>;
+<b>use</b> <a href="coin.md#0x1_coin">0x1::coin</a>;
+<b>use</b> <a href="fungible_asset.md#0x1_fungible_asset">0x1::fungible_asset</a>;
+</code></pre>
+
+
+
+<a id="0x1_atomic_bridge_AptosCoinBurnCapability"></a>
+
+## Resource `AptosCoinBurnCapability`
+
+
+
+<pre><code><b>struct</b> <a href="atomic_bridge.md#0x1_atomic_bridge_AptosCoinBurnCapability">AptosCoinBurnCapability</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>burn_cap: <a href="coin.md#0x1_coin_BurnCapability">coin::BurnCapability</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">aptos_coin::AptosCoin</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_atomic_bridge_AptosCoinMintCapability"></a>
+
+## Resource `AptosCoinMintCapability`
+
+
+
+<pre><code><b>struct</b> <a href="atomic_bridge.md#0x1_atomic_bridge_AptosCoinMintCapability">AptosCoinMintCapability</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>mint_cap: <a href="coin.md#0x1_coin_MintCapability">coin::MintCapability</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">aptos_coin::AptosCoin</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_atomic_bridge_AptosFABurnCapabilities"></a>
+
+## Resource `AptosFABurnCapabilities`
+
+
+
+<pre><code><b>struct</b> <a href="atomic_bridge.md#0x1_atomic_bridge_AptosFABurnCapabilities">AptosFABurnCapabilities</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>burn_ref: <a href="fungible_asset.md#0x1_fungible_asset_BurnRef">fungible_asset::BurnRef</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_atomic_bridge_AptosFAMintCapabilities"></a>
+
+## Resource `AptosFAMintCapabilities`
+
+
+
+<pre><code><b>struct</b> <a href="atomic_bridge.md#0x1_atomic_bridge_AptosFAMintCapabilities">AptosFAMintCapabilities</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>burn_ref: <a href="fungible_asset.md#0x1_fungible_asset_MintRef">fungible_asset::MintRef</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x1_atomic_bridge_EATOMIC_BRIDGE_NOT_ENABLED"></a>
+
+
+
+<pre><code><b>const</b> <a href="atomic_bridge.md#0x1_atomic_bridge_EATOMIC_BRIDGE_NOT_ENABLED">EATOMIC_BRIDGE_NOT_ENABLED</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x1_atomic_bridge_EATOMIC_BRIDGE_DISABLED"></a>
+
+
+
+<pre><code><b>const</b> <a href="atomic_bridge.md#0x1_atomic_bridge_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>: u64 = 198461;
+</code></pre>
+
+
+
+<a id="0x1_atomic_bridge_initialize"></a>
+
+## Function `initialize`
+
+Initializes the atomic bridge by setting up necessary configurations.
+
+@param aptos_framework The signer representing the Aptos framework.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initialize">initialize</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initialize">initialize</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_atomic_bridge_store_aptos_coin_burn_cap"></a>
+
+## Function `store_aptos_coin_burn_cap`
+
+Stores the burn capability for AptosCoin, converting to a fungible asset reference if the feature is enabled.
+
+@param aptos_framework The signer representing the Aptos framework.
+@param burn_cap The burn capability for AptosCoin.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_aptos_coin_burn_cap">store_aptos_coin_burn_cap</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _burn_cap: <a href="coin.md#0x1_coin_BurnCapability">coin::BurnCapability</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">aptos_coin::AptosCoin</a>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_aptos_coin_burn_cap">store_aptos_coin_burn_cap</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _burn_cap: BurnCapability&lt;AptosCoin&gt;) {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_atomic_bridge_store_aptos_coin_mint_cap"></a>
+
+## Function `store_aptos_coin_mint_cap`
+
+Stores the mint capability for AptosCoin.
+
+@param aptos_framework The signer representing the Aptos framework.
+@param mint_cap The mint capability for AptosCoin.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_aptos_coin_mint_cap">store_aptos_coin_mint_cap</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _mint_cap: <a href="coin.md#0x1_coin_MintCapability">coin::MintCapability</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">aptos_coin::AptosCoin</a>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_aptos_coin_mint_cap">store_aptos_coin_mint_cap</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _mint_cap: MintCapability&lt;AptosCoin&gt;) {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_atomic_bridge_mint"></a>
+
+## Function `mint`
+
+Mints a specified amount of AptosCoin to a recipient's address.
+
+@param recipient The address of the recipient to mint coins to.
+@param amount The amount of AptosCoin to mint.
+@abort If the mint capability is not available.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_mint">mint</a>(_recipient: <b>address</b>, _amount: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_mint">mint</a>(_recipient: <b>address</b>, _amount: u64) {
+   <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_atomic_bridge_burn"></a>
+
+## Function `burn`
+
+Burns a specified amount of AptosCoin from an address.
+
+@param from The address from which to burn AptosCoin.
+@param amount The amount of AptosCoin to burn.
+@abort If the burn capability is not available.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_burn">burn</a>(_from: <b>address</b>, _amount: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_burn">burn</a>(_from: <b>address</b>, _amount: u64) {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
+}
+</code></pre>
+
+
+
+</details>
+
+
+
 <a id="0x1_atomic_bridge_store"></a>
 
 # Module `0x1::atomic_bridge_store`
@@ -33,27 +332,11 @@
 -  [Function `get_bridge_transfer_details_initiator`](#0x1_atomic_bridge_store_get_bridge_transfer_details_initiator)
 -  [Function `get_bridge_transfer_details_counterparty`](#0x1_atomic_bridge_store_get_bridge_transfer_details_counterparty)
 -  [Function `get_bridge_transfer_details`](#0x1_atomic_bridge_store_get_bridge_transfer_details)
--  [Specification](#@Specification_1)
-    -  [Function `initialize`](#@Specification_1_initialize)
-    -  [Function `create_time_lock`](#@Specification_1_create_time_lock)
-    -  [Function `create_details`](#@Specification_1_create_details)
-    -  [Function `add`](#@Specification_1_add)
-    -  [Function `create_hashlock`](#@Specification_1_create_hashlock)
-    -  [Function `complete`](#@Specification_1_complete)
-    -  [Function `cancel`](#@Specification_1_cancel)
-    -  [Function `complete_details`](#@Specification_1_complete_details)
-    -  [Function `complete_transfer`](#@Specification_1_complete_transfer)
-    -  [Function `cancel_details`](#@Specification_1_cancel_details)
 
 
-<pre><code><b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_aptos_hash">0x1::aptos_hash</a>;
-<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs">0x1::bcs</a>;
-<b>use</b> <a href="ethereum.md#0x1_ethereum">0x1::ethereum</a>;
-<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
+<pre><code><b>use</b> <a href="ethereum.md#0x1_ethereum">0x1::ethereum</a>;
 <b>use</b> <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table">0x1::smart_table</a>;
-<b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
 <b>use</b> <a href="timestamp.md#0x1_timestamp">0x1::timestamp</a>;
-<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
 </code></pre>
 
 
@@ -221,6 +504,15 @@ Details on the transfer
 
 
 
+<a id="0x1_atomic_bridge_store_EATOMIC_BRIDGE_DISABLED"></a>
+
+
+
+<pre><code><b>const</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>: u64 = 198461;
+</code></pre>
+
+
+
 <a id="0x1_atomic_bridge_store_CANCELLED_TRANSACTION"></a>
 
 
@@ -341,7 +633,7 @@ Initializes the initiators and counterparties tables and nonce.
 @param aptos_framework The signer for Aptos framework.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_initialize">initialize</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
 </code></pre>
 
 
@@ -350,23 +642,8 @@ Initializes the initiators and counterparties tables and nonce.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
-    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-    <b>move_to</b>(aptos_framework, <a href="atomic_bridge.md#0x1_atomic_bridge_store_Nonce">Nonce</a> {
-        inner: 0,
-    });
-
-    <b>let</b> initiators = <a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;<b>address</b>, EthereumAddress&gt;&gt; {
-        inner: <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_new">smart_table::new</a>(),
-    };
-
-    <b>move_to</b>(aptos_framework, initiators);
-
-    <b>let</b> counterparties = <a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;EthereumAddress, <b>address</b>&gt;&gt; {
-        inner: <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_new">smart_table::new</a>(),
-    };
-
-    <b>move_to</b>(aptos_framework, counterparties);
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_initialize">initialize</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+   <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -412,7 +689,7 @@ Creates a time lock by adding a duration to the current time.
 @abort If lock is not above MIN_TIME_LOCK
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_time_lock">create_time_lock</a>(time_lock: u64): u64
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_time_lock">create_time_lock</a>(_time_lock: u64): u64
 </code></pre>
 
 
@@ -421,9 +698,8 @@ Creates a time lock by adding a duration to the current time.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_time_lock">create_time_lock</a>(time_lock: u64) : u64 {
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_min_time_lock">assert_min_time_lock</a>(time_lock);
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_now">now</a>() + time_lock
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_time_lock">create_time_lock</a>(_time_lock: u64) : u64 {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -446,7 +722,7 @@ Creates bridge transfer details with validation.
 @abort If the amount is zero or locks are invalid.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_details">create_details</a>&lt;Initiator: store, Recipient: store&gt;(initiator: Initiator, recipient: Recipient, amount: u64, hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, time_lock: u64): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_details">create_details</a>&lt;Initiator: store, Recipient: store&gt;(_initiator: Initiator, _recipient: Recipient, _amount: u64, _hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _time_lock: u64): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;
 </code></pre>
 
 
@@ -455,22 +731,9 @@ Creates bridge transfer details with validation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_details">create_details</a>&lt;Initiator: store, Recipient: store&gt;(initiator: Initiator, recipient: Recipient, amount: u64, hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, time_lock: u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_details">create_details</a>&lt;Initiator: store, Recipient: store&gt;(_initiator: Initiator, _recipient: Recipient, _amount: u64, _hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _time_lock: u64)
     : <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt; {
-    <b>assert</b>!(amount &gt; 0, <a href="atomic_bridge.md#0x1_atomic_bridge_store_EZERO_AMOUNT">EZERO_AMOUNT</a>);
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_valid_hash_lock">assert_valid_hash_lock</a>(&hash_lock);
-    time_lock = <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_time_lock">create_time_lock</a>(time_lock);
-
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a> {
-        addresses: <a href="atomic_bridge.md#0x1_atomic_bridge_store_AddressPair">AddressPair</a> {
-            initiator,
-            recipient
-        },
-        amount,
-        hash_lock,
-        time_lock,
-        state: <a href="atomic_bridge.md#0x1_atomic_bridge_store_PENDING_TRANSACTION">PENDING_TRANSACTION</a>,
-    }
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -488,7 +751,7 @@ Record details of a transfer
 @param details The bridge transfer details
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_add">add</a>&lt;Initiator: store, Recipient: store&gt;(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, details: <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_add">add</a>&lt;Initiator: store, Recipient: store&gt;(_bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _details: <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;)
 </code></pre>
 
 
@@ -497,12 +760,8 @@ Record details of a transfer
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_add">add</a>&lt;Initiator: store, Recipient: store&gt;(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, details: <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a> {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_abort_atomic_bridge_enabled">features::abort_atomic_bridge_enabled</a>(), <a href="atomic_bridge.md#0x1_atomic_bridge_store_EATOMIC_BRIDGE_NOT_ENABLED">EATOMIC_BRIDGE_NOT_ENABLED</a>);
-
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_valid_bridge_transfer_id">assert_valid_bridge_transfer_id</a>(&bridge_transfer_id);
-    <b>let</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a> = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;&gt;&gt;(@aptos_framework);
-    <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_add">smart_table::add</a>(&<b>mut</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>.inner, bridge_transfer_id, details);
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_add">add</a>&lt;Initiator: store, Recipient: store&gt;(_bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _details: <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;) {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -520,7 +779,7 @@ Asserts that the time lock is valid.
 @abort If the time lock is invalid.
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_min_time_lock">assert_min_time_lock</a>(time_lock: u64)
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_min_time_lock">assert_min_time_lock</a>(_time_lock: u64)
 </code></pre>
 
 
@@ -529,8 +788,8 @@ Asserts that the time lock is valid.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_min_time_lock">assert_min_time_lock</a>(time_lock: u64) {
-    <b>assert</b>!(time_lock &gt;= <a href="atomic_bridge.md#0x1_atomic_bridge_store_MIN_TIME_LOCK">MIN_TIME_LOCK</a>, <a href="atomic_bridge.md#0x1_atomic_bridge_store_EINVALID_TIME_LOCK">EINVALID_TIME_LOCK</a>);
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_min_time_lock">assert_min_time_lock</a>(_time_lock: u64) {
+    <b>assert</b>!(_time_lock &gt;= <a href="atomic_bridge.md#0x1_atomic_bridge_store_MIN_TIME_LOCK">MIN_TIME_LOCK</a>, <a href="atomic_bridge.md#0x1_atomic_bridge_store_EINVALID_TIME_LOCK">EINVALID_TIME_LOCK</a>);
 }
 </code></pre>
 
@@ -548,7 +807,7 @@ Asserts that the details state is pending.
 @abort If the state is not pending.
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_pending">assert_pending</a>&lt;Initiator: store, Recipient: store&gt;(details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;)
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_pending">assert_pending</a>&lt;Initiator: store, Recipient: store&gt;(_details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;)
 </code></pre>
 
 
@@ -557,8 +816,8 @@ Asserts that the details state is pending.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_pending">assert_pending</a>&lt;Initiator: store, Recipient: store&gt;(details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;) {
-    <b>assert</b>!(details.state == <a href="atomic_bridge.md#0x1_atomic_bridge_store_PENDING_TRANSACTION">PENDING_TRANSACTION</a>, <a href="atomic_bridge.md#0x1_atomic_bridge_store_ENOT_PENDING_TRANSACTION">ENOT_PENDING_TRANSACTION</a>)
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_pending">assert_pending</a>&lt;Initiator: store, Recipient: store&gt;(_details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;) {
+    <b>assert</b>!(_details.state == <a href="atomic_bridge.md#0x1_atomic_bridge_store_PENDING_TRANSACTION">PENDING_TRANSACTION</a>, <a href="atomic_bridge.md#0x1_atomic_bridge_store_ENOT_PENDING_TRANSACTION">ENOT_PENDING_TRANSACTION</a>)
 }
 </code></pre>
 
@@ -576,7 +835,7 @@ Asserts that the hash lock is valid.
 @abort If the hash lock is invalid.
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_valid_hash_lock">assert_valid_hash_lock</a>(hash_lock: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_valid_hash_lock">assert_valid_hash_lock</a>(_hash_lock: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -585,8 +844,8 @@ Asserts that the hash lock is valid.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_valid_hash_lock">assert_valid_hash_lock</a>(hash_lock: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(hash_lock) == 32, <a href="atomic_bridge.md#0x1_atomic_bridge_store_EINVALID_HASH_LOCK">EINVALID_HASH_LOCK</a>);
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_valid_hash_lock">assert_valid_hash_lock</a>(_hash_lock: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(_hash_lock) == 32, <a href="atomic_bridge.md#0x1_atomic_bridge_store_EINVALID_HASH_LOCK">EINVALID_HASH_LOCK</a>);
 }
 </code></pre>
 
@@ -604,7 +863,7 @@ Asserts that the bridge transfer ID is valid.
 @abort If the ID is invalid.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_valid_bridge_transfer_id">assert_valid_bridge_transfer_id</a>(bridge_transfer_id: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_valid_bridge_transfer_id">assert_valid_bridge_transfer_id</a>(_bridge_transfer_id: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -613,8 +872,8 @@ Asserts that the bridge transfer ID is valid.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_valid_bridge_transfer_id">assert_valid_bridge_transfer_id</a>(bridge_transfer_id: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(bridge_transfer_id) == 32, <a href="atomic_bridge.md#0x1_atomic_bridge_store_EINVALID_BRIDGE_TRANSFER_ID">EINVALID_BRIDGE_TRANSFER_ID</a>);
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_valid_bridge_transfer_id">assert_valid_bridge_transfer_id</a>(_bridge_transfer_id: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(_bridge_transfer_id) == 32, <a href="atomic_bridge.md#0x1_atomic_bridge_store_EINVALID_BRIDGE_TRANSFER_ID">EINVALID_BRIDGE_TRANSFER_ID</a>);
 }
 </code></pre>
 
@@ -632,7 +891,7 @@ Creates a hash lock from a pre-image.
 @return The generated hash lock.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_hashlock">create_hashlock</a>(pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_hashlock">create_hashlock</a>(_pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -641,9 +900,8 @@ Creates a hash lock from a pre-image.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_hashlock">create_hashlock</a>(pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) : <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&pre_image) &gt; 0, <a href="atomic_bridge.md#0x1_atomic_bridge_store_EINVALID_PRE_IMAGE">EINVALID_PRE_IMAGE</a>);
-    keccak256(pre_image)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_hashlock">create_hashlock</a>(_pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) : <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -662,7 +920,7 @@ Asserts that the hash lock matches the expected value.
 @abort If the hash lock is incorrect.
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_correct_hash_lock">assert_correct_hash_lock</a>&lt;Initiator: store, Recipient: store&gt;(details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;, hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_correct_hash_lock">assert_correct_hash_lock</a>&lt;Initiator: store, Recipient: store&gt;(_details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;, _hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -671,8 +929,8 @@ Asserts that the hash lock matches the expected value.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_correct_hash_lock">assert_correct_hash_lock</a>&lt;Initiator: store, Recipient: store&gt;(details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;, hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
-    <b>assert</b>!(&hash_lock == &details.hash_lock, <a href="atomic_bridge.md#0x1_atomic_bridge_store_EINVALID_PRE_IMAGE">EINVALID_PRE_IMAGE</a>);
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_correct_hash_lock">assert_correct_hash_lock</a>&lt;Initiator: store, Recipient: store&gt;(_details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;, _hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
+    <b>assert</b>!(&_hash_lock == &_details.hash_lock, <a href="atomic_bridge.md#0x1_atomic_bridge_store_EINVALID_PRE_IMAGE">EINVALID_PRE_IMAGE</a>);
 }
 </code></pre>
 
@@ -690,7 +948,7 @@ Asserts that the time lock has expired.
 @abort If the time lock has not expired.
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_timed_out_lock">assert_timed_out_lock</a>&lt;Initiator: store, Recipient: store&gt;(details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;)
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_timed_out_lock">assert_timed_out_lock</a>&lt;Initiator: store, Recipient: store&gt;(_details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;)
 </code></pre>
 
 
@@ -699,8 +957,8 @@ Asserts that the time lock has expired.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_timed_out_lock">assert_timed_out_lock</a>&lt;Initiator: store, Recipient: store&gt;(details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;) {
-    <b>assert</b>!(<a href="atomic_bridge.md#0x1_atomic_bridge_store_now">now</a>() &gt; details.time_lock, <a href="atomic_bridge.md#0x1_atomic_bridge_store_ENOT_EXPIRED">ENOT_EXPIRED</a>);
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_timed_out_lock">assert_timed_out_lock</a>&lt;Initiator: store, Recipient: store&gt;(_details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;) {
+    <b>assert</b>!(<a href="atomic_bridge.md#0x1_atomic_bridge_store_now">now</a>() &gt; _details.time_lock, <a href="atomic_bridge.md#0x1_atomic_bridge_store_ENOT_EXPIRED">ENOT_EXPIRED</a>);
 }
 </code></pre>
 
@@ -718,7 +976,7 @@ Asserts we are still within the timelock.
 @abort If the time lock has expired.
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_within_timelock">assert_within_timelock</a>&lt;Initiator: store, Recipient: store&gt;(details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;)
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_within_timelock">assert_within_timelock</a>&lt;Initiator: store, Recipient: store&gt;(_details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;)
 </code></pre>
 
 
@@ -727,8 +985,8 @@ Asserts we are still within the timelock.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_within_timelock">assert_within_timelock</a>&lt;Initiator: store, Recipient: store&gt;(details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;) {
-    <b>assert</b>!(!(<a href="atomic_bridge.md#0x1_atomic_bridge_store_now">now</a>() &gt; details.time_lock), <a href="atomic_bridge.md#0x1_atomic_bridge_store_EEXPIRED">EEXPIRED</a>);
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_within_timelock">assert_within_timelock</a>&lt;Initiator: store, Recipient: store&gt;(_details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;) {
+    <b>assert</b>!(!(<a href="atomic_bridge.md#0x1_atomic_bridge_store_now">now</a>() &gt; _details.time_lock), <a href="atomic_bridge.md#0x1_atomic_bridge_store_EEXPIRED">EEXPIRED</a>);
 }
 </code></pre>
 
@@ -745,7 +1003,7 @@ Completes the bridge transfer.
 @param details The bridge transfer details to complete.
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete">complete</a>&lt;Initiator: store, Recipient: store&gt;(details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;)
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete">complete</a>&lt;Initiator: store, Recipient: store&gt;(_details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;)
 </code></pre>
 
 
@@ -754,8 +1012,8 @@ Completes the bridge transfer.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete">complete</a>&lt;Initiator: store, Recipient: store&gt;(details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;) {
-    details.state = <a href="atomic_bridge.md#0x1_atomic_bridge_store_COMPLETED_TRANSACTION">COMPLETED_TRANSACTION</a>;
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete">complete</a>&lt;Initiator: store, Recipient: store&gt;(_details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;) {
+    _details.state = <a href="atomic_bridge.md#0x1_atomic_bridge_store_COMPLETED_TRANSACTION">COMPLETED_TRANSACTION</a>;
 }
 </code></pre>
 
@@ -772,7 +1030,7 @@ Cancels the bridge transfer.
 @param details The bridge transfer details to cancel.
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel">cancel</a>&lt;Initiator: store, Recipient: store&gt;(details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;)
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel">cancel</a>&lt;Initiator: store, Recipient: store&gt;(_details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;)
 </code></pre>
 
 
@@ -781,8 +1039,8 @@ Cancels the bridge transfer.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel">cancel</a>&lt;Initiator: store, Recipient: store&gt;(details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;) {
-    details.state = <a href="atomic_bridge.md#0x1_atomic_bridge_store_CANCELLED_TRANSACTION">CANCELLED_TRANSACTION</a>;
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel">cancel</a>&lt;Initiator: store, Recipient: store&gt;(_details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;) {
+    _details.state = <a href="atomic_bridge.md#0x1_atomic_bridge_store_CANCELLED_TRANSACTION">CANCELLED_TRANSACTION</a>;
 }
 </code></pre>
 
@@ -802,7 +1060,7 @@ Validates and completes a bridge transfer by confirming the hash lock and state.
 @abort If the hash lock is invalid, the transfer is not pending, or the hash lock does not match.
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete_details">complete_details</a>&lt;Initiator: store, Recipient: <b>copy</b>, store&gt;(hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;): (Recipient, u64)
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete_details">complete_details</a>&lt;Initiator: store, Recipient: <b>copy</b>, store&gt;(_hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;): (Recipient, u64)
 </code></pre>
 
 
@@ -811,15 +1069,15 @@ Validates and completes a bridge transfer by confirming the hash lock and state.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete_details">complete_details</a>&lt;Initiator: store, Recipient: store + <b>copy</b>&gt;(hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;) : (Recipient, u64) {
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_valid_hash_lock">assert_valid_hash_lock</a>(&hash_lock);
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_pending">assert_pending</a>(details);
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_correct_hash_lock">assert_correct_hash_lock</a>(details, hash_lock);
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_within_timelock">assert_within_timelock</a>(details);
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete_details">complete_details</a>&lt;Initiator: store, Recipient: store + <b>copy</b>&gt;(_hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;) : (Recipient, u64) {
+    <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_valid_hash_lock">assert_valid_hash_lock</a>(&_hash_lock);
+    <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_pending">assert_pending</a>(_details);
+    <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_correct_hash_lock">assert_correct_hash_lock</a>(_details, _hash_lock);
+    <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_within_timelock">assert_within_timelock</a>(_details);
 
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete">complete</a>(details);
+    <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete">complete</a>(_details);
 
-    (details.addresses.recipient, details.amount)
+    (_details.addresses.recipient, _details.amount)
 }
 </code></pre>
 
@@ -839,7 +1097,7 @@ Completes a bridge transfer by validating the hash lock and updating the transfe
 @abort If the bridge transfer details are not found or if the completion checks in <code>complete_details</code> fail.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete_transfer">complete_transfer</a>&lt;Initiator: store, Recipient: <b>copy</b>, store&gt;(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): (Recipient, u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete_transfer">complete_transfer</a>&lt;Initiator: store, Recipient: <b>copy</b>, store&gt;(_bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): (Recipient, u64)
 </code></pre>
 
 
@@ -848,16 +1106,8 @@ Completes a bridge transfer by validating the hash lock and updating the transfe
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete_transfer">complete_transfer</a>&lt;Initiator: store, Recipient: <b>copy</b> + store&gt;(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) : (Recipient, u64) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a> {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_abort_atomic_bridge_enabled">features::abort_atomic_bridge_enabled</a>(), <a href="atomic_bridge.md#0x1_atomic_bridge_store_EATOMIC_BRIDGE_NOT_ENABLED">EATOMIC_BRIDGE_NOT_ENABLED</a>);
-
-    <b>let</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a> = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;&gt;&gt;(@aptos_framework);
-
-    <b>let</b> details = <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_borrow_mut">smart_table::borrow_mut</a>(
-        &<b>mut</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>.inner,
-        bridge_transfer_id);
-
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete_details">complete_details</a>&lt;Initiator, Recipient&gt;(hash_lock, details)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete_transfer">complete_transfer</a>&lt;Initiator: store, Recipient: <b>copy</b> + store&gt;(_bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) : (Recipient, u64) {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -876,7 +1126,7 @@ Cancels a pending bridge transfer if the time lock has expired.
 @abort If the transfer is not in a pending state or the time lock has not expired.
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel_details">cancel_details</a>&lt;Initiator: <b>copy</b>, store, Recipient: store&gt;(details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;): (Initiator, u64)
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel_details">cancel_details</a>&lt;Initiator: <b>copy</b>, store, Recipient: store&gt;(_details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;): (Initiator, u64)
 </code></pre>
 
 
@@ -885,13 +1135,13 @@ Cancels a pending bridge transfer if the time lock has expired.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel_details">cancel_details</a>&lt;Initiator: store + <b>copy</b>, Recipient: store&gt;(details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;) : (Initiator, u64) {
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_pending">assert_pending</a>(details);
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_timed_out_lock">assert_timed_out_lock</a>(details);
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel_details">cancel_details</a>&lt;Initiator: store + <b>copy</b>, Recipient: store&gt;(_details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;) : (Initiator, u64) {
+    <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_pending">assert_pending</a>(_details);
+    <a href="atomic_bridge.md#0x1_atomic_bridge_store_assert_timed_out_lock">assert_timed_out_lock</a>(_details);
 
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel">cancel</a>(details);
+    <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel">cancel</a>(_details);
 
-    (details.addresses.initiator, details.amount)
+    (_details.addresses.initiator, _details.amount)
 }
 </code></pre>
 
@@ -910,7 +1160,7 @@ Cancels a bridge transfer if it is pending and the time lock has expired.
 @abort If the bridge transfer details are not found or if the cancellation conditions in <code>cancel_details</code> fail.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel_transfer">cancel_transfer</a>&lt;Initiator: <b>copy</b>, store, Recipient: store&gt;(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): (Initiator, u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel_transfer">cancel_transfer</a>&lt;Initiator: <b>copy</b>, store, Recipient: store&gt;(_bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): (Initiator, u64)
 </code></pre>
 
 
@@ -919,16 +1169,8 @@ Cancels a bridge transfer if it is pending and the time lock has expired.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel_transfer">cancel_transfer</a>&lt;Initiator: store + <b>copy</b>, Recipient: store&gt;(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) : (Initiator, u64) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a> {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_abort_atomic_bridge_enabled">features::abort_atomic_bridge_enabled</a>(), <a href="atomic_bridge.md#0x1_atomic_bridge_store_EATOMIC_BRIDGE_NOT_ENABLED">EATOMIC_BRIDGE_NOT_ENABLED</a>);
-
-    <b>let</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a> = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;&gt;&gt;(@aptos_framework);
-
-    <b>let</b> details = <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_borrow_mut">smart_table::borrow_mut</a>(
-        &<b>mut</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>.inner,
-        bridge_transfer_id);
-
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel_details">cancel_details</a>&lt;Initiator, Recipient&gt;(details)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel_transfer">cancel_transfer</a>&lt;Initiator: store + <b>copy</b>, Recipient: store&gt;(_bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) : (Initiator, u64) {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -946,7 +1188,7 @@ Generates a unique bridge transfer ID based on transfer details and nonce.
 @return The generated bridge transfer ID.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_bridge_transfer_id">bridge_transfer_id</a>&lt;Initiator: store, Recipient: store&gt;(details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_bridge_transfer_id">bridge_transfer_id</a>&lt;Initiator: store, Recipient: store&gt;(_details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -955,20 +1197,8 @@ Generates a unique bridge transfer ID based on transfer details and nonce.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_bridge_transfer_id">bridge_transfer_id</a>&lt;Initiator: store, Recipient: store&gt;(details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;) : <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_Nonce">Nonce</a> {
-    <b>let</b> nonce = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_store_Nonce">Nonce</a>&gt;(@aptos_framework);
-    <b>let</b> combined_bytes = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&details.addresses.initiator));
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&details.addresses.recipient));
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, details.hash_lock);
-    <b>if</b> (nonce.inner == <a href="atomic_bridge.md#0x1_atomic_bridge_store_MAX_U64">MAX_U64</a>) {
-        nonce.inner = 0;  // Wrap around <b>to</b> 0 <b>if</b> at maximum value
-    } <b>else</b> {
-        nonce.inner = nonce.inner + 1;  // Safe <b>to</b> increment without overflow
-    };
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&nonce.inner));
-
-    keccak256(combined_bytes)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_bridge_transfer_id">bridge_transfer_id</a>&lt;Initiator: store, Recipient: store&gt;(_details: &<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;) : <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -988,7 +1218,7 @@ Gets initiator bridge transfer details given a bridge transfer ID
 
 
 <pre><code>#[view]
-<b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details_initiator">get_bridge_transfer_details_initiator</a>(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;<b>address</b>, <a href="ethereum.md#0x1_ethereum_EthereumAddress">ethereum::EthereumAddress</a>&gt;
+<b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details_initiator">get_bridge_transfer_details_initiator</a>(_bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;<b>address</b>, <a href="ethereum.md#0x1_ethereum_EthereumAddress">ethereum::EthereumAddress</a>&gt;
 </code></pre>
 
 
@@ -998,9 +1228,9 @@ Gets initiator bridge transfer details given a bridge transfer ID
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details_initiator">get_bridge_transfer_details_initiator</a>(
-    bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;<b>address</b>, EthereumAddress&gt; <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a> {
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details">get_bridge_transfer_details</a>(bridge_transfer_id)
+    _bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;<b>address</b>, EthereumAddress&gt; {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -1020,7 +1250,7 @@ Gets counterparty bridge transfer details given a bridge transfer ID
 
 
 <pre><code>#[view]
-<b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details_counterparty">get_bridge_transfer_details_counterparty</a>(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;<a href="ethereum.md#0x1_ethereum_EthereumAddress">ethereum::EthereumAddress</a>, <b>address</b>&gt;
+<b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details_counterparty">get_bridge_transfer_details_counterparty</a>(_bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;<a href="ethereum.md#0x1_ethereum_EthereumAddress">ethereum::EthereumAddress</a>, <b>address</b>&gt;
 </code></pre>
 
 
@@ -1030,9 +1260,9 @@ Gets counterparty bridge transfer details given a bridge transfer ID
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details_counterparty">get_bridge_transfer_details_counterparty</a>(
-    bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;EthereumAddress, <b>address</b>&gt; <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a> {
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details">get_bridge_transfer_details</a>(bridge_transfer_id)
+    _bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;EthereumAddress, <b>address</b>&gt; {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -1046,7 +1276,7 @@ Gets counterparty bridge transfer details given a bridge transfer ID
 
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details">get_bridge_transfer_details</a>&lt;Initiator: <b>copy</b>, store, Recipient: <b>copy</b>, store&gt;(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details">get_bridge_transfer_details</a>&lt;Initiator: <b>copy</b>, store, Recipient: <b>copy</b>, store&gt;(_bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;
 </code></pre>
 
 
@@ -1055,294 +1285,15 @@ Gets counterparty bridge transfer details given a bridge transfer ID
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details">get_bridge_transfer_details</a>&lt;Initiator: store + <b>copy</b>, Recipient: store + <b>copy</b>&gt;(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt; <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a> {
-    <b>let</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a> = <b>borrow_global</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;&gt;&gt;(@aptos_framework);
-
-    <b>let</b> details_ref = <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_borrow">smart_table::borrow</a>(
-        &<a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>.inner,
-        bridge_transfer_id
-    );
-
-    *details_ref
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details">get_bridge_transfer_details</a>&lt;Initiator: store + <b>copy</b>, Recipient: store + <b>copy</b>&gt;(_bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt; {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
 
 
 </details>
-
-<a id="@Specification_1"></a>
-
-## Specification
-
-
-<a id="@Specification_1_initialize"></a>
-
-### Function `initialize`
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
-</code></pre>
-
-
-
-
-<pre><code><b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
-<b>ensures</b> <b>exists</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_store_Nonce">Nonce</a>&gt;(addr);
-<b>ensures</b> <b>exists</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;<b>address</b>, EthereumAddress&gt;&gt;&gt;(addr);
-<b>ensures</b> <b>exists</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;EthereumAddress, <b>address</b>&gt;&gt;&gt;(addr);
-</code></pre>
-
-
-
-
-<a id="0x1_atomic_bridge_store_TimeLockAbortsIf"></a>
-
-
-<pre><code><b>schema</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_TimeLockAbortsIf">TimeLockAbortsIf</a> {
-    time_lock: u64;
-    <b>aborts_if</b> time_lock &lt; <a href="atomic_bridge.md#0x1_atomic_bridge_store_MIN_TIME_LOCK">MIN_TIME_LOCK</a>;
-    <b>aborts_if</b> !<b>exists</b>&lt;CurrentTimeMicroseconds&gt;(@aptos_framework);
-    <b>aborts_if</b> time_lock &gt; <a href="atomic_bridge.md#0x1_atomic_bridge_store_MAX_U64">MAX_U64</a> - <a href="timestamp.md#0x1_timestamp_spec_now_seconds">timestamp::spec_now_seconds</a>();
-}
-</code></pre>
-
-
-
-<a id="@Specification_1_create_time_lock"></a>
-
-### Function `create_time_lock`
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_time_lock">create_time_lock</a>(time_lock: u64): u64
-</code></pre>
-
-
-
-
-<pre><code><b>include</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_TimeLockAbortsIf">TimeLockAbortsIf</a>;
-<b>ensures</b> result == <a href="timestamp.md#0x1_timestamp_spec_now_seconds">timestamp::spec_now_seconds</a>() + time_lock;
-</code></pre>
-
-
-If the sum of <code><a href="atomic_bridge.md#0x1_atomic_bridge_store_now">now</a>()</code> and <code>lock</code> does not overflow, the result is the sum of <code><a href="atomic_bridge.md#0x1_atomic_bridge_store_now">now</a>()</code> and <code>lock</code>.
-
-
-<pre><code><b>ensures</b> (<a href="timestamp.md#0x1_timestamp_spec_now_seconds">timestamp::spec_now_seconds</a>() + time_lock &lt;= 0xFFFFFFFFFFFFFFFF) ==&gt; result == <a href="timestamp.md#0x1_timestamp_spec_now_seconds">timestamp::spec_now_seconds</a>() + time_lock;
-</code></pre>
-
-
-
-<a id="@Specification_1_create_details"></a>
-
-### Function `create_details`
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_details">create_details</a>&lt;Initiator: store, Recipient: store&gt;(initiator: Initiator, recipient: Recipient, amount: u64, hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, time_lock: u64): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;
-</code></pre>
-
-
-
-
-<pre><code><b>include</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_TimeLockAbortsIf">TimeLockAbortsIf</a>;
-<b>aborts_if</b> amount == 0;
-<b>aborts_if</b> len(hash_lock) != 32;
-<b>ensures</b> result == <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt; {
-        addresses: <a href="atomic_bridge.md#0x1_atomic_bridge_store_AddressPair">AddressPair</a>&lt;Initiator, Recipient&gt; {
-        initiator,
-        recipient
-    },
-    amount,
-    hash_lock,
-    time_lock: <a href="timestamp.md#0x1_timestamp_spec_now_seconds">timestamp::spec_now_seconds</a>() + time_lock,
-    state: <a href="atomic_bridge.md#0x1_atomic_bridge_store_PENDING_TRANSACTION">PENDING_TRANSACTION</a>,
-};
-</code></pre>
-
-
-
-
-<a id="0x1_atomic_bridge_store_AddAbortsIf"></a>
-
-
-<pre><code><b>schema</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_AddAbortsIf">AddAbortsIf</a>&lt;T&gt; {
-    bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
-    <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>: SmartTable&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, T&gt;;
-    <b>aborts_if</b> len(bridge_transfer_id) != 32;
-    <b>aborts_if</b> <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_spec_contains">smart_table::spec_contains</a>(<a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>, bridge_transfer_id);
-    <b>aborts_if</b> !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_is_enabled">features::spec_is_enabled</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_ATOMIC_BRIDGE">features::ATOMIC_BRIDGE</a>);
-}
-</code></pre>
-
-
-
-<a id="@Specification_1_add"></a>
-
-### Function `add`
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_add">add</a>&lt;Initiator: store, Recipient: store&gt;(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, details: <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;)
-</code></pre>
-
-
-
-
-<pre><code><b>let</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a> = <b>global</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;&gt;&gt;(@aptos_framework).inner;
-<b>include</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_AddAbortsIf">AddAbortsIf</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;&gt;;
-<b>aborts_if</b> !<b>exists</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;&gt;&gt;(@aptos_framework);
-<b>aborts_if</b> <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_spec_contains">smart_table::spec_contains</a>(<a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>, bridge_transfer_id);
-<b>ensures</b> <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_spec_contains">smart_table::spec_contains</a>(<b>global</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;&gt;&gt;(@aptos_framework).inner, bridge_transfer_id);
-<b>ensures</b> <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_spec_len">smart_table::spec_len</a>(<b>global</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;&gt;&gt;(@aptos_framework).inner) ==
-    <b>old</b>(<a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_spec_len">smart_table::spec_len</a>(<b>global</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;&gt;&gt;(@aptos_framework).inner)) + 1;
-</code></pre>
-
-
-
-
-<a id="0x1_atomic_bridge_store_HashLockAbortsIf"></a>
-
-
-<pre><code><b>schema</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_HashLockAbortsIf">HashLockAbortsIf</a> {
-    hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
-    <b>aborts_if</b> len(hash_lock) != 32;
-}
-</code></pre>
-
-
-
-
-<a id="0x1_atomic_bridge_store_BridgetTransferDetailsAbortsIf"></a>
-
-
-<pre><code><b>schema</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgetTransferDetailsAbortsIf">BridgetTransferDetailsAbortsIf</a>&lt;Initiator, Recipient&gt; {
-    hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
-    details: <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;;
-    <b>include</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_HashLockAbortsIf">HashLockAbortsIf</a>;
-    <b>aborts_if</b> <a href="timestamp.md#0x1_timestamp_spec_now_seconds">timestamp::spec_now_seconds</a>() &gt; details.time_lock;
-    <b>aborts_if</b> !<b>exists</b>&lt;CurrentTimeMicroseconds&gt;(@aptos_framework);
-    <b>aborts_if</b> details.state != <a href="atomic_bridge.md#0x1_atomic_bridge_store_PENDING_TRANSACTION">PENDING_TRANSACTION</a>;
-    <b>aborts_if</b> details.hash_lock != hash_lock;
-}
-</code></pre>
-
-
-
-<a id="@Specification_1_create_hashlock"></a>
-
-### Function `create_hashlock`
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_hashlock">create_hashlock</a>(pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-
-<pre><code><b>aborts_if</b> len(pre_image) == 0;
-</code></pre>
-
-
-
-<a id="@Specification_1_complete"></a>
-
-### Function `complete`
-
-
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete">complete</a>&lt;Initiator: store, Recipient: store&gt;(details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;)
-</code></pre>
-
-
-
-
-<pre><code><b>requires</b> details.state == <a href="atomic_bridge.md#0x1_atomic_bridge_store_PENDING_TRANSACTION">PENDING_TRANSACTION</a>;
-<b>ensures</b> details.state == <a href="atomic_bridge.md#0x1_atomic_bridge_store_COMPLETED_TRANSACTION">COMPLETED_TRANSACTION</a>;
-</code></pre>
-
-
-
-<a id="@Specification_1_cancel"></a>
-
-### Function `cancel`
-
-
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel">cancel</a>&lt;Initiator: store, Recipient: store&gt;(details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;)
-</code></pre>
-
-
-
-
-<pre><code><b>requires</b> details.state == <a href="atomic_bridge.md#0x1_atomic_bridge_store_PENDING_TRANSACTION">PENDING_TRANSACTION</a>;
-<b>ensures</b> details.state == <a href="atomic_bridge.md#0x1_atomic_bridge_store_CANCELLED_TRANSACTION">CANCELLED_TRANSACTION</a>;
-</code></pre>
-
-
-
-<a id="@Specification_1_complete_details"></a>
-
-### Function `complete_details`
-
-
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete_details">complete_details</a>&lt;Initiator: store, Recipient: <b>copy</b>, store&gt;(hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;): (Recipient, u64)
-</code></pre>
-
-
-
-
-<pre><code><b>include</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgetTransferDetailsAbortsIf">BridgetTransferDetailsAbortsIf</a>&lt;Initiator, Recipient&gt;;
-</code></pre>
-
-
-
-<a id="@Specification_1_complete_transfer"></a>
-
-### Function `complete_transfer`
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete_transfer">complete_transfer</a>&lt;Initiator: store, Recipient: <b>copy</b>, store&gt;(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): (Recipient, u64)
-</code></pre>
-
-
-
-
-<pre><code><b>let</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a> = <b>global</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;&gt;&gt;(@aptos_framework).inner;
-<b>aborts_if</b> !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_is_enabled">features::spec_is_enabled</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_ATOMIC_BRIDGE">features::ATOMIC_BRIDGE</a>);
-<b>aborts_if</b> !<b>exists</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;&gt;&gt;(@aptos_framework);
-<b>aborts_if</b> !<a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_spec_contains">smart_table::spec_contains</a>(<a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>, bridge_transfer_id);
-<b>let</b> details = <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_spec_get">smart_table::spec_get</a>(<a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>, bridge_transfer_id);
-<b>include</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgetTransferDetailsAbortsIf">BridgetTransferDetailsAbortsIf</a>&lt;Initiator, Recipient&gt;;
-</code></pre>
-
-
-
-
-<a id="0x1_atomic_bridge_store_AbortBridgetTransferDetailsAbortsIf"></a>
-
-
-<pre><code><b>schema</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_AbortBridgetTransferDetailsAbortsIf">AbortBridgetTransferDetailsAbortsIf</a>&lt;Initiator, Recipient&gt; {
-    details: <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;;
-    <b>aborts_if</b> details.state != <a href="atomic_bridge.md#0x1_atomic_bridge_store_PENDING_TRANSACTION">PENDING_TRANSACTION</a>;
-    <b>aborts_if</b> !(<a href="timestamp.md#0x1_timestamp_spec_now_seconds">timestamp::spec_now_seconds</a>() &gt; details.time_lock);
-    <b>aborts_if</b> !<b>exists</b>&lt;CurrentTimeMicroseconds&gt;(@aptos_framework);
-    <b>ensures</b> details.state == <a href="atomic_bridge.md#0x1_atomic_bridge_store_CANCELLED_TRANSACTION">CANCELLED_TRANSACTION</a>;
-}
-</code></pre>
-
-
-
-<a id="@Specification_1_cancel_details"></a>
-
-### Function `cancel_details`
-
-
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel_details">cancel_details</a>&lt;Initiator: <b>copy</b>, store, Recipient: store&gt;(details: &<b>mut</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;): (Initiator, u64)
-</code></pre>
-
-
-
-
-<pre><code><b>include</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_AbortBridgetTransferDetailsAbortsIf">AbortBridgetTransferDetailsAbortsIf</a>&lt;Initiator, Recipient&gt;;
-</code></pre>
 
 
 
@@ -1365,15 +1316,9 @@ If the sum of <code><a href="atomic_bridge.md#0x1_atomic_bridge_store_now">now</
 -  [Function `counterparty_timelock_duration`](#0x1_atomic_bridge_configuration_counterparty_timelock_duration)
 -  [Function `bridge_operator`](#0x1_atomic_bridge_configuration_bridge_operator)
 -  [Function `assert_is_caller_operator`](#0x1_atomic_bridge_configuration_assert_is_caller_operator)
--  [Specification](#@Specification_1)
-    -  [Function `initialize`](#@Specification_1_initialize)
-    -  [Function `update_bridge_operator`](#@Specification_1_update_bridge_operator)
 
 
-<pre><code><b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
-<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
-<b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
-</code></pre>
+<pre><code></code></pre>
 
 
 
@@ -1514,6 +1459,16 @@ Event emitted when the initiator time lock has been updated.
 ## Constants
 
 
+<a id="0x1_atomic_bridge_configuration_EATOMIC_BRIDGE_DISABLED"></a>
+
+Error code for atomic bridge disabled
+
+
+<pre><code><b>const</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>: u64 = 2;
+</code></pre>
+
+
+
 <a id="0x1_atomic_bridge_configuration_COUNTERPARTY_TIME_LOCK_DUARTION"></a>
 
 Counterparty time lock duration is 24 hours in seconds
@@ -1553,7 +1508,7 @@ Initializes the bridge configuration with Aptos framework as the bridge operator
 @param aptos_framework The signer representing the Aptos framework.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_initialize">initialize</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
 </code></pre>
 
 
@@ -1562,14 +1517,8 @@ Initializes the bridge configuration with Aptos framework as the bridge operator
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
-    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-    <b>let</b> bridge_config = <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a> {
-        bridge_operator: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework),
-        initiator_time_lock: <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_INITIATOR_TIME_LOCK_DUARTION">INITIATOR_TIME_LOCK_DUARTION</a>,
-        counterparty_time_lock: <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_COUNTERPARTY_TIME_LOCK_DUARTION">COUNTERPARTY_TIME_LOCK_DUARTION</a>,
-    };
-    <b>move_to</b>(aptos_framework, bridge_config);
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_initialize">initialize</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+   <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -1588,7 +1537,7 @@ Updates the bridge operator, requiring governance validation.
 @abort If the current operator is the same as the new operator.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_update_bridge_operator">update_bridge_operator</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_operator: <b>address</b>)
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_update_bridge_operator">update_bridge_operator</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _new_operator: <b>address</b>)
 </code></pre>
 
 
@@ -1597,21 +1546,9 @@ Updates the bridge operator, requiring governance validation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_update_bridge_operator">update_bridge_operator</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_operator: <b>address</b>
-)   <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a> {
-    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-    <b>let</b> bridge_config = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework);
-    <b>let</b> old_operator = bridge_config.bridge_operator;
-    <b>assert</b>!(old_operator != new_operator, <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_EINVALID_BRIDGE_OPERATOR">EINVALID_BRIDGE_OPERATOR</a>);
-
-    bridge_config.bridge_operator = new_operator;
-
-    <a href="event.md#0x1_event_emit">event::emit</a>(
-        <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfigOperatorUpdated">BridgeConfigOperatorUpdated</a> {
-            old_operator,
-            new_operator,
-        },
-    );
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_update_bridge_operator">update_bridge_operator</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _new_operator: <b>address</b>
+) {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -1625,7 +1562,7 @@ Updates the bridge operator, requiring governance validation.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_set_initiator_time_lock_duration">set_initiator_time_lock_duration</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, time_lock: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_set_initiator_time_lock_duration">set_initiator_time_lock_duration</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _time_lock: u64)
 </code></pre>
 
 
@@ -1634,16 +1571,9 @@ Updates the bridge operator, requiring governance validation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_set_initiator_time_lock_duration">set_initiator_time_lock_duration</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, time_lock: u64
-) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a> {
-    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-    <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework).initiator_time_lock = time_lock;
-
-    <a href="event.md#0x1_event_emit">event::emit</a>(
-        <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_InitiatorTimeLockUpdated">InitiatorTimeLockUpdated</a> {
-            time_lock
-        },
-    );
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_set_initiator_time_lock_duration">set_initiator_time_lock_duration</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _time_lock: u64
+) {
+   <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -1657,7 +1587,7 @@ Updates the bridge operator, requiring governance validation.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_set_counterparty_time_lock_duration">set_counterparty_time_lock_duration</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, time_lock: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_set_counterparty_time_lock_duration">set_counterparty_time_lock_duration</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _time_lock: u64)
 </code></pre>
 
 
@@ -1666,16 +1596,9 @@ Updates the bridge operator, requiring governance validation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_set_counterparty_time_lock_duration">set_counterparty_time_lock_duration</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, time_lock: u64
-) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a> {
-    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-    <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework).counterparty_time_lock = time_lock;
-
-    <a href="event.md#0x1_event_emit">event::emit</a>(
-        <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_CounterpartyTimeLockUpdated">CounterpartyTimeLockUpdated</a> {
-            time_lock
-        },
-    );
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_set_counterparty_time_lock_duration">set_counterparty_time_lock_duration</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _time_lock: u64
+) {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -1699,8 +1622,8 @@ Updates the bridge operator, requiring governance validation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_initiator_timelock_duration">initiator_timelock_duration</a>() : u64 <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a> {
-    <b>borrow_global</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework).initiator_time_lock
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_initiator_timelock_duration">initiator_timelock_duration</a>() : u64 {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -1724,8 +1647,8 @@ Updates the bridge operator, requiring governance validation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_counterparty_timelock_duration">counterparty_timelock_duration</a>() : u64 <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a> {
-    <b>borrow_global</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework).counterparty_time_lock
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_counterparty_timelock_duration">counterparty_timelock_duration</a>() : u64 {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -1752,8 +1675,8 @@ Retrieves the address of the current bridge operator.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_bridge_operator">bridge_operator</a>(): <b>address</b> <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a> {
-    <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework).bridge_operator
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_bridge_operator">bridge_operator</a>(): <b>address</b> {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -1771,7 +1694,7 @@ Asserts that the caller is the current bridge operator.
 @abort If the caller is not the current bridge operator.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_assert_is_caller_operator">assert_is_caller_operator</a>(caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_assert_is_caller_operator">assert_is_caller_operator</a>(_caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
 </code></pre>
 
 
@@ -1780,362 +1703,9 @@ Asserts that the caller is the current bridge operator.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_assert_is_caller_operator">assert_is_caller_operator</a>(caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
-) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a> {
-    <b>assert</b>!(<b>borrow_global</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework).bridge_operator == <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(caller), <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_EINVALID_BRIDGE_OPERATOR">EINVALID_BRIDGE_OPERATOR</a>);
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="@Specification_1"></a>
-
-## Specification
-
-
-<a id="@Specification_1_initialize"></a>
-
-### Function `initialize`
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
-</code></pre>
-
-
-
-
-<pre><code><b>aborts_if</b> !<a href="system_addresses.md#0x1_system_addresses_is_aptos_framework_address">system_addresses::is_aptos_framework_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework));
-<b>aborts_if</b> <b>exists</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework));
-<b>ensures</b> <b>global</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework)).bridge_operator == <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
-</code></pre>
-
-
-
-<a id="@Specification_1_update_bridge_operator"></a>
-
-### Function `update_bridge_operator`
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_update_bridge_operator">update_bridge_operator</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_operator: <b>address</b>)
-</code></pre>
-
-
-
-
-<pre><code><b>aborts_if</b> !<a href="system_addresses.md#0x1_system_addresses_is_aptos_framework_address">system_addresses::is_aptos_framework_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework));
-<b>aborts_if</b> !<b>exists</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework));
-<b>aborts_if</b> <b>global</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework)).bridge_operator == new_operator;
-<b>ensures</b> <b>global</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework)).bridge_operator == new_operator;
-</code></pre>
-
-
-
-<a id="0x1_atomic_bridge"></a>
-
-# Module `0x1::atomic_bridge`
-
-
-
--  [Resource `AptosCoinBurnCapability`](#0x1_atomic_bridge_AptosCoinBurnCapability)
--  [Resource `AptosCoinMintCapability`](#0x1_atomic_bridge_AptosCoinMintCapability)
--  [Resource `AptosFABurnCapabilities`](#0x1_atomic_bridge_AptosFABurnCapabilities)
--  [Resource `AptosFAMintCapabilities`](#0x1_atomic_bridge_AptosFAMintCapabilities)
--  [Constants](#@Constants_0)
--  [Function `initialize`](#0x1_atomic_bridge_initialize)
--  [Function `store_aptos_coin_burn_cap`](#0x1_atomic_bridge_store_aptos_coin_burn_cap)
--  [Function `store_aptos_coin_mint_cap`](#0x1_atomic_bridge_store_aptos_coin_mint_cap)
--  [Function `mint`](#0x1_atomic_bridge_mint)
--  [Function `burn`](#0x1_atomic_bridge_burn)
-
-
-<pre><code><b>use</b> <a href="aptos_coin.md#0x1_aptos_coin">0x1::aptos_coin</a>;
-<b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration">0x1::atomic_bridge_configuration</a>;
-<b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store">0x1::atomic_bridge_store</a>;
-<b>use</b> <a href="coin.md#0x1_coin">0x1::coin</a>;
-<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
-<b>use</b> <a href="fungible_asset.md#0x1_fungible_asset">0x1::fungible_asset</a>;
-<b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
-</code></pre>
-
-
-
-<a id="0x1_atomic_bridge_AptosCoinBurnCapability"></a>
-
-## Resource `AptosCoinBurnCapability`
-
-
-
-<pre><code><b>struct</b> <a href="atomic_bridge.md#0x1_atomic_bridge_AptosCoinBurnCapability">AptosCoinBurnCapability</a> <b>has</b> key
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>burn_cap: <a href="coin.md#0x1_coin_BurnCapability">coin::BurnCapability</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">aptos_coin::AptosCoin</a>&gt;</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
-<a id="0x1_atomic_bridge_AptosCoinMintCapability"></a>
-
-## Resource `AptosCoinMintCapability`
-
-
-
-<pre><code><b>struct</b> <a href="atomic_bridge.md#0x1_atomic_bridge_AptosCoinMintCapability">AptosCoinMintCapability</a> <b>has</b> key
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>mint_cap: <a href="coin.md#0x1_coin_MintCapability">coin::MintCapability</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">aptos_coin::AptosCoin</a>&gt;</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
-<a id="0x1_atomic_bridge_AptosFABurnCapabilities"></a>
-
-## Resource `AptosFABurnCapabilities`
-
-
-
-<pre><code><b>struct</b> <a href="atomic_bridge.md#0x1_atomic_bridge_AptosFABurnCapabilities">AptosFABurnCapabilities</a> <b>has</b> key
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>burn_ref: <a href="fungible_asset.md#0x1_fungible_asset_BurnRef">fungible_asset::BurnRef</a></code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
-<a id="0x1_atomic_bridge_AptosFAMintCapabilities"></a>
-
-## Resource `AptosFAMintCapabilities`
-
-
-
-<pre><code><b>struct</b> <a href="atomic_bridge.md#0x1_atomic_bridge_AptosFAMintCapabilities">AptosFAMintCapabilities</a> <b>has</b> key
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>burn_ref: <a href="fungible_asset.md#0x1_fungible_asset_MintRef">fungible_asset::MintRef</a></code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
-<a id="@Constants_0"></a>
-
-## Constants
-
-
-<a id="0x1_atomic_bridge_EATOMIC_BRIDGE_NOT_ENABLED"></a>
-
-
-
-<pre><code><b>const</b> <a href="atomic_bridge.md#0x1_atomic_bridge_EATOMIC_BRIDGE_NOT_ENABLED">EATOMIC_BRIDGE_NOT_ENABLED</a>: u64 = 1;
-</code></pre>
-
-
-
-<a id="0x1_atomic_bridge_initialize"></a>
-
-## Function `initialize`
-
-Initializes the atomic bridge by setting up necessary configurations.
-
-@param aptos_framework The signer representing the Aptos framework.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
-    <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_initialize">atomic_bridge_configuration::initialize</a>(aptos_framework);
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_initialize">atomic_bridge_store::initialize</a>(aptos_framework);
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_atomic_bridge_store_aptos_coin_burn_cap"></a>
-
-## Function `store_aptos_coin_burn_cap`
-
-Stores the burn capability for AptosCoin, converting to a fungible asset reference if the feature is enabled.
-
-@param aptos_framework The signer representing the Aptos framework.
-@param burn_cap The burn capability for AptosCoin.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_aptos_coin_burn_cap">store_aptos_coin_burn_cap</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, burn_cap: <a href="coin.md#0x1_coin_BurnCapability">coin::BurnCapability</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">aptos_coin::AptosCoin</a>&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_aptos_coin_burn_cap">store_aptos_coin_burn_cap</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, burn_cap: BurnCapability&lt;AptosCoin&gt;) {
-    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operations_default_to_fa_apt_store_enabled">features::operations_default_to_fa_apt_store_enabled</a>()) {
-        <b>let</b> burn_ref = <a href="coin.md#0x1_coin_convert_and_take_paired_burn_ref">coin::convert_and_take_paired_burn_ref</a>(burn_cap);
-        <b>move_to</b>(aptos_framework, <a href="atomic_bridge.md#0x1_atomic_bridge_AptosFABurnCapabilities">AptosFABurnCapabilities</a> { burn_ref });
-    } <b>else</b> {
-        <b>move_to</b>(aptos_framework, <a href="atomic_bridge.md#0x1_atomic_bridge_AptosCoinBurnCapability">AptosCoinBurnCapability</a> { burn_cap })
-    }
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_atomic_bridge_store_aptos_coin_mint_cap"></a>
-
-## Function `store_aptos_coin_mint_cap`
-
-Stores the mint capability for AptosCoin.
-
-@param aptos_framework The signer representing the Aptos framework.
-@param mint_cap The mint capability for AptosCoin.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_aptos_coin_mint_cap">store_aptos_coin_mint_cap</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, mint_cap: <a href="coin.md#0x1_coin_MintCapability">coin::MintCapability</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">aptos_coin::AptosCoin</a>&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_aptos_coin_mint_cap">store_aptos_coin_mint_cap</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, mint_cap: MintCapability&lt;AptosCoin&gt;) {
-    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-    <b>move_to</b>(aptos_framework, <a href="atomic_bridge.md#0x1_atomic_bridge_AptosCoinMintCapability">AptosCoinMintCapability</a> { mint_cap })
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_atomic_bridge_mint"></a>
-
-## Function `mint`
-
-Mints a specified amount of AptosCoin to a recipient's address.
-
-@param recipient The address of the recipient to mint coins to.
-@param amount The amount of AptosCoin to mint.
-@abort If the mint capability is not available.
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_mint">mint</a>(recipient: <b>address</b>, amount: u64)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_mint">mint</a>(recipient: <b>address</b>, amount: u64) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_AptosCoinMintCapability">AptosCoinMintCapability</a> {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_abort_atomic_bridge_enabled">features::abort_atomic_bridge_enabled</a>(), <a href="atomic_bridge.md#0x1_atomic_bridge_EATOMIC_BRIDGE_NOT_ENABLED">EATOMIC_BRIDGE_NOT_ENABLED</a>);
-
-    <a href="coin.md#0x1_coin_deposit">coin::deposit</a>(recipient, <a href="coin.md#0x1_coin_mint">coin::mint</a>(
-        amount,
-        &<b>borrow_global</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_AptosCoinMintCapability">AptosCoinMintCapability</a>&gt;(@aptos_framework).mint_cap
-    ));
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_atomic_bridge_burn"></a>
-
-## Function `burn`
-
-Burns a specified amount of AptosCoin from an address.
-
-@param from The address from which to burn AptosCoin.
-@param amount The amount of AptosCoin to burn.
-@abort If the burn capability is not available.
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_burn">burn</a>(from: <b>address</b>, amount: u64)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_burn">burn</a>(from: <b>address</b>, amount: u64) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_AptosCoinBurnCapability">AptosCoinBurnCapability</a> {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_abort_atomic_bridge_enabled">features::abort_atomic_bridge_enabled</a>(), <a href="atomic_bridge.md#0x1_atomic_bridge_EATOMIC_BRIDGE_NOT_ENABLED">EATOMIC_BRIDGE_NOT_ENABLED</a>);
-
-    <a href="coin.md#0x1_coin_burn_from">coin::burn_from</a>(
-        from,
-        amount,
-        &<b>borrow_global</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_AptosCoinBurnCapability">AptosCoinBurnCapability</a>&gt;(@aptos_framework).burn_cap,
-    );
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_assert_is_caller_operator">assert_is_caller_operator</a>(_caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
+) {
+   <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -2155,6 +1725,7 @@ Burns a specified amount of AptosCoin from an address.
 -  [Struct `BridgeTransferCompletedEvent`](#0x1_atomic_bridge_counterparty_BridgeTransferCompletedEvent)
 -  [Struct `BridgeTransferCancelledEvent`](#0x1_atomic_bridge_counterparty_BridgeTransferCancelledEvent)
 -  [Resource `BridgeCounterpartyEvents`](#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents)
+-  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_atomic_bridge_counterparty_initialize)
 -  [Function `lock_bridge_transfer_assets`](#0x1_atomic_bridge_counterparty_lock_bridge_transfer_assets)
 -  [Function `complete_bridge_transfer`](#0x1_atomic_bridge_counterparty_complete_bridge_transfer)
@@ -2162,10 +1733,6 @@ Burns a specified amount of AptosCoin from an address.
 
 
 <pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
-<b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge">0x1::atomic_bridge</a>;
-<b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration">0x1::atomic_bridge_configuration</a>;
-<b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store">0x1::atomic_bridge_store</a>;
-<b>use</b> <a href="ethereum.md#0x1_ethereum">0x1::ethereum</a>;
 <b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
 </code></pre>
 
@@ -2334,6 +1901,20 @@ This struct will store the event handles for bridge events.
 
 </details>
 
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x1_atomic_bridge_counterparty_EATOMIC_BRIDGE_DISABLED"></a>
+
+
+
+<pre><code><b>const</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>: u64 = 198461;
+</code></pre>
+
+
+
 <a id="0x1_atomic_bridge_counterparty_initialize"></a>
 
 ## Function `initialize`
@@ -2379,7 +1960,7 @@ Locks assets for a bridge transfer by the initiator.
 @abort If the caller is not the bridge operator.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_lock_bridge_transfer_assets">lock_bridge_transfer_assets</a>(caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, initiator: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, recipient: <b>address</b>, amount: u64)
+<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_lock_bridge_transfer_assets">lock_bridge_transfer_assets</a>(_caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _initiator: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _recipient: <b>address</b>, _amount: u64)
 </code></pre>
 
 
@@ -2389,40 +1970,14 @@ Locks assets for a bridge transfer by the initiator.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_lock_bridge_transfer_assets">lock_bridge_transfer_assets</a> (
-    caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    initiator: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    recipient: <b>address</b>,
-    amount: u64
-) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents">BridgeCounterpartyEvents</a> {
-    <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_assert_is_caller_operator">atomic_bridge_configuration::assert_is_caller_operator</a>(caller);
-    <b>let</b> ethereum_address = <a href="ethereum.md#0x1_ethereum_ethereum_address_no_eip55">ethereum::ethereum_address_no_eip55</a>(initiator);
-    <b>let</b> time_lock = <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_counterparty_timelock_duration">atomic_bridge_configuration::counterparty_timelock_duration</a>();
-    <b>let</b> details = <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_details">atomic_bridge_store::create_details</a>(
-        ethereum_address,
-        recipient,
-        amount,
-        hash_lock,
-        time_lock
-    );
-
-    // bridge_store::add_counterparty(bridge_transfer_id, details);
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_add">atomic_bridge_store::add</a>(bridge_transfer_id, details);
-
-    <b>let</b> bridge_events = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents">BridgeCounterpartyEvents</a>&gt;(@aptos_framework);
-
-    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
-        &<b>mut</b> bridge_events.bridge_transfer_locked_events,
-        <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferLockedEvent">BridgeTransferLockedEvent</a> {
-            bridge_transfer_id,
-            initiator,
-            recipient,
-            amount,
-            hash_lock,
-            time_lock,
-        },
-    );
+    _caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    _initiator: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    _bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    _hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    _recipient: <b>address</b>,
+    _amount: u64
+) {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -2441,7 +1996,7 @@ Completes a bridge transfer by revealing the pre-image.
 @abort If the caller is not the bridge operator or the hash lock validation fails.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_complete_bridge_transfer">complete_bridge_transfer</a>(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_complete_bridge_transfer">complete_bridge_transfer</a>(_bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -2451,25 +2006,10 @@ Completes a bridge transfer by revealing the pre-image.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_complete_bridge_transfer">complete_bridge_transfer</a> (
-    bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents">BridgeCounterpartyEvents</a> {
-    <b>let</b> (recipient, amount) = <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete_transfer">atomic_bridge_store::complete_transfer</a>&lt;EthereumAddress, <b>address</b>&gt;(
-        bridge_transfer_id,
-        create_hashlock(pre_image)
-    );
-
-    // Mint, fails silently
-    <a href="atomic_bridge.md#0x1_atomic_bridge_mint">atomic_bridge::mint</a>(recipient, amount);
-
-    <b>let</b> bridge_counterparty_events = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents">BridgeCounterpartyEvents</a>&gt;(@aptos_framework);
-    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
-        &<b>mut</b> bridge_counterparty_events.bridge_transfer_completed_events,
-        <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferCompletedEvent">BridgeTransferCompletedEvent</a> {
-            bridge_transfer_id,
-            pre_image,
-        },
-    );
+    _bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    _pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+) {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -2488,7 +2028,7 @@ Aborts a bridge transfer if the time lock has expired.
 @abort If the caller is not the bridge operator or if the time lock has not expired.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_abort_bridge_transfer">abort_bridge_transfer</a>(caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_abort_bridge_transfer">abort_bridge_transfer</a>(_caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -2498,20 +2038,10 @@ Aborts a bridge transfer if the time lock has expired.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_abort_bridge_transfer">abort_bridge_transfer</a> (
-    caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents">BridgeCounterpartyEvents</a> {
-    <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_assert_is_caller_operator">atomic_bridge_configuration::assert_is_caller_operator</a>(caller);
-
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel_transfer">atomic_bridge_store::cancel_transfer</a>&lt;EthereumAddress, <b>address</b>&gt;(bridge_transfer_id);
-
-    <b>let</b> bridge_counterparty_events = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents">BridgeCounterpartyEvents</a>&gt;(@aptos_framework);
-    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
-        &<b>mut</b> bridge_counterparty_events.bridge_transfer_cancelled_events,
-        <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferCancelledEvent">BridgeTransferCancelledEvent</a> {
-            bridge_transfer_id,
-        },
-    );
+    _caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    _bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+) {
+   <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -2531,19 +2061,14 @@ Aborts a bridge transfer if the time lock has expired.
 -  [Struct `BridgeTransferCompletedEvent`](#0x1_atomic_bridge_initiator_BridgeTransferCompletedEvent)
 -  [Struct `BridgeTransferRefundedEvent`](#0x1_atomic_bridge_initiator_BridgeTransferRefundedEvent)
 -  [Resource `BridgeInitiatorEvents`](#0x1_atomic_bridge_initiator_BridgeInitiatorEvents)
+-  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_atomic_bridge_initiator_initialize)
 -  [Function `initiate_bridge_transfer`](#0x1_atomic_bridge_initiator_initiate_bridge_transfer)
 -  [Function `complete_bridge_transfer`](#0x1_atomic_bridge_initiator_complete_bridge_transfer)
 -  [Function `refund_bridge_transfer`](#0x1_atomic_bridge_initiator_refund_bridge_transfer)
 
 
-<pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
-<b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge">0x1::atomic_bridge</a>;
-<b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration">0x1::atomic_bridge_configuration</a>;
-<b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store">0x1::atomic_bridge_store</a>;
-<b>use</b> <a href="ethereum.md#0x1_ethereum">0x1::ethereum</a>;
-<b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
-<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
+<pre><code><b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
 </code></pre>
 
 
@@ -2708,6 +2233,20 @@ This struct will store the event handles for bridge events.
 
 </details>
 
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x1_atomic_bridge_initiator_EATOMIC_BRIDGE_DISABLED"></a>
+
+
+
+<pre><code><b>const</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>: u64 = 198461;
+</code></pre>
+
+
+
 <a id="0x1_atomic_bridge_initiator_initialize"></a>
 
 ## Function `initialize`
@@ -2715,7 +2254,7 @@ This struct will store the event handles for bridge events.
 Initializes the module and stores the <code>EventHandle</code>s in the resource.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_initialize">initialize</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
 </code></pre>
 
 
@@ -2724,12 +2263,8 @@ Initializes the module and stores the <code>EventHandle</code>s in the resource.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
-    <b>move_to</b>(aptos_framework, <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a> {
-        bridge_transfer_initiated_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferInitiatedEvent">BridgeTransferInitiatedEvent</a>&gt;(aptos_framework),
-        bridge_transfer_completed_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferCompletedEvent">BridgeTransferCompletedEvent</a>&gt;(aptos_framework),
-        bridge_transfer_refunded_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferRefundedEvent">BridgeTransferRefundedEvent</a>&gt;(aptos_framework),
-    });
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_initialize">initialize</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+
 }
 </code></pre>
 
@@ -2746,7 +2281,7 @@ Anyone can initiate a bridge transfer from the source chain
 The amount is burnt from the initiator
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_initiate_bridge_transfer">initiate_bridge_transfer</a>(initiator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, recipient: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, amount: u64)
+<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_initiate_bridge_transfer">initiate_bridge_transfer</a>(_initiator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _recipient: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _amount: u64)
 </code></pre>
 
 
@@ -2756,39 +2291,12 @@ The amount is burnt from the initiator
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_initiate_bridge_transfer">initiate_bridge_transfer</a>(
-    initiator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    recipient: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    amount: u64
-) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a> {
-    <b>let</b> ethereum_address = <a href="ethereum.md#0x1_ethereum_ethereum_address_no_eip55">ethereum::ethereum_address_no_eip55</a>(recipient);
-    <b>let</b> initiator_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(initiator);
-    <b>let</b> time_lock = <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_initiator_timelock_duration">atomic_bridge_configuration::initiator_timelock_duration</a>();
-
-    <b>let</b> details =
-        <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_details">atomic_bridge_store::create_details</a>(
-            initiator_address,
-            ethereum_address, amount,
-            hash_lock,
-            time_lock
-        );
-
-    <b>let</b> bridge_transfer_id = bridge_transfer_id(&details);
-    <a href="atomic_bridge.md#0x1_atomic_bridge_store_add">atomic_bridge_store::add</a>(bridge_transfer_id, details);
-    <a href="atomic_bridge.md#0x1_atomic_bridge_burn">atomic_bridge::burn</a>(initiator_address, amount);
-
-    <b>let</b> bridge_initiator_events = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a>&gt;(@aptos_framework);
-    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
-        &<b>mut</b> bridge_initiator_events.bridge_transfer_initiated_events,
-        <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferInitiatedEvent">BridgeTransferInitiatedEvent</a> {
-            bridge_transfer_id,
-            initiator: initiator_address,
-            recipient,
-            amount,
-            hash_lock,
-            time_lock
-        },
-    );
+    _initiator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    _recipient: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    _hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    _amount: u64
+) {
+    <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -2803,7 +2311,7 @@ The amount is burnt from the initiator
 Bridge operator can complete the transfer
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_complete_bridge_transfer">complete_bridge_transfer</a>(caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_complete_bridge_transfer">complete_bridge_transfer</a>(_caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -2813,21 +2321,11 @@ Bridge operator can complete the transfer
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_complete_bridge_transfer">complete_bridge_transfer</a> (
-    caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a> {
-    assert_is_caller_operator(caller);
-    <b>let</b> (_, _) = <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete_transfer">atomic_bridge_store::complete_transfer</a>&lt;<b>address</b>, EthereumAddress&gt;(bridge_transfer_id, create_hashlock(pre_image));
-
-    <b>let</b> bridge_initiator_events = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a>&gt;(@aptos_framework);
-    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
-        &<b>mut</b> bridge_initiator_events.bridge_transfer_completed_events,
-        <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferCompletedEvent">BridgeTransferCompletedEvent</a> {
-            bridge_transfer_id,
-            pre_image,
-        },
-    );
+    _caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    _bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    _pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+) {
+   <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 
@@ -2842,7 +2340,7 @@ Bridge operator can complete the transfer
 Anyone can refund the transfer on the source chain once time lock has passed
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_refund_bridge_transfer">refund_bridge_transfer</a>(_caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_refund_bridge_transfer">refund_bridge_transfer</a>(_caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -2853,18 +2351,9 @@ Anyone can refund the transfer on the source chain once time lock has passed
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_refund_bridge_transfer">refund_bridge_transfer</a> (
     _caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a> {
-    <b>let</b> (receiver, amount) = <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel_transfer">atomic_bridge_store::cancel_transfer</a>&lt;<b>address</b>, EthereumAddress&gt;(bridge_transfer_id);
-    <a href="atomic_bridge.md#0x1_atomic_bridge_mint">atomic_bridge::mint</a>(receiver, amount);
-
-    <b>let</b> bridge_initiator_events = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a>&gt;(@aptos_framework);
-    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
-        &<b>mut</b> bridge_initiator_events.bridge_transfer_refunded_events,
-        <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferRefundedEvent">BridgeTransferRefundedEvent</a> {
-            bridge_transfer_id,
-        },
-    );
+    _bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+) {
+   <b>abort</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_EATOMIC_BRIDGE_DISABLED">EATOMIC_BRIDGE_DISABLED</a>
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/native_bridge.md
+++ b/aptos-move/framework/aptos-framework/doc/native_bridge.md
@@ -59,20 +59,12 @@
 -  [Function `test_normalize_u64_to_32_bytes_helper`](#0x1_native_bridge_test_normalize_u64_to_32_bytes_helper)
 
 
-<pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
-<b>use</b> <a href="aptos_coin.md#0x1_aptos_coin">0x1::aptos_coin</a>;
-<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_aptos_hash">0x1::aptos_hash</a>;
-<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs">0x1::bcs</a>;
+<pre><code><b>use</b> <a href="aptos_coin.md#0x1_aptos_coin">0x1::aptos_coin</a>;
 <b>use</b> <a href="coin.md#0x1_coin">0x1::coin</a>;
 <b>use</b> <a href="ethereum.md#0x1_ethereum">0x1::ethereum</a>;
 <b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
-<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
 <b>use</b> <a href="fungible_asset.md#0x1_fungible_asset">0x1::fungible_asset</a>;
-<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
 <b>use</b> <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table">0x1::smart_table</a>;
-<b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
-<b>use</b> <a href="timestamp.md#0x1_timestamp">0x1::timestamp</a>;
-<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
 </code></pre>
 
 
@@ -804,7 +796,7 @@ Details on the outbound transfer
 Initializes the module and stores the <code>EventHandle</code>s in the resource.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_initialize">initialize</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
 </code></pre>
 
 
@@ -813,59 +805,8 @@ Initializes the module and stores the <code>EventHandle</code>s in the resource.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
-    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_initialize">initialize</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
 
-    <b>let</b> bridge_config = <a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a> {
-        bridge_relayer: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework),
-        insurance_fund: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework),
-        insurance_budget_divider: 4,
-        bridge_fee: 40_000_000_000,
-    };
-    <b>move_to</b>(aptos_framework, bridge_config);
-
-    // Ensure the nonce is not already initialized
-    <b>assert</b>!(
-        !<b>exists</b>&lt;<a href="native_bridge.md#0x1_native_bridge_Nonce">Nonce</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework)),
-        2
-    );
-
-    // Create the <a href="native_bridge.md#0x1_native_bridge_Nonce">Nonce</a> resource <b>with</b> an initial value of 0
-    <b>move_to</b>&lt;<a href="native_bridge.md#0x1_native_bridge_Nonce">Nonce</a>&gt;(aptos_framework, <a href="native_bridge.md#0x1_native_bridge_Nonce">Nonce</a> {
-        value: 0
-    });
-
-
-    <b>move_to</b>(aptos_framework, <a href="native_bridge.md#0x1_native_bridge_BridgeEvents">BridgeEvents</a> {
-        bridge_transfer_initiated_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="native_bridge.md#0x1_native_bridge_BridgeTransferInitiatedEvent">BridgeTransferInitiatedEvent</a>&gt;(aptos_framework),
-        bridge_transfer_completed_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="native_bridge.md#0x1_native_bridge_BridgeTransferCompletedEvent">BridgeTransferCompletedEvent</a>&gt;(aptos_framework),
-    });
-    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-
-    <b>let</b> outbound_rate_limit_budget = <a href="native_bridge.md#0x1_native_bridge_OutboundRateLimitBudget">OutboundRateLimitBudget</a> {
-        day: <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_new">smart_table::new</a>(),
-    };
-
-    <b>move_to</b>(aptos_framework, outbound_rate_limit_budget);
-
-
-    <b>let</b> inbound_rate_limit_budget = <a href="native_bridge.md#0x1_native_bridge_InboundRateLimitBudget">InboundRateLimitBudget</a> {
-        day: <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_new">smart_table::new</a>(),
-    };
-
-    <b>move_to</b>(aptos_framework, inbound_rate_limit_budget);
-
-    <b>let</b> nonces_to_details = <a href="native_bridge.md#0x1_native_bridge_SmartTableWrapper">SmartTableWrapper</a>&lt;u64, <a href="native_bridge.md#0x1_native_bridge_OutboundTransfer">OutboundTransfer</a>&gt; {
-        inner: <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_new">smart_table::new</a>(),
-    };
-
-    <b>move_to</b>(aptos_framework, nonces_to_details);
-
-    <b>let</b> ids_to_inbound_nonces = <a href="native_bridge.md#0x1_native_bridge_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, u64&gt; {
-        inner: <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_new">smart_table::new</a>(),
-    };
-
-    <b>move_to</b>(aptos_framework, ids_to_inbound_nonces);
 }
 </code></pre>
 
@@ -888,7 +829,7 @@ How BCS works: https://github.com/zefchain/bcs?tab=readme-ov-file#booleans-and-i
 [0x00, 0x00, ..., 0x00, 0x12, 0x34, 0x56, 0x78, 0xab, 0xcd, 0xef, 0x00]
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_normalize_u64_to_32_bytes">normalize_u64_to_32_bytes</a>(value: &u64): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_normalize_u64_to_32_bytes">normalize_u64_to_32_bytes</a>(_value: &u64): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -897,11 +838,8 @@ How BCS works: https://github.com/zefchain/bcs?tab=readme-ov-file#booleans-and-i
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_normalize_u64_to_32_bytes">normalize_u64_to_32_bytes</a>(value: &u64): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>let</b> r = <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&(*value <b>as</b> u256));
-    // BCS returns the bytes in reverse order, so we reverse the result.
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_reverse">vector::reverse</a>(&<b>mut</b> r);
-    r
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_normalize_u64_to_32_bytes">normalize_u64_to_32_bytes</a>(_value: &u64): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -918,7 +856,7 @@ Checks if a bridge transfer ID is associated with an inbound nonce.
 @return <code><b>true</b></code> if the ID is associated with an existing inbound nonce, <code><b>false</b></code> otherwise.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_is_inbound_nonce_set">is_inbound_nonce_set</a>(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): bool
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_is_inbound_nonce_set">is_inbound_nonce_set</a>(_bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): bool
 </code></pre>
 
 
@@ -927,9 +865,8 @@ Checks if a bridge transfer ID is associated with an inbound nonce.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_is_inbound_nonce_set">is_inbound_nonce_set</a>(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): bool <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_SmartTableWrapper">SmartTableWrapper</a> {
-    <b>let</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a> = <b>borrow_global</b>&lt;<a href="native_bridge.md#0x1_native_bridge_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, u64&gt;&gt;(@aptos_framework);
-    <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_contains">smart_table::contains</a>(&<a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>.inner, bridge_transfer_id)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_is_inbound_nonce_set">is_inbound_nonce_set</a>(_bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): bool {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -951,7 +888,7 @@ Creates bridge transfer details with validation.
 @abort If the amount is zero or locks are invalid.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_create_details">create_details</a>(initiator: <b>address</b>, recipient: <a href="ethereum.md#0x1_ethereum_EthereumAddress">ethereum::EthereumAddress</a>, amount: u64, nonce: u64): <a href="native_bridge.md#0x1_native_bridge_OutboundTransfer">native_bridge::OutboundTransfer</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_create_details">create_details</a>(_initiator: <b>address</b>, _recipient: <a href="ethereum.md#0x1_ethereum_EthereumAddress">ethereum::EthereumAddress</a>, _amount: u64, _nonce: u64): <a href="native_bridge.md#0x1_native_bridge_OutboundTransfer">native_bridge::OutboundTransfer</a>
 </code></pre>
 
 
@@ -960,24 +897,9 @@ Creates bridge transfer details with validation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_create_details">create_details</a>(initiator: <b>address</b>, recipient: EthereumAddress, amount: u64, nonce: u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_create_details">create_details</a>(_initiator: <b>address</b>, _recipient: EthereumAddress, _amount: u64, _nonce: u64)
     : <a href="native_bridge.md#0x1_native_bridge_OutboundTransfer">OutboundTransfer</a> {
-    <b>assert</b>!(amount &gt; 0, <a href="native_bridge.md#0x1_native_bridge_EZERO_AMOUNT">EZERO_AMOUNT</a>);
-
-    // Create a bridge transfer ID algorithmically
-    <b>let</b> combined_bytes = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&initiator));
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&recipient));
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&amount));
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&nonce));
-    <b>let</b> bridge_transfer_id = keccak256(combined_bytes);
-
-    <a href="native_bridge.md#0x1_native_bridge_OutboundTransfer">OutboundTransfer</a> {
-        bridge_transfer_id,
-        initiator,
-        recipient,
-        amount,
-    }
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -995,7 +917,7 @@ Record details of an initiated transfer for quick lookup of details, mapping bri
 @param details The bridge transfer details
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_add">add</a>(nonce: u64, details: <a href="native_bridge.md#0x1_native_bridge_OutboundTransfer">native_bridge::OutboundTransfer</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_add">add</a>(_nonce: u64, _details: <a href="native_bridge.md#0x1_native_bridge_OutboundTransfer">native_bridge::OutboundTransfer</a>)
 </code></pre>
 
 
@@ -1004,11 +926,8 @@ Record details of an initiated transfer for quick lookup of details, mapping bri
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_add">add</a>(nonce: u64, details: <a href="native_bridge.md#0x1_native_bridge_OutboundTransfer">OutboundTransfer</a>) <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_SmartTableWrapper">SmartTableWrapper</a> {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_abort_native_bridge_enabled">features::abort_native_bridge_enabled</a>(), <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>);
-
-    <b>let</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a> = <b>borrow_global_mut</b>&lt;<a href="native_bridge.md#0x1_native_bridge_SmartTableWrapper">SmartTableWrapper</a>&lt;u64, <a href="native_bridge.md#0x1_native_bridge_OutboundTransfer">OutboundTransfer</a>&gt;&gt;(@aptos_framework);
-    <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_add">smart_table::add</a>(&<b>mut</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>.inner, nonce, details);
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_add">add</a>(_nonce: u64, _details: <a href="native_bridge.md#0x1_native_bridge_OutboundTransfer">OutboundTransfer</a>)  {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1026,7 +945,7 @@ Record details of a completed transfer, mapping bridge transfer ID to inbound no
 @param details The bridge transfer details
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_set_bridge_transfer_id_to_inbound_nonce">set_bridge_transfer_id_to_inbound_nonce</a>(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, inbound_nonce: u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_set_bridge_transfer_id_to_inbound_nonce">set_bridge_transfer_id_to_inbound_nonce</a>(_bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _inbound_nonce: u64)
 </code></pre>
 
 
@@ -1035,12 +954,8 @@ Record details of a completed transfer, mapping bridge transfer ID to inbound no
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_set_bridge_transfer_id_to_inbound_nonce">set_bridge_transfer_id_to_inbound_nonce</a>(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, inbound_nonce: u64) <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_SmartTableWrapper">SmartTableWrapper</a> {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_abort_native_bridge_enabled">features::abort_native_bridge_enabled</a>(), <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>);
-
-    <a href="native_bridge.md#0x1_native_bridge_assert_valid_bridge_transfer_id">assert_valid_bridge_transfer_id</a>(&bridge_transfer_id);
-    <b>let</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a> = <b>borrow_global_mut</b>&lt;<a href="native_bridge.md#0x1_native_bridge_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, u64&gt;&gt;(@aptos_framework);
-    <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_add">smart_table::add</a>(&<b>mut</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>.inner, bridge_transfer_id, inbound_nonce);
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_set_bridge_transfer_id_to_inbound_nonce">set_bridge_transfer_id_to_inbound_nonce</a>(_bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _inbound_nonce: u64) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1058,7 +973,7 @@ Asserts that the bridge transfer ID is valid.
 @abort If the ID is invalid.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_assert_valid_bridge_transfer_id">assert_valid_bridge_transfer_id</a>(bridge_transfer_id: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_assert_valid_bridge_transfer_id">assert_valid_bridge_transfer_id</a>(_bridge_transfer_id: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -1067,8 +982,8 @@ Asserts that the bridge transfer ID is valid.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_assert_valid_bridge_transfer_id">assert_valid_bridge_transfer_id</a>(bridge_transfer_id: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(bridge_transfer_id) == 32, <a href="native_bridge.md#0x1_native_bridge_EINVALID_BRIDGE_TRANSFER_ID">EINVALID_BRIDGE_TRANSFER_ID</a>);
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_assert_valid_bridge_transfer_id">assert_valid_bridge_transfer_id</a>(_bridge_transfer_id: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1086,7 +1001,7 @@ Generates a unique outbound bridge transfer ID based on transfer details and non
 @return The generated bridge transfer ID.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_bridge_transfer_id">bridge_transfer_id</a>(initiator: <b>address</b>, recipient: <a href="ethereum.md#0x1_ethereum_EthereumAddress">ethereum::EthereumAddress</a>, amount: u64, nonce: u64): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_bridge_transfer_id">bridge_transfer_id</a>(_initiator: <b>address</b>, _recipient: <a href="ethereum.md#0x1_ethereum_EthereumAddress">ethereum::EthereumAddress</a>, _amount: u64, _nonce: u64): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -1095,19 +1010,8 @@ Generates a unique outbound bridge transfer ID based on transfer details and non
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_bridge_transfer_id">bridge_transfer_id</a>(initiator: <b>address</b>, recipient: EthereumAddress, amount: u64, nonce: u64) : <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    // Serialize each param
-    <b>let</b> initiator_bytes = <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>&lt;<b>address</b>&gt;(&initiator);
-    <b>let</b> recipient_bytes = <a href="ethereum.md#0x1_ethereum_get_inner_ethereum_address">ethereum::get_inner_ethereum_address</a>(recipient);
-    <b>let</b> amount_bytes = <a href="native_bridge.md#0x1_native_bridge_normalize_u64_to_32_bytes">normalize_u64_to_32_bytes</a>(&amount);
-    <b>let</b> nonce_bytes = <a href="native_bridge.md#0x1_native_bridge_normalize_u64_to_32_bytes">normalize_u64_to_32_bytes</a>(&nonce);
-    //Contatenate then <a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_hash">hash</a> and <b>return</b> bridge transfer ID
-    <b>let</b> combined_bytes = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, initiator_bytes);
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, recipient_bytes);
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, amount_bytes);
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, nonce_bytes);
-    keccak256(combined_bytes)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_bridge_transfer_id">bridge_transfer_id</a>(_initiator: <b>address</b>, _recipient: EthereumAddress, _amount: u64, _nonce: u64) : <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1134,8 +1038,8 @@ Retrieves the address of the current bridge relayer.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_bridge_relayer">bridge_relayer</a>(): <b>address</b> <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a> {
-    <b>borrow_global_mut</b>&lt;<a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework).bridge_relayer
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_bridge_relayer">bridge_relayer</a>(): <b>address</b> {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1162,8 +1066,8 @@ Retrieves the address of the current insurance fund.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_insurance_fund">insurance_fund</a>(): <b>address</b> <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a> {
-    <b>borrow_global_mut</b>&lt;<a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework).insurance_fund
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_insurance_fund">insurance_fund</a>(): <b>address</b> {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1190,8 +1094,8 @@ Retrieves the current insurance budget divider.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_insurance_budget_divider">insurance_budget_divider</a>(): u64 <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a> {
-    <b>borrow_global_mut</b>&lt;<a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework).insurance_budget_divider
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_insurance_budget_divider">insurance_budget_divider</a>(): u64 {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1218,8 +1122,8 @@ Retrieves the current bridge fee.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_bridge_fee">bridge_fee</a>(): u64 <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a> {
-    <b>borrow_global_mut</b>&lt;<a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework).bridge_fee
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_bridge_fee">bridge_fee</a>(): u64 {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1238,7 +1142,7 @@ Gets the bridge transfer details (<code><a href="native_bridge.md#0x1_native_bri
 
 
 <pre><code>#[view]
-<b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_get_bridge_transfer_details_from_nonce">get_bridge_transfer_details_from_nonce</a>(nonce: u64): <a href="native_bridge.md#0x1_native_bridge_OutboundTransfer">native_bridge::OutboundTransfer</a>
+<b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_get_bridge_transfer_details_from_nonce">get_bridge_transfer_details_from_nonce</a>(_nonce: u64): <a href="native_bridge.md#0x1_native_bridge_OutboundTransfer">native_bridge::OutboundTransfer</a>
 </code></pre>
 
 
@@ -1247,14 +1151,8 @@ Gets the bridge transfer details (<code><a href="native_bridge.md#0x1_native_bri
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_get_bridge_transfer_details_from_nonce">get_bridge_transfer_details_from_nonce</a>(nonce: u64): <a href="native_bridge.md#0x1_native_bridge_OutboundTransfer">OutboundTransfer</a> <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_SmartTableWrapper">SmartTableWrapper</a> {
-    <b>let</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a> = <b>borrow_global</b>&lt;<a href="native_bridge.md#0x1_native_bridge_SmartTableWrapper">SmartTableWrapper</a>&lt;u64, <a href="native_bridge.md#0x1_native_bridge_OutboundTransfer">OutboundTransfer</a>&gt;&gt;(@aptos_framework);
-
-    // Check <b>if</b> the nonce <b>exists</b> in the <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>
-    <b>assert</b>!(<a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_contains">smart_table::contains</a>(&<a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>.inner, nonce), <a href="native_bridge.md#0x1_native_bridge_ENONCE_NOT_FOUND">ENONCE_NOT_FOUND</a>);
-
-    // If it <b>exists</b>, <b>return</b> the associated `<a href="native_bridge.md#0x1_native_bridge_OutboundTransfer">OutboundTransfer</a>` details
-    *<a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_borrow">smart_table::borrow</a>(&<a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>.inner, nonce)
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_get_bridge_transfer_details_from_nonce">get_bridge_transfer_details_from_nonce</a>(_nonce: u64): <a href="native_bridge.md#0x1_native_bridge_OutboundTransfer">OutboundTransfer</a> {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1273,7 +1171,7 @@ Gets inbound <code>nonce</code> from <code>bridge_transfer_id</code>
 
 
 <pre><code>#[view]
-<b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_get_inbound_nonce_from_bridge_transfer_id">get_inbound_nonce_from_bridge_transfer_id</a>(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): u64
+<b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_get_inbound_nonce_from_bridge_transfer_id">get_inbound_nonce_from_bridge_transfer_id</a>(_bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): u64
 </code></pre>
 
 
@@ -1282,14 +1180,8 @@ Gets inbound <code>nonce</code> from <code>bridge_transfer_id</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_get_inbound_nonce_from_bridge_transfer_id">get_inbound_nonce_from_bridge_transfer_id</a>(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): u64 <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_SmartTableWrapper">SmartTableWrapper</a> {
-    <b>let</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a> = <b>borrow_global</b>&lt;<a href="native_bridge.md#0x1_native_bridge_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, u64&gt;&gt;(@aptos_framework);
-
-     // Check <b>if</b> the nonce <b>exists</b> in the <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>
-    <b>assert</b>!(<a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_contains">smart_table::contains</a>(&<a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>.inner, bridge_transfer_id), <a href="native_bridge.md#0x1_native_bridge_ENONCE_NOT_FOUND">ENONCE_NOT_FOUND</a>);
-
-    // If it <b>exists</b>, <b>return</b> the associated nonce
-    *<a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_borrow">smart_table::borrow</a>(&<a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>.inner, bridge_transfer_id)
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_get_inbound_nonce_from_bridge_transfer_id">get_inbound_nonce_from_bridge_transfer_id</a>(_bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): u64 {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1313,10 +1205,8 @@ Increment and get the current nonce
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_increment_and_get_nonce">increment_and_get_nonce</a>(): u64 <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_Nonce">Nonce</a> {
-    <b>let</b> nonce_ref = <b>borrow_global_mut</b>&lt;<a href="native_bridge.md#0x1_native_bridge_Nonce">Nonce</a>&gt;(@aptos_framework);
-    nonce_ref.value = nonce_ref.value + 1;
-    nonce_ref.value
+<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_increment_and_get_nonce">increment_and_get_nonce</a>(): u64 {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1334,7 +1224,7 @@ Stores the burn capability for AptosCoin, converting to a fungible asset referen
 @param burn_cap The burn capability for AptosCoin.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_store_aptos_coin_burn_cap">store_aptos_coin_burn_cap</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, burn_cap: <a href="coin.md#0x1_coin_BurnCapability">coin::BurnCapability</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">aptos_coin::AptosCoin</a>&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_store_aptos_coin_burn_cap">store_aptos_coin_burn_cap</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _burn_cap: <a href="coin.md#0x1_coin_BurnCapability">coin::BurnCapability</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">aptos_coin::AptosCoin</a>&gt;)
 </code></pre>
 
 
@@ -1343,14 +1233,8 @@ Stores the burn capability for AptosCoin, converting to a fungible asset referen
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_store_aptos_coin_burn_cap">store_aptos_coin_burn_cap</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, burn_cap: BurnCapability&lt;AptosCoin&gt;) {
-    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operations_default_to_fa_apt_store_enabled">features::operations_default_to_fa_apt_store_enabled</a>()) {
-        <b>let</b> burn_ref = <a href="coin.md#0x1_coin_convert_and_take_paired_burn_ref">coin::convert_and_take_paired_burn_ref</a>(burn_cap);
-        <b>move_to</b>(aptos_framework, <a href="native_bridge.md#0x1_native_bridge_AptosFABurnCapabilities">AptosFABurnCapabilities</a> { burn_ref });
-    } <b>else</b> {
-        <b>move_to</b>(aptos_framework, <a href="native_bridge.md#0x1_native_bridge_AptosCoinBurnCapability">AptosCoinBurnCapability</a> { burn_cap })
-    }
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_store_aptos_coin_burn_cap">store_aptos_coin_burn_cap</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _burn_cap: BurnCapability&lt;AptosCoin&gt;) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1368,7 +1252,7 @@ Stores the mint capability for AptosCoin.
 @param mint_cap The mint capability for AptosCoin.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_store_aptos_coin_mint_cap">store_aptos_coin_mint_cap</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, mint_cap: <a href="coin.md#0x1_coin_MintCapability">coin::MintCapability</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">aptos_coin::AptosCoin</a>&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_store_aptos_coin_mint_cap">store_aptos_coin_mint_cap</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _mint_cap: <a href="coin.md#0x1_coin_MintCapability">coin::MintCapability</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">aptos_coin::AptosCoin</a>&gt;)
 </code></pre>
 
 
@@ -1377,9 +1261,8 @@ Stores the mint capability for AptosCoin.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_store_aptos_coin_mint_cap">store_aptos_coin_mint_cap</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, mint_cap: MintCapability&lt;AptosCoin&gt;) {
-    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-    <b>move_to</b>(aptos_framework, <a href="native_bridge.md#0x1_native_bridge_AptosCoinMintCapability">AptosCoinMintCapability</a> { mint_cap })
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_store_aptos_coin_mint_cap">store_aptos_coin_mint_cap</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _mint_cap: MintCapability&lt;AptosCoin&gt;) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1398,7 +1281,7 @@ Mints a specified amount of AptosCoin to a recipient's address.
 @param amount The amount of AptosCoin to mint.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_mint_to">mint_to</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, recipient: <b>address</b>, amount: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_mint_to">mint_to</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _recipient: <b>address</b>, _amount: u64)
 </code></pre>
 
 
@@ -1407,9 +1290,8 @@ Mints a specified amount of AptosCoin to a recipient's address.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_mint_to">mint_to</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, recipient: <b>address</b>, amount: u64) <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_AptosCoinMintCapability">AptosCoinMintCapability</a> {
-    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-    <a href="native_bridge.md#0x1_native_bridge_mint_internal">mint_internal</a>(recipient, amount);
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_mint_to">mint_to</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _recipient: <b>address</b>, _amount: u64) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1428,7 +1310,7 @@ Mints a specified amount of AptosCoin to a recipient's address.
 @abort If the mint capability is not available.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_mint">mint</a>(recipient: <b>address</b>, amount: u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_mint">mint</a>(_recipient: <b>address</b>, _amount: u64)
 </code></pre>
 
 
@@ -1437,10 +1319,8 @@ Mints a specified amount of AptosCoin to a recipient's address.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_mint">mint</a>(recipient: <b>address</b>, amount: u64) <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_AptosCoinMintCapability">AptosCoinMintCapability</a> {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_abort_native_bridge_enabled">features::abort_native_bridge_enabled</a>(), <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>);
-
-    <a href="native_bridge.md#0x1_native_bridge_mint_internal">mint_internal</a>(recipient, amount);
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_mint">mint</a>(_recipient: <b>address</b>, _amount: u64) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1458,7 +1338,7 @@ Mints a specified amount of AptosCoin to a recipient's address.
 @param amount The amount of AptosCoin to mint.
 
 
-<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_mint_internal">mint_internal</a>(recipient: <b>address</b>, amount: u64)
+<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_mint_internal">mint_internal</a>(_recipient: <b>address</b>, _amount: u64)
 </code></pre>
 
 
@@ -1467,11 +1347,8 @@ Mints a specified amount of AptosCoin to a recipient's address.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_mint_internal">mint_internal</a>(recipient: <b>address</b>, amount: u64) <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_AptosCoinMintCapability">AptosCoinMintCapability</a> {
-    <a href="coin.md#0x1_coin_deposit">coin::deposit</a>(recipient, <a href="coin.md#0x1_coin_mint">coin::mint</a>(
-        amount,
-        &<b>borrow_global</b>&lt;<a href="native_bridge.md#0x1_native_bridge_AptosCoinMintCapability">AptosCoinMintCapability</a>&gt;(@aptos_framework).mint_cap
-    ));
+<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_mint_internal">mint_internal</a>(_recipient: <b>address</b>, _amount: u64) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1491,7 +1368,7 @@ Burns a specified amount of AptosCoin from an address.
 @abort If the burn capability is not available.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_burn_from">burn_from</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, from: <b>address</b>, amount: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_burn_from">burn_from</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _from: <b>address</b>, _amount: u64)
 </code></pre>
 
 
@@ -1500,9 +1377,8 @@ Burns a specified amount of AptosCoin from an address.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_burn_from">burn_from</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, from: <b>address</b>, amount: u64) <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_AptosCoinBurnCapability">AptosCoinBurnCapability</a> {
-    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-    <a href="native_bridge.md#0x1_native_bridge_burn_internal">burn_internal</a>(from, amount);
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_burn_from">burn_from</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _from: <b>address</b>, _amount: u64) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1521,7 +1397,7 @@ Burns a specified amount of AptosCoin from an address.
 @abort If the burn capability is not available.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_burn">burn</a>(from: <b>address</b>, amount: u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_burn">burn</a>(_from: <b>address</b>, _amount: u64)
 </code></pre>
 
 
@@ -1530,10 +1406,8 @@ Burns a specified amount of AptosCoin from an address.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_burn">burn</a>(from: <b>address</b>, amount: u64) <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_AptosCoinBurnCapability">AptosCoinBurnCapability</a> {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_abort_native_bridge_enabled">features::abort_native_bridge_enabled</a>(), <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>);
-
-    <a href="native_bridge.md#0x1_native_bridge_burn_internal">burn_internal</a>(from, amount);
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_burn">burn</a>(_from: <b>address</b>, _amount: u64) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1551,7 +1425,7 @@ Burns a specified amount of AptosCoin from an address.
 @param amount The amount of AptosCoin to burn.
 
 
-<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_burn_internal">burn_internal</a>(from: <b>address</b>, amount: u64)
+<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_burn_internal">burn_internal</a>(_from: <b>address</b>, _amount: u64)
 </code></pre>
 
 
@@ -1560,12 +1434,8 @@ Burns a specified amount of AptosCoin from an address.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_burn_internal">burn_internal</a>(from: <b>address</b>, amount: u64) <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_AptosCoinBurnCapability">AptosCoinBurnCapability</a> {
-    <a href="coin.md#0x1_coin_burn_from">coin::burn_from</a>(
-        from,
-        amount,
-        &<b>borrow_global</b>&lt;<a href="native_bridge.md#0x1_native_bridge_AptosCoinBurnCapability">AptosCoinBurnCapability</a>&gt;(@aptos_framework).burn_cap,
-    );
+<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_burn_internal">burn_internal</a>(_from: <b>address</b>, _amount: u64) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1585,7 +1455,7 @@ The amount is burnt from the initiator and the module-level nonce is incremented
 @param amount The amount of assets to be locked.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_initiate_bridge_transfer">initiate_bridge_transfer</a>(initiator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, recipient: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, amount: u64)
+<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_initiate_bridge_transfer">initiate_bridge_transfer</a>(_initiator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _recipient: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _amount: u64)
 </code></pre>
 
 
@@ -1595,55 +1465,11 @@ The amount is burnt from the initiator and the module-level nonce is incremented
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_initiate_bridge_transfer">initiate_bridge_transfer</a>(
-    initiator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    recipient: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    amount: u64
-) <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_BridgeEvents">BridgeEvents</a>, <a href="native_bridge.md#0x1_native_bridge_Nonce">Nonce</a>, <a href="native_bridge.md#0x1_native_bridge_AptosCoinBurnCapability">AptosCoinBurnCapability</a>, <a href="native_bridge.md#0x1_native_bridge_AptosCoinMintCapability">AptosCoinMintCapability</a>, <a href="native_bridge.md#0x1_native_bridge_SmartTableWrapper">SmartTableWrapper</a>, <a href="native_bridge.md#0x1_native_bridge_OutboundRateLimitBudget">OutboundRateLimitBudget</a>, <a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a> {
-    <b>let</b> initiator_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(initiator);
-    <b>let</b> ethereum_address = <a href="ethereum.md#0x1_ethereum_ethereum_address_20_bytes">ethereum::ethereum_address_20_bytes</a>(recipient);
-
-    // Ensure the amount is enough for the bridge fee and charge for it
-    <b>let</b> new_amount = <a href="native_bridge.md#0x1_native_bridge_charge_bridge_fee">charge_bridge_fee</a>(amount);
-
-    <a href="native_bridge.md#0x1_native_bridge_assert_outbound_rate_limit_budget_not_exceeded">assert_outbound_rate_limit_budget_not_exceeded</a>(new_amount);
-
-    // Increment and retrieve the nonce
-    <b>let</b> nonce = <a href="native_bridge.md#0x1_native_bridge_increment_and_get_nonce">increment_and_get_nonce</a>();
-
-    // Create bridge transfer details
-    <b>let</b> details = <a href="native_bridge.md#0x1_native_bridge_create_details">create_details</a>(
-        initiator_address,
-        ethereum_address,
-        new_amount,
-        nonce
-    );
-
-    <b>let</b> bridge_transfer_id = <a href="native_bridge.md#0x1_native_bridge_bridge_transfer_id">bridge_transfer_id</a>(
-        initiator_address,
-        ethereum_address,
-        new_amount,
-        nonce
-    );
-
-    // Add the transfer details <b>to</b> storage
-    <a href="native_bridge.md#0x1_native_bridge_add">add</a>(nonce, details);
-
-    // Burn the amount from the initiator
-    <a href="native_bridge.md#0x1_native_bridge_burn_internal">burn_internal</a>(initiator_address, amount);
-
-    <b>let</b> bridge_events = <b>borrow_global_mut</b>&lt;<a href="native_bridge.md#0x1_native_bridge_BridgeEvents">BridgeEvents</a>&gt;(@aptos_framework);
-
-    // Emit an <a href="event.md#0x1_event">event</a> <b>with</b> nonce
-    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
-         &<b>mut</b> bridge_events.bridge_transfer_initiated_events,
-        <a href="native_bridge.md#0x1_native_bridge_BridgeTransferInitiatedEvent">BridgeTransferInitiatedEvent</a> {
-            bridge_transfer_id,
-            initiator: initiator_address,
-            recipient,
-            amount: new_amount,
-            nonce,
-        }
-    );
+    _initiator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    _recipient: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    _amount: u64
+) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1666,7 +1492,7 @@ Completes a bridge transfer on the destination chain.
 @abort If the caller is not the bridge relayer or the transfer has already been processed.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_complete_bridge_transfer">complete_bridge_transfer</a>(caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, initiator: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, recipient: <b>address</b>, amount: u64, nonce: u64)
+<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_complete_bridge_transfer">complete_bridge_transfer</a>(_caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _initiator: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, _recipient: <b>address</b>, _amount: u64, _nonce: u64)
 </code></pre>
 
 
@@ -1676,53 +1502,14 @@ Completes a bridge transfer on the destination chain.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_complete_bridge_transfer">complete_bridge_transfer</a>(
-    caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    initiator: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    recipient: <b>address</b>,
-    amount: u64,
-    nonce: u64
-) <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_BridgeEvents">BridgeEvents</a>, <a href="native_bridge.md#0x1_native_bridge_AptosCoinMintCapability">AptosCoinMintCapability</a>, <a href="native_bridge.md#0x1_native_bridge_SmartTableWrapper">SmartTableWrapper</a>, <a href="native_bridge.md#0x1_native_bridge_InboundRateLimitBudget">InboundRateLimitBudget</a>, <a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a> {
-    // Ensure the caller is the bridge relayer
-    <a href="native_bridge.md#0x1_native_bridge_assert_is_caller_relayer">assert_is_caller_relayer</a>(caller);
-    <a href="native_bridge.md#0x1_native_bridge_assert_inbound_rate_limit_budget_not_exceeded">assert_inbound_rate_limit_budget_not_exceeded</a>(amount);
-
-    // Check <b>if</b> the bridge transfer ID is already associated <b>with</b> an inbound nonce
-    <b>let</b> inbound_nonce_exists = <a href="native_bridge.md#0x1_native_bridge_is_inbound_nonce_set">is_inbound_nonce_set</a>(bridge_transfer_id);
-    <b>assert</b>!(!inbound_nonce_exists, <a href="native_bridge.md#0x1_native_bridge_ETRANSFER_ALREADY_PROCESSED">ETRANSFER_ALREADY_PROCESSED</a>);
-    <b>assert</b>!(nonce &gt; 0, <a href="native_bridge.md#0x1_native_bridge_EINVALID_NONCE">EINVALID_NONCE</a>);
-
-    // Validate the bridge_transfer_id by reconstructing the <a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_hash">hash</a>
-    <b>let</b> recipient_bytes = <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&recipient);
-    <b>let</b> amount_bytes = <a href="native_bridge.md#0x1_native_bridge_normalize_u64_to_32_bytes">normalize_u64_to_32_bytes</a>(&amount);
-    <b>let</b> nonce_bytes = <a href="native_bridge.md#0x1_native_bridge_normalize_u64_to_32_bytes">normalize_u64_to_32_bytes</a>(&nonce);
-
-    <b>let</b> combined_bytes = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, initiator);
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, recipient_bytes);
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, amount_bytes);
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, nonce_bytes);
-
-    <b>assert</b>!(keccak256(combined_bytes) == bridge_transfer_id, <a href="native_bridge.md#0x1_native_bridge_EINVALID_BRIDGE_TRANSFER_ID">EINVALID_BRIDGE_TRANSFER_ID</a>);
-
-    // Record the transfer <b>as</b> completed by associating the bridge_transfer_id <b>with</b> the inbound nonce
-    <a href="native_bridge.md#0x1_native_bridge_set_bridge_transfer_id_to_inbound_nonce">set_bridge_transfer_id_to_inbound_nonce</a>(bridge_transfer_id, nonce);
-
-    // Mint <b>to</b> the recipient
-    <a href="native_bridge.md#0x1_native_bridge_mint_internal">mint_internal</a>(recipient, amount);
-
-    // Emit the <a href="event.md#0x1_event">event</a>
-    <b>let</b> bridge_events = <b>borrow_global_mut</b>&lt;<a href="native_bridge.md#0x1_native_bridge_BridgeEvents">BridgeEvents</a>&gt;(@aptos_framework);
-    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
-        &<b>mut</b> bridge_events.bridge_transfer_completed_events,
-        <a href="native_bridge.md#0x1_native_bridge_BridgeTransferCompletedEvent">BridgeTransferCompletedEvent</a> {
-            bridge_transfer_id,
-            initiator,
-            recipient,
-            amount,
-            nonce,
-        },
-    );
+    _caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    _bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    _initiator: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    _recipient: <b>address</b>,
+    _amount: u64,
+    _nonce: u64
+)  {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1741,7 +1528,7 @@ Charge bridge fee to the initiate bridge transfer.
 @return The new amount after deducting the bridge fee.
 
 
-<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_charge_bridge_fee">charge_bridge_fee</a>(amount: u64): u64
+<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_charge_bridge_fee">charge_bridge_fee</a>(_amount: u64): u64
 </code></pre>
 
 
@@ -1750,13 +1537,8 @@ Charge bridge fee to the initiate bridge transfer.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_charge_bridge_fee">charge_bridge_fee</a>(amount: u64) : u64 <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_AptosCoinMintCapability">AptosCoinMintCapability</a>, <a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a> {
-    <b>let</b> bridge_fee = <a href="native_bridge.md#0x1_native_bridge_bridge_fee">bridge_fee</a>();
-    <b>let</b> bridge_relayer = <a href="native_bridge.md#0x1_native_bridge_bridge_relayer">bridge_relayer</a>();
-    <b>assert</b>!(amount &gt; bridge_fee, <a href="native_bridge.md#0x1_native_bridge_EINVALID_AMOUNT">EINVALID_AMOUNT</a>);
-    <b>let</b> new_amount = amount - bridge_fee;
-    <a href="native_bridge.md#0x1_native_bridge_mint_internal">mint_internal</a>(bridge_relayer, bridge_fee);
-    new_amount
+<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_charge_bridge_fee">charge_bridge_fee</a>(_amount: u64): u64 {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1775,7 +1557,7 @@ Updates the bridge relayer, requiring governance validation.
 @abort If the current relayer is the same as the new relayer.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_update_bridge_relayer">update_bridge_relayer</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_relayer: <b>address</b>)
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_update_bridge_relayer">update_bridge_relayer</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _new_relayer: <b>address</b>)
 </code></pre>
 
 
@@ -1784,21 +1566,8 @@ Updates the bridge relayer, requiring governance validation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_update_bridge_relayer">update_bridge_relayer</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_relayer: <b>address</b>
-)   <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a> {
-    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-    <b>let</b> bridge_config = <b>borrow_global_mut</b>&lt;<a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework);
-    <b>let</b> old_relayer = bridge_config.bridge_relayer;
-    <b>assert</b>!(old_relayer != new_relayer, <a href="native_bridge.md#0x1_native_bridge_EINVALID_BRIDGE_RELAYER">EINVALID_BRIDGE_RELAYER</a>);
-
-    bridge_config.bridge_relayer = new_relayer;
-
-    <a href="event.md#0x1_event_emit">event::emit</a>(
-        <a href="native_bridge.md#0x1_native_bridge_BridgeConfigRelayerUpdated">BridgeConfigRelayerUpdated</a> {
-            old_relayer,
-            new_relayer,
-        },
-    );
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_update_bridge_relayer">update_bridge_relayer</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _new_relayer: <b>address</b>) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1817,7 +1586,7 @@ Updates the bridge fee, requiring relayer validation.
 @abort If the new bridge fee is the same as the old bridge fee.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_update_bridge_fee">update_bridge_fee</a>(relayer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_bridge_fee: u64)
+<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_update_bridge_fee">update_bridge_fee</a>(_relayer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _new_bridge_fee: u64)
 </code></pre>
 
 
@@ -1826,20 +1595,8 @@ Updates the bridge fee, requiring relayer validation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_update_bridge_fee">update_bridge_fee</a>(relayer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_bridge_fee: u64
-) <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a> {
-    <a href="native_bridge.md#0x1_native_bridge_assert_is_caller_relayer">assert_is_caller_relayer</a>(relayer);
-    <b>let</b> bridge_config = <b>borrow_global_mut</b>&lt;<a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework);
-    <b>let</b> old_bridge_fee = bridge_config.bridge_fee;
-    <b>assert</b>!(old_bridge_fee != new_bridge_fee, <a href="native_bridge.md#0x1_native_bridge_ESAME_FEE">ESAME_FEE</a>);
-    bridge_config.bridge_fee = new_bridge_fee;
-
-    <a href="event.md#0x1_event_emit">event::emit</a>(
-        <a href="native_bridge.md#0x1_native_bridge_BridgeFeeChangedEvent">BridgeFeeChangedEvent</a> {
-            old_bridge_fee,
-            new_bridge_fee,
-        },
-    );
+<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_update_bridge_fee">update_bridge_fee</a>(_relayer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _new_bridge_fee: u64) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1858,7 +1615,7 @@ Updates the insurance fund, requiring governance validation.
 @abort If the new insurance fund is the same as the old insurance fund.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_update_insurance_fund">update_insurance_fund</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_insurance_fund: <b>address</b>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_update_insurance_fund">update_insurance_fund</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _new_insurance_fund: <b>address</b>)
 </code></pre>
 
 
@@ -1867,20 +1624,8 @@ Updates the insurance fund, requiring governance validation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_update_insurance_fund">update_insurance_fund</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_insurance_fund: <b>address</b>
-) <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a> {
-    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-    <b>let</b> bridge_config = <b>borrow_global_mut</b>&lt;<a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework);
-    <b>let</b> old_insurance_fund = bridge_config.insurance_fund;
-    <b>assert</b>!(old_insurance_fund != new_insurance_fund, <a href="native_bridge.md#0x1_native_bridge_EINVALID_VALUE">EINVALID_VALUE</a>);
-    bridge_config.insurance_fund = new_insurance_fund;
-
-    <a href="event.md#0x1_event_emit">event::emit</a>(
-        <a href="native_bridge.md#0x1_native_bridge_BridgeInsuranceFundChangedEvent">BridgeInsuranceFundChangedEvent</a> {
-            old_insurance_fund,
-            new_insurance_fund,
-        },
-    );
+<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_update_insurance_fund">update_insurance_fund</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _new_insurance_fund: <b>address</b>) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1899,7 +1644,7 @@ Updates the insurance budget divider, requiring governance validation.
 @abort If the new insurance budget divider is the same as the old insurance budget divider.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_update_insurance_budget_divider">update_insurance_budget_divider</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_insurance_budget_divider: u64)
+<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_update_insurance_budget_divider">update_insurance_budget_divider</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _new_insurance_budget_divider: u64)
 </code></pre>
 
 
@@ -1908,25 +1653,8 @@ Updates the insurance budget divider, requiring governance validation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_update_insurance_budget_divider">update_insurance_budget_divider</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_insurance_budget_divider: u64
-) <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a> {
-    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-    // Ensure the new insurance budget divider is greater than 1 and different from the <b>old</b> one
-    // Assumes symmetric Insurance Funds on both L1 and L2
-    <b>assert</b>!(new_insurance_budget_divider &gt; 1, <a href="native_bridge.md#0x1_native_bridge_EINVALID_VALUE">EINVALID_VALUE</a>);
-
-    <b>let</b> bridge_config = <b>borrow_global_mut</b>&lt;<a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework);
-    <b>let</b> old_insurance_budget_divider = bridge_config.insurance_budget_divider;
-    <b>assert</b>!(old_insurance_budget_divider != new_insurance_budget_divider, <a href="native_bridge.md#0x1_native_bridge_EINVALID_VALUE">EINVALID_VALUE</a>);
-
-    bridge_config.insurance_budget_divider = new_insurance_budget_divider;
-
-    <a href="event.md#0x1_event_emit">event::emit</a>(
-        <a href="native_bridge.md#0x1_native_bridge_BridgeInsuranceBudgetDividerChangedEvent">BridgeInsuranceBudgetDividerChangedEvent</a> {
-            old_insurance_budget_divider,
-            new_insurance_budget_divider,
-        },
-    );
+<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_update_insurance_budget_divider">update_insurance_budget_divider</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _new_insurance_budget_divider: u64) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1944,7 +1672,7 @@ Asserts that the caller is the current bridge relayer.
 @abort If the caller is not the current bridge relayer.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_assert_is_caller_relayer">assert_is_caller_relayer</a>(caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_assert_is_caller_relayer">assert_is_caller_relayer</a>(_caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
 </code></pre>
 
 
@@ -1953,9 +1681,8 @@ Asserts that the caller is the current bridge relayer.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_assert_is_caller_relayer">assert_is_caller_relayer</a>(caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
-) <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a> {
-    <b>assert</b>!(<b>borrow_global</b>&lt;<a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework).bridge_relayer == <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(caller), <a href="native_bridge.md#0x1_native_bridge_EINVALID_BRIDGE_RELAYER">EINVALID_BRIDGE_RELAYER</a>);
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_assert_is_caller_relayer">assert_is_caller_relayer</a>(_caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -1972,7 +1699,7 @@ Asserts that the rate limit budget is not exceeded.
 @param amount The amount to be transferred.
 
 
-<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_assert_outbound_rate_limit_budget_not_exceeded">assert_outbound_rate_limit_budget_not_exceeded</a>(amount: u64)
+<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_assert_outbound_rate_limit_budget_not_exceeded">assert_outbound_rate_limit_budget_not_exceeded</a>(_amount: u64)
 </code></pre>
 
 
@@ -1981,16 +1708,8 @@ Asserts that the rate limit budget is not exceeded.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_assert_outbound_rate_limit_budget_not_exceeded">assert_outbound_rate_limit_budget_not_exceeded</a>(amount: u64) <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_OutboundRateLimitBudget">OutboundRateLimitBudget</a>, <a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a> {
-    <b>let</b> insurance_fund = <b>borrow_global</b>&lt;<a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework).insurance_fund;
-    <b>let</b> insurance_budget_divider = <b>borrow_global</b>&lt;<a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework).insurance_budget_divider;
-    <b>let</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a> = <b>borrow_global_mut</b>&lt;<a href="native_bridge.md#0x1_native_bridge_OutboundRateLimitBudget">OutboundRateLimitBudget</a>&gt;(@aptos_framework);
-
-    <b>let</b> day = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>() / 86400;
-    <b>let</b> current_budget = <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_borrow_mut_with_default">smart_table::borrow_mut_with_default</a>(&<b>mut</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>.day, day, 0);
-    <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_upsert">smart_table::upsert</a>(&<b>mut</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>.day, day, *current_budget + amount);
-    <b>let</b> rate_limit = <a href="coin.md#0x1_coin_balance">coin::balance</a>&lt;AptosCoin&gt;(insurance_fund) / insurance_budget_divider;
-    <b>assert</b>!(*<a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_borrow">smart_table::borrow</a>(&<a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>.day, day) &lt; rate_limit, <a href="native_bridge.md#0x1_native_bridge_ERATE_LIMIT_EXCEEDED">ERATE_LIMIT_EXCEEDED</a>);
+<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_assert_outbound_rate_limit_budget_not_exceeded">assert_outbound_rate_limit_budget_not_exceeded</a>(_amount: u64) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -2007,7 +1726,7 @@ Asserts that the rate limit budget is not exceeded.
 @param amount The amount to be transferred.
 
 
-<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_assert_inbound_rate_limit_budget_not_exceeded">assert_inbound_rate_limit_budget_not_exceeded</a>(amount: u64)
+<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_assert_inbound_rate_limit_budget_not_exceeded">assert_inbound_rate_limit_budget_not_exceeded</a>(_amount: u64)
 </code></pre>
 
 
@@ -2016,16 +1735,8 @@ Asserts that the rate limit budget is not exceeded.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_assert_inbound_rate_limit_budget_not_exceeded">assert_inbound_rate_limit_budget_not_exceeded</a>(amount: u64) <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_InboundRateLimitBudget">InboundRateLimitBudget</a>, <a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a> {
-    <b>let</b> insurance_fund = <b>borrow_global</b>&lt;<a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework).insurance_fund;
-    <b>let</b> insurance_budget_divider = <b>borrow_global</b>&lt;<a href="native_bridge.md#0x1_native_bridge_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework).insurance_budget_divider;
-    <b>let</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a> = <b>borrow_global_mut</b>&lt;<a href="native_bridge.md#0x1_native_bridge_InboundRateLimitBudget">InboundRateLimitBudget</a>&gt;(@aptos_framework);
-
-    <b>let</b> day = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>() / 86400;
-    <b>let</b> current_budget = <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_borrow_mut_with_default">smart_table::borrow_mut_with_default</a>(&<b>mut</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>.day, day, 0);
-    <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_upsert">smart_table::upsert</a>(&<b>mut</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>.day, day, *current_budget + amount);
-    <b>let</b> rate_limit = <a href="coin.md#0x1_coin_balance">coin::balance</a>&lt;AptosCoin&gt;(insurance_fund) / insurance_budget_divider;
-    <b>assert</b>!(*<a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_borrow">smart_table::borrow</a>(&<a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>.day, day) &lt; rate_limit, <a href="native_bridge.md#0x1_native_bridge_ERATE_LIMIT_EXCEEDED">ERATE_LIMIT_EXCEEDED</a>);
+<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_assert_inbound_rate_limit_budget_not_exceeded">assert_inbound_rate_limit_budget_not_exceeded</a>(_amount: u64) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 
@@ -2040,7 +1751,7 @@ Asserts that the rate limit budget is not exceeded.
 Test serialization of u64 to 32 bytes
 
 
-<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_test_normalize_u64_to_32_bytes_helper">test_normalize_u64_to_32_bytes_helper</a>(x: u64, expected: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_test_normalize_u64_to_32_bytes_helper">test_normalize_u64_to_32_bytes_helper</a>(_x: u64, _expected: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -2049,10 +1760,8 @@ Test serialization of u64 to 32 bytes
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_test_normalize_u64_to_32_bytes_helper">test_normalize_u64_to_32_bytes_helper</a>(x: u64, expected: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
-    <b>let</b> r = <a href="native_bridge.md#0x1_native_bridge_normalize_u64_to_32_bytes">normalize_u64_to_32_bytes</a>(&x);
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&r) == 32, 0);
-    <b>assert</b>!(r == expected, 0);
+<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_test_normalize_u64_to_32_bytes_helper">test_normalize_u64_to_32_bytes_helper</a>(_x: u64, _expected: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
+    <b>abort</b> <a href="native_bridge.md#0x1_native_bridge_ENATIVE_BRIDGE_NOT_ENABLED">ENATIVE_BRIDGE_NOT_ENABLED</a>
 }
 </code></pre>
 

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -286,22 +286,22 @@ pub enum EntryFunctionCall {
     /// @param bridge_transfer_id The unique identifier for the bridge transfer.
     /// @abort If the caller is not the bridge operator or if the time lock has not expired.
     AtomicBridgeCounterpartyAbortBridgeTransfer {
-        bridge_transfer_id: Vec<u8>,
+        _bridge_transfer_id: Vec<u8>,
     },
 
     /// Bridge operator can complete the transfer
     AtomicBridgeInitiatorCompleteBridgeTransfer {
-        bridge_transfer_id: Vec<u8>,
-        pre_image: Vec<u8>,
+        _bridge_transfer_id: Vec<u8>,
+        _pre_image: Vec<u8>,
     },
 
     /// Initiate a bridge transfer of ETH from Movement to the base layer
     /// Anyone can initiate a bridge transfer from the source chain
     /// The amount is burnt from the initiator
     AtomicBridgeInitiatorInitiateBridgeTransfer {
-        recipient: Vec<u8>,
-        hash_lock: Vec<u8>,
-        amount: u64,
+        _recipient: Vec<u8>,
+        _hash_lock: Vec<u8>,
+        _amount: u64,
     },
 
     /// Locks assets for a bridge transfer by the initiator.
@@ -315,16 +315,16 @@ pub enum EntryFunctionCall {
     /// @param amount The amount of assets to be locked.
     /// @abort If the caller is not the bridge operator.
     AtomicBridgeCounterpartyLockBridgeTransferAssets {
-        initiator: Vec<u8>,
-        bridge_transfer_id: Vec<u8>,
-        hash_lock: Vec<u8>,
-        recipient: AccountAddress,
-        amount: u64,
+        _initiator: Vec<u8>,
+        _bridge_transfer_id: Vec<u8>,
+        _hash_lock: Vec<u8>,
+        _recipient: AccountAddress,
+        _amount: u64,
     },
 
     /// Anyone can refund the transfer on the source chain once time lock has passed
     AtomicBridgeInitiatorRefundBridgeTransfer {
-        bridge_transfer_id: Vec<u8>,
+        _bridge_transfer_id: Vec<u8>,
     },
 
     /// Same as `publish_package` but as an entry function which can be called as a transaction. Because
@@ -724,11 +724,11 @@ pub enum EntryFunctionCall {
     /// @param nonce The unique nonce for the transfer.    
     /// @abort If the caller is not the bridge relayer or the transfer has already been processed.
     NativeBridgeCompleteBridgeTransfer {
-        bridge_transfer_id: Vec<u8>,
-        initiator: Vec<u8>,
-        recipient: AccountAddress,
-        amount: u64,
-        nonce: u64,
+        _bridge_transfer_id: Vec<u8>,
+        _initiator: Vec<u8>,
+        _recipient: AccountAddress,
+        _amount: u64,
+        _nonce: u64,
     },
 
     /// Initiate a bridge transfer of MOVE from Movement to Ethereum
@@ -738,8 +738,8 @@ pub enum EntryFunctionCall {
     /// @param recipient The address of the recipient on the Aptos blockchain.  
     /// @param amount The amount of assets to be locked.
     NativeBridgeInitiateBridgeTransfer {
-        recipient: Vec<u8>,
-        amount: u64,
+        _recipient: Vec<u8>,
+        _amount: u64,
     },
 
     /// Updates the bridge fee, requiring relayer validation.
@@ -748,7 +748,7 @@ pub enum EntryFunctionCall {
     /// @param new_bridge_fee The new bridge fee to be set.
     /// @abort If the new bridge fee is the same as the old bridge fee.
     NativeBridgeUpdateBridgeFee {
-        new_bridge_fee: u64,
+        _new_bridge_fee: u64,
     },
 
     /// Updates the insurance budget divider, requiring governance validation.
@@ -757,7 +757,7 @@ pub enum EntryFunctionCall {
     /// @param new_insurance_budget_divider The new insurance budget divider to be set.
     /// @abort If the new insurance budget divider is the same as the old insurance budget divider.
     NativeBridgeUpdateInsuranceBudgetDivider {
-        new_insurance_budget_divider: u64,
+        _new_insurance_budget_divider: u64,
     },
 
     /// Updates the insurance fund, requiring governance validation.
@@ -766,7 +766,7 @@ pub enum EntryFunctionCall {
     /// @param new_insurance_fund The new insurance fund to be set.
     /// @abort If the new insurance fund is the same as the old insurance fund.
     NativeBridgeUpdateInsuranceFund {
-        new_insurance_fund: AccountAddress,
+        _new_insurance_fund: AccountAddress,
     },
 
     /// Entry function that can be used to transfer, if allow_ungated_transfer is set true.
@@ -1268,34 +1268,34 @@ impl EntryFunctionCall {
                 proposal_id,
                 should_pass,
             } => aptos_governance_vote(stake_pool, proposal_id, should_pass),
-            AtomicBridgeCounterpartyAbortBridgeTransfer { bridge_transfer_id } => {
-                atomic_bridge_counterparty_abort_bridge_transfer(bridge_transfer_id)
-            },
+            AtomicBridgeCounterpartyAbortBridgeTransfer {
+                _bridge_transfer_id,
+            } => atomic_bridge_counterparty_abort_bridge_transfer(_bridge_transfer_id),
             AtomicBridgeInitiatorCompleteBridgeTransfer {
-                bridge_transfer_id,
-                pre_image,
-            } => atomic_bridge_initiator_complete_bridge_transfer(bridge_transfer_id, pre_image),
+                _bridge_transfer_id,
+                _pre_image,
+            } => atomic_bridge_initiator_complete_bridge_transfer(_bridge_transfer_id, _pre_image),
             AtomicBridgeInitiatorInitiateBridgeTransfer {
-                recipient,
-                hash_lock,
-                amount,
-            } => atomic_bridge_initiator_initiate_bridge_transfer(recipient, hash_lock, amount),
+                _recipient,
+                _hash_lock,
+                _amount,
+            } => atomic_bridge_initiator_initiate_bridge_transfer(_recipient, _hash_lock, _amount),
             AtomicBridgeCounterpartyLockBridgeTransferAssets {
-                initiator,
-                bridge_transfer_id,
-                hash_lock,
-                recipient,
-                amount,
+                _initiator,
+                _bridge_transfer_id,
+                _hash_lock,
+                _recipient,
+                _amount,
             } => atomic_bridge_counterparty_lock_bridge_transfer_assets(
-                initiator,
-                bridge_transfer_id,
-                hash_lock,
-                recipient,
-                amount,
+                _initiator,
+                _bridge_transfer_id,
+                _hash_lock,
+                _recipient,
+                _amount,
             ),
-            AtomicBridgeInitiatorRefundBridgeTransfer { bridge_transfer_id } => {
-                atomic_bridge_initiator_refund_bridge_transfer(bridge_transfer_id)
-            },
+            AtomicBridgeInitiatorRefundBridgeTransfer {
+                _bridge_transfer_id,
+            } => atomic_bridge_initiator_refund_bridge_transfer(_bridge_transfer_id),
             CodePublishPackageTxn {
                 metadata_serialized,
                 code,
@@ -1553,30 +1553,31 @@ impl EntryFunctionCall {
                 approved,
             } => multisig_account_vote_transanction(multisig_account, sequence_number, approved),
             NativeBridgeCompleteBridgeTransfer {
-                bridge_transfer_id,
-                initiator,
-                recipient,
-                amount,
-                nonce,
+                _bridge_transfer_id,
+                _initiator,
+                _recipient,
+                _amount,
+                _nonce,
             } => native_bridge_complete_bridge_transfer(
-                bridge_transfer_id,
-                initiator,
-                recipient,
-                amount,
-                nonce,
+                _bridge_transfer_id,
+                _initiator,
+                _recipient,
+                _amount,
+                _nonce,
             ),
-            NativeBridgeInitiateBridgeTransfer { recipient, amount } => {
-                native_bridge_initiate_bridge_transfer(recipient, amount)
-            },
-            NativeBridgeUpdateBridgeFee { new_bridge_fee } => {
-                native_bridge_update_bridge_fee(new_bridge_fee)
+            NativeBridgeInitiateBridgeTransfer {
+                _recipient,
+                _amount,
+            } => native_bridge_initiate_bridge_transfer(_recipient, _amount),
+            NativeBridgeUpdateBridgeFee { _new_bridge_fee } => {
+                native_bridge_update_bridge_fee(_new_bridge_fee)
             },
             NativeBridgeUpdateInsuranceBudgetDivider {
-                new_insurance_budget_divider,
-            } => native_bridge_update_insurance_budget_divider(new_insurance_budget_divider),
-            NativeBridgeUpdateInsuranceFund { new_insurance_fund } => {
-                native_bridge_update_insurance_fund(new_insurance_fund)
-            },
+                _new_insurance_budget_divider,
+            } => native_bridge_update_insurance_budget_divider(_new_insurance_budget_divider),
+            NativeBridgeUpdateInsuranceFund {
+                _new_insurance_fund,
+            } => native_bridge_update_insurance_fund(_new_insurance_fund),
             ObjectTransferCall { object, to } => object_transfer_call(object, to),
             ObjectCodeDeploymentPublish {
                 metadata_serialized,
@@ -2461,7 +2462,7 @@ pub fn aptos_governance_vote(
 /// @param bridge_transfer_id The unique identifier for the bridge transfer.
 /// @abort If the caller is not the bridge operator or if the time lock has not expired.
 pub fn atomic_bridge_counterparty_abort_bridge_transfer(
-    bridge_transfer_id: Vec<u8>,
+    _bridge_transfer_id: Vec<u8>,
 ) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
@@ -2473,14 +2474,14 @@ pub fn atomic_bridge_counterparty_abort_bridge_transfer(
         ),
         ident_str!("abort_bridge_transfer").to_owned(),
         vec![],
-        vec![bcs::to_bytes(&bridge_transfer_id).unwrap()],
+        vec![bcs::to_bytes(&_bridge_transfer_id).unwrap()],
     ))
 }
 
 /// Bridge operator can complete the transfer
 pub fn atomic_bridge_initiator_complete_bridge_transfer(
-    bridge_transfer_id: Vec<u8>,
-    pre_image: Vec<u8>,
+    _bridge_transfer_id: Vec<u8>,
+    _pre_image: Vec<u8>,
 ) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
@@ -2493,8 +2494,8 @@ pub fn atomic_bridge_initiator_complete_bridge_transfer(
         ident_str!("complete_bridge_transfer").to_owned(),
         vec![],
         vec![
-            bcs::to_bytes(&bridge_transfer_id).unwrap(),
-            bcs::to_bytes(&pre_image).unwrap(),
+            bcs::to_bytes(&_bridge_transfer_id).unwrap(),
+            bcs::to_bytes(&_pre_image).unwrap(),
         ],
     ))
 }
@@ -2503,9 +2504,9 @@ pub fn atomic_bridge_initiator_complete_bridge_transfer(
 /// Anyone can initiate a bridge transfer from the source chain
 /// The amount is burnt from the initiator
 pub fn atomic_bridge_initiator_initiate_bridge_transfer(
-    recipient: Vec<u8>,
-    hash_lock: Vec<u8>,
-    amount: u64,
+    _recipient: Vec<u8>,
+    _hash_lock: Vec<u8>,
+    _amount: u64,
 ) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
@@ -2518,9 +2519,9 @@ pub fn atomic_bridge_initiator_initiate_bridge_transfer(
         ident_str!("initiate_bridge_transfer").to_owned(),
         vec![],
         vec![
-            bcs::to_bytes(&recipient).unwrap(),
-            bcs::to_bytes(&hash_lock).unwrap(),
-            bcs::to_bytes(&amount).unwrap(),
+            bcs::to_bytes(&_recipient).unwrap(),
+            bcs::to_bytes(&_hash_lock).unwrap(),
+            bcs::to_bytes(&_amount).unwrap(),
         ],
     ))
 }
@@ -2536,11 +2537,11 @@ pub fn atomic_bridge_initiator_initiate_bridge_transfer(
 /// @param amount The amount of assets to be locked.
 /// @abort If the caller is not the bridge operator.
 pub fn atomic_bridge_counterparty_lock_bridge_transfer_assets(
-    initiator: Vec<u8>,
-    bridge_transfer_id: Vec<u8>,
-    hash_lock: Vec<u8>,
-    recipient: AccountAddress,
-    amount: u64,
+    _initiator: Vec<u8>,
+    _bridge_transfer_id: Vec<u8>,
+    _hash_lock: Vec<u8>,
+    _recipient: AccountAddress,
+    _amount: u64,
 ) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
@@ -2553,18 +2554,18 @@ pub fn atomic_bridge_counterparty_lock_bridge_transfer_assets(
         ident_str!("lock_bridge_transfer_assets").to_owned(),
         vec![],
         vec![
-            bcs::to_bytes(&initiator).unwrap(),
-            bcs::to_bytes(&bridge_transfer_id).unwrap(),
-            bcs::to_bytes(&hash_lock).unwrap(),
-            bcs::to_bytes(&recipient).unwrap(),
-            bcs::to_bytes(&amount).unwrap(),
+            bcs::to_bytes(&_initiator).unwrap(),
+            bcs::to_bytes(&_bridge_transfer_id).unwrap(),
+            bcs::to_bytes(&_hash_lock).unwrap(),
+            bcs::to_bytes(&_recipient).unwrap(),
+            bcs::to_bytes(&_amount).unwrap(),
         ],
     ))
 }
 
 /// Anyone can refund the transfer on the source chain once time lock has passed
 pub fn atomic_bridge_initiator_refund_bridge_transfer(
-    bridge_transfer_id: Vec<u8>,
+    _bridge_transfer_id: Vec<u8>,
 ) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
@@ -2576,7 +2577,7 @@ pub fn atomic_bridge_initiator_refund_bridge_transfer(
         ),
         ident_str!("refund_bridge_transfer").to_owned(),
         vec![],
-        vec![bcs::to_bytes(&bridge_transfer_id).unwrap()],
+        vec![bcs::to_bytes(&_bridge_transfer_id).unwrap()],
     ))
 }
 
@@ -3744,11 +3745,11 @@ pub fn multisig_account_vote_transanction(
 /// @param nonce The unique nonce for the transfer.    
 /// @abort If the caller is not the bridge relayer or the transfer has already been processed.
 pub fn native_bridge_complete_bridge_transfer(
-    bridge_transfer_id: Vec<u8>,
-    initiator: Vec<u8>,
-    recipient: AccountAddress,
-    amount: u64,
-    nonce: u64,
+    _bridge_transfer_id: Vec<u8>,
+    _initiator: Vec<u8>,
+    _recipient: AccountAddress,
+    _amount: u64,
+    _nonce: u64,
 ) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
@@ -3761,11 +3762,11 @@ pub fn native_bridge_complete_bridge_transfer(
         ident_str!("complete_bridge_transfer").to_owned(),
         vec![],
         vec![
-            bcs::to_bytes(&bridge_transfer_id).unwrap(),
-            bcs::to_bytes(&initiator).unwrap(),
-            bcs::to_bytes(&recipient).unwrap(),
-            bcs::to_bytes(&amount).unwrap(),
-            bcs::to_bytes(&nonce).unwrap(),
+            bcs::to_bytes(&_bridge_transfer_id).unwrap(),
+            bcs::to_bytes(&_initiator).unwrap(),
+            bcs::to_bytes(&_recipient).unwrap(),
+            bcs::to_bytes(&_amount).unwrap(),
+            bcs::to_bytes(&_nonce).unwrap(),
         ],
     ))
 }
@@ -3777,8 +3778,8 @@ pub fn native_bridge_complete_bridge_transfer(
 /// @param recipient The address of the recipient on the Aptos blockchain.  
 /// @param amount The amount of assets to be locked.
 pub fn native_bridge_initiate_bridge_transfer(
-    recipient: Vec<u8>,
-    amount: u64,
+    _recipient: Vec<u8>,
+    _amount: u64,
 ) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
@@ -3791,8 +3792,8 @@ pub fn native_bridge_initiate_bridge_transfer(
         ident_str!("initiate_bridge_transfer").to_owned(),
         vec![],
         vec![
-            bcs::to_bytes(&recipient).unwrap(),
-            bcs::to_bytes(&amount).unwrap(),
+            bcs::to_bytes(&_recipient).unwrap(),
+            bcs::to_bytes(&_amount).unwrap(),
         ],
     ))
 }
@@ -3802,7 +3803,7 @@ pub fn native_bridge_initiate_bridge_transfer(
 /// @param relayer The signer representing the Relayer.
 /// @param new_bridge_fee The new bridge fee to be set.
 /// @abort If the new bridge fee is the same as the old bridge fee.
-pub fn native_bridge_update_bridge_fee(new_bridge_fee: u64) -> TransactionPayload {
+pub fn native_bridge_update_bridge_fee(_new_bridge_fee: u64) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
             AccountAddress::new([
@@ -3813,7 +3814,7 @@ pub fn native_bridge_update_bridge_fee(new_bridge_fee: u64) -> TransactionPayloa
         ),
         ident_str!("update_bridge_fee").to_owned(),
         vec![],
-        vec![bcs::to_bytes(&new_bridge_fee).unwrap()],
+        vec![bcs::to_bytes(&_new_bridge_fee).unwrap()],
     ))
 }
 
@@ -3823,7 +3824,7 @@ pub fn native_bridge_update_bridge_fee(new_bridge_fee: u64) -> TransactionPayloa
 /// @param new_insurance_budget_divider The new insurance budget divider to be set.
 /// @abort If the new insurance budget divider is the same as the old insurance budget divider.
 pub fn native_bridge_update_insurance_budget_divider(
-    new_insurance_budget_divider: u64,
+    _new_insurance_budget_divider: u64,
 ) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
@@ -3835,7 +3836,7 @@ pub fn native_bridge_update_insurance_budget_divider(
         ),
         ident_str!("update_insurance_budget_divider").to_owned(),
         vec![],
-        vec![bcs::to_bytes(&new_insurance_budget_divider).unwrap()],
+        vec![bcs::to_bytes(&_new_insurance_budget_divider).unwrap()],
     ))
 }
 
@@ -3845,7 +3846,7 @@ pub fn native_bridge_update_insurance_budget_divider(
 /// @param new_insurance_fund The new insurance fund to be set.
 /// @abort If the new insurance fund is the same as the old insurance fund.
 pub fn native_bridge_update_insurance_fund(
-    new_insurance_fund: AccountAddress,
+    _new_insurance_fund: AccountAddress,
 ) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
@@ -3857,7 +3858,7 @@ pub fn native_bridge_update_insurance_fund(
         ),
         ident_str!("update_insurance_fund").to_owned(),
         vec![],
-        vec![bcs::to_bytes(&new_insurance_fund).unwrap()],
+        vec![bcs::to_bytes(&_new_insurance_fund).unwrap()],
     ))
 }
 
@@ -5390,7 +5391,7 @@ mod decoder {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(
                 EntryFunctionCall::AtomicBridgeCounterpartyAbortBridgeTransfer {
-                    bridge_transfer_id: bcs::from_bytes(script.args().get(0)?).ok()?,
+                    _bridge_transfer_id: bcs::from_bytes(script.args().get(0)?).ok()?,
                 },
             )
         } else {
@@ -5404,8 +5405,8 @@ mod decoder {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(
                 EntryFunctionCall::AtomicBridgeInitiatorCompleteBridgeTransfer {
-                    bridge_transfer_id: bcs::from_bytes(script.args().get(0)?).ok()?,
-                    pre_image: bcs::from_bytes(script.args().get(1)?).ok()?,
+                    _bridge_transfer_id: bcs::from_bytes(script.args().get(0)?).ok()?,
+                    _pre_image: bcs::from_bytes(script.args().get(1)?).ok()?,
                 },
             )
         } else {
@@ -5419,9 +5420,9 @@ mod decoder {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(
                 EntryFunctionCall::AtomicBridgeInitiatorInitiateBridgeTransfer {
-                    recipient: bcs::from_bytes(script.args().get(0)?).ok()?,
-                    hash_lock: bcs::from_bytes(script.args().get(1)?).ok()?,
-                    amount: bcs::from_bytes(script.args().get(2)?).ok()?,
+                    _recipient: bcs::from_bytes(script.args().get(0)?).ok()?,
+                    _hash_lock: bcs::from_bytes(script.args().get(1)?).ok()?,
+                    _amount: bcs::from_bytes(script.args().get(2)?).ok()?,
                 },
             )
         } else {
@@ -5435,11 +5436,11 @@ mod decoder {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(
                 EntryFunctionCall::AtomicBridgeCounterpartyLockBridgeTransferAssets {
-                    initiator: bcs::from_bytes(script.args().get(0)?).ok()?,
-                    bridge_transfer_id: bcs::from_bytes(script.args().get(1)?).ok()?,
-                    hash_lock: bcs::from_bytes(script.args().get(2)?).ok()?,
-                    recipient: bcs::from_bytes(script.args().get(3)?).ok()?,
-                    amount: bcs::from_bytes(script.args().get(4)?).ok()?,
+                    _initiator: bcs::from_bytes(script.args().get(0)?).ok()?,
+                    _bridge_transfer_id: bcs::from_bytes(script.args().get(1)?).ok()?,
+                    _hash_lock: bcs::from_bytes(script.args().get(2)?).ok()?,
+                    _recipient: bcs::from_bytes(script.args().get(3)?).ok()?,
+                    _amount: bcs::from_bytes(script.args().get(4)?).ok()?,
                 },
             )
         } else {
@@ -5453,7 +5454,7 @@ mod decoder {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(
                 EntryFunctionCall::AtomicBridgeInitiatorRefundBridgeTransfer {
-                    bridge_transfer_id: bcs::from_bytes(script.args().get(0)?).ok()?,
+                    _bridge_transfer_id: bcs::from_bytes(script.args().get(0)?).ok()?,
                 },
             )
         } else {
@@ -6147,11 +6148,11 @@ mod decoder {
     ) -> Option<EntryFunctionCall> {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(EntryFunctionCall::NativeBridgeCompleteBridgeTransfer {
-                bridge_transfer_id: bcs::from_bytes(script.args().get(0)?).ok()?,
-                initiator: bcs::from_bytes(script.args().get(1)?).ok()?,
-                recipient: bcs::from_bytes(script.args().get(2)?).ok()?,
-                amount: bcs::from_bytes(script.args().get(3)?).ok()?,
-                nonce: bcs::from_bytes(script.args().get(4)?).ok()?,
+                _bridge_transfer_id: bcs::from_bytes(script.args().get(0)?).ok()?,
+                _initiator: bcs::from_bytes(script.args().get(1)?).ok()?,
+                _recipient: bcs::from_bytes(script.args().get(2)?).ok()?,
+                _amount: bcs::from_bytes(script.args().get(3)?).ok()?,
+                _nonce: bcs::from_bytes(script.args().get(4)?).ok()?,
             })
         } else {
             None
@@ -6163,8 +6164,8 @@ mod decoder {
     ) -> Option<EntryFunctionCall> {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(EntryFunctionCall::NativeBridgeInitiateBridgeTransfer {
-                recipient: bcs::from_bytes(script.args().get(0)?).ok()?,
-                amount: bcs::from_bytes(script.args().get(1)?).ok()?,
+                _recipient: bcs::from_bytes(script.args().get(0)?).ok()?,
+                _amount: bcs::from_bytes(script.args().get(1)?).ok()?,
             })
         } else {
             None
@@ -6176,7 +6177,7 @@ mod decoder {
     ) -> Option<EntryFunctionCall> {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(EntryFunctionCall::NativeBridgeUpdateBridgeFee {
-                new_bridge_fee: bcs::from_bytes(script.args().get(0)?).ok()?,
+                _new_bridge_fee: bcs::from_bytes(script.args().get(0)?).ok()?,
             })
         } else {
             None
@@ -6189,7 +6190,7 @@ mod decoder {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(
                 EntryFunctionCall::NativeBridgeUpdateInsuranceBudgetDivider {
-                    new_insurance_budget_divider: bcs::from_bytes(script.args().get(0)?).ok()?,
+                    _new_insurance_budget_divider: bcs::from_bytes(script.args().get(0)?).ok()?,
                 },
             )
         } else {
@@ -6202,7 +6203,7 @@ mod decoder {
     ) -> Option<EntryFunctionCall> {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(EntryFunctionCall::NativeBridgeUpdateInsuranceFund {
-                new_insurance_fund: bcs::from_bytes(script.args().get(0)?).ok()?,
+                _new_insurance_fund: bcs::from_bytes(script.args().get(0)?).ok()?,
             })
         } else {
             None

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -113,44 +113,38 @@ impl CliCommand<()> for InitTool {
             eprintln!("Configuring for network {:?}", network);
             network
         } else {
-            eprintln!(
-                "Choose network from [devnet, testnet, local, custom | defaults to devnet]. For testnet, start over and run movement init --skip-faucet"
-            );
+            eprintln!("Choose network from [testnet, local, custom | defaults to testnet]");
             let input = read_line("network")?;
             let input = input.trim();
             if input.is_empty() {
-                eprintln!("No network given, using devnet...");
-                Network::Devnet
+                eprintln!("No network given, using testnet...");
+                Network::Testnet
             } else {
                 Network::from_str(input)?
             }
         };
-
-        if network == Network::Testnet && !self.skip_faucet {
-            return Err(CliError::CommandArgumentError(format!(
-                "For testnet, start over and run movement init --skip-faucet"
-            )));
-        }
 
         // Ensure the config contains the network used
         profile_config.network = Some(network);
 
         // Ensure that there is at least a REST URL set for the network
         match network {
-            // Network::Mainnet => {
-            //     profile_config.rest_url =
-            //         Some("https://fullnode.mainnet.aptoslabs.com".to_string());
-            //     profile_config.faucet_url = None;
-            // },
+            Network::Mainnet => {
+                profile_config.rest_url =
+                    Some("https://full.mainnet.movementinfra.xyz/v1".to_string());
+                profile_config.faucet_url = None;
+            },
             Network::Testnet => {
                 profile_config.rest_url =
-                    Some("https://aptos.testnet.suzuka.movementlabs.xyz/v1/".to_string());
+                    Some("https://full.testnet.movementinfra.xyz/v1".to_string());
                 profile_config.faucet_url =
-                    Some("https://faucet.testnet.suzuka.movementlabs.xyz/".to_string());
+                    Some("https://faucet.testnet.movementinfra.xyz/v1".to_string());
             },
             Network::Devnet => {
-                profile_config.rest_url = Some("https://aptos.devnet.inola.movementlabs.xyz/v1".to_string());
-                profile_config.faucet_url = Some("https://faucet.devnet.inola.movementlabs.xyz".to_string());
+                profile_config.rest_url =
+                    Some("https://aptos.devnet.inola.movementlabs.xyz/v1".to_string());
+                profile_config.faucet_url =
+                    Some("https://faucet.devnet.inola.movementlabs.xyz".to_string());
             },
             Network::Local => {
                 profile_config.rest_url = Some("http://localhost:8080".to_string());
@@ -334,9 +328,11 @@ impl CliCommand<()> for InitTool {
             }
         } else if account_exists {
             eprintln!("Account {} has been already found onchain", address);
-        } /* else if network == Network::Mainnet {
+        }
+        else if network == Network::Mainnet {
             eprintln!("Account {} does not exist, you will need to create and fund the account by transferring funds from another account", address);
-        } */ else {
+        }
+        else {
             eprintln!("Account {} has been initialized locally, but you must transfer coins to it to create the account onchain", address);
         }
 
@@ -355,9 +351,7 @@ impl CliCommand<()> for InitTool {
             .profile_name()
             .unwrap_or(DEFAULT_PROFILE);
         eprintln!(
-            "\n---\nMovement CLI is now set up for account {} as profile {}!\n See the account here: {}\n 
-            Run `movement --help` for more information about commands. \n 
-            Visit https://faucet.movementlabs.xyz to use the testnet faucet.",
+            "\n---\nMovement CLI is now set up for account {} as profile {}!\n See the account here: {}\n Run `movement --help` for more information about commands",
             address,
             profile_name,
             explorer_account_link(address, Some(network))
@@ -448,7 +442,7 @@ impl InitTool {
 /// Any command using this, will be simpler to setup as profiles
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum Network {
-    // Mainnet,
+    Mainnet,
     Testnet,
     Devnet,
     Local,
@@ -457,13 +451,17 @@ pub enum Network {
 
 impl Display for Network {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", match self {
-            // Network::Mainnet => "mainnet",
-            Network::Testnet => "testnet",
-            Network::Devnet => "devnet",
-            Network::Local => "local",
-            Network::Custom => "custom",
-        })
+        write!(
+            f,
+            "{}",
+            match self {
+                Network::Mainnet => "mainnet",
+                Network::Testnet => "bardock+testnet",
+                Network::Devnet => "devnet",
+                Network::Local => "local",
+                Network::Custom => "custom",
+            }
+        )
     }
 }
 
@@ -472,14 +470,14 @@ impl FromStr for Network {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s.to_lowercase().trim() {
-            // "mainnet" => Self::Mainnet,
+            "mainnet" => Self::Mainnet,
             "testnet" => Self::Testnet,
             "devnet" => Self::Devnet,
             "local" => Self::Local,
             "custom" => Self::Custom,
             str => {
                 return Err(CliError::CommandArgumentError(format!(
-                    "Invalid network {}.  Must be one of [devnet, testnet, local, custom]",
+                    "Invalid network {}.  Must be one of [testnet, local, custom]",
                     str
                 )));
             },
@@ -489,6 +487,6 @@ impl FromStr for Network {
 
 impl Default for Network {
     fn default() -> Self {
-        Self::Devnet
+        Self::Testnet
     }
 }

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -351,7 +351,8 @@ impl CliCommand<()> for InitTool {
             .profile_name()
             .unwrap_or(DEFAULT_PROFILE);
         eprintln!(
-            "\n---\nMovement CLI is now set up for account {} as profile {}!\n See the account here: {}\n Run `movement --help` for more information about commands",
+            "\n---\nMovement CLI is now set up for account {} as profile {}!\n See the account here: {}\n 
+            Run `movement --help` for more information about commands.",
             address,
             profile_name,
             explorer_account_link(address, Some(network))

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -113,7 +113,7 @@ impl CliCommand<()> for InitTool {
             eprintln!("Configuring for network {:?}", network);
             network
         } else {
-            eprintln!("Choose network from [testnet, local, custom | defaults to testnet]");
+            eprintln!("Choose network from [devnet, testnet, local, custom | defaults to testnet]");
             let input = read_line("network")?;
             let input = input.trim();
             if input.is_empty() {

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -138,13 +138,13 @@ impl CliCommand<()> for InitTool {
                 profile_config.rest_url =
                     Some("https://full.testnet.movementinfra.xyz/v1".to_string());
                 profile_config.faucet_url =
-                    Some("https://faucet.testnet.movementinfra.xyz/v1".to_string());
+                    Some("https://faucet.testnet.movementinfra.xyz".to_string());
             },
             Network::Devnet => {
                 profile_config.rest_url =
-                    Some("https://aptos.devnet.inola.movementlabs.xyz/v1".to_string());
+                    Some("https://full.devnet.movementinfra.xyz/v1".to_string());
                 profile_config.faucet_url =
-                    Some("https://faucet.devnet.inola.movementlabs.xyz".to_string());
+                    Some("https://faucet.devnet.movementinfra.xyz".to_string());
             },
             Network::Local => {
                 profile_config.rest_url = Some("http://localhost:8080".to_string());
@@ -328,11 +328,9 @@ impl CliCommand<()> for InitTool {
             }
         } else if account_exists {
             eprintln!("Account {} has been already found onchain", address);
-        }
-        else if network == Network::Mainnet {
+        } else if network == Network::Mainnet {
             eprintln!("Account {} does not exist, you will need to create and fund the account by transferring funds from another account", address);
-        }
-        else {
+        } else {
             eprintln!("Account {} has been initialized locally, but you must transfer coins to it to create the account onchain", address);
         }
 
@@ -452,17 +450,13 @@ pub enum Network {
 
 impl Display for Network {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Network::Mainnet => "mainnet",
-                Network::Testnet => "bardock+testnet",
-                Network::Devnet => "devnet",
-                Network::Local => "local",
-                Network::Custom => "custom",
-            }
-        )
+        write!(f, "{}", match self {
+            Network::Mainnet => "mainnet",
+            Network::Testnet => "bardock+testnet",
+            Network::Devnet => "devnet",
+            Network::Local => "local",
+            Network::Custom => "custom",
+        })
     }
 }
 
@@ -478,7 +472,7 @@ impl FromStr for Network {
             "custom" => Self::Custom,
             str => {
                 return Err(CliError::CommandArgumentError(format!(
-                    "Invalid network {}.  Must be one of [testnet, local, custom]",
+                    "Invalid network {}.  Must be one of [testnet, devnet, local, custom]",
                     str
                 )));
             },

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -571,11 +571,11 @@ pub fn explorer_account_link(hash: AccountAddress, network: Option<Network>) -> 
     // For now, default to what the browser is already on, though the link could be wrong
     if let Some(network) = network {
         format!(
-            "https://explorer.movementlabs.xyz/account/{}?network={}",
+            "https://explorer.movementnetwork.xyz/account/{}?network={}",
             hash, network
         )
     } else {
-        format!("https://explorer.movementlabs.xyz/account/{}", hash)
+        format!("https://explorer.movementnetwork.xyz/account/{}", hash)
     }
 }
 


### PR DESCRIPTION
## Description
Per devrel request, update Movement CLI network endpoints and ensure faucet works with testnet on `movement init`.

Changes:
- Update testnet endpoint and enable mainnet for `movement init`.
- Enable faucet for testnet on `movement init`.
- Update explorer endpoints.
- Update some atomic bridge and native bridge docs and SDK that hadn't been updated after disabling those modules.
- Add ignoring `config.yaml` files to `.gitingore` because I noticed on `git add .` my `config.yaml` file was added.
- Make CLI default to `testnet`. (Init with devnet also works.)

## Type of Change
- [ ] New feature
- [ x] Bug fix
- [ ] Breaking change
- [ x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
To test, run:
`cargo build -p movement`
then
`./target/debug/movement init`
and play with the different options.
- Testnet account should be quickly init and funded, and explorer link should work.
- Mainnet account should be init and not funded; explorer link should still work.

## Key Areas to Review

## Checklist
- [ x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ x] I tested both happy and unhappy path of the functionality
- [ x] I have made corresponding changes to the documentation

## Outstanding Issues

- `local` option still fails due to https://github.com/movementlabsxyz/aptos-core/issues/174 but this should still be good to ship, for the improvements with `testnet` and `devnet`.
- Need to figure out a better release pipeline than me manually building and releasing at https://github.com/movementlabsxyz/homebrew-movement-cli/releases/tag/bypass-homebrew
