### PR TITLE
feat: features reconfiguration script

### DIFF
--- a/movement-migration/framework-upgrades/Move.toml
+++ b/movement-migration/framework-upgrades/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "feature-flag-reconfig"
+version = "0.0.0"
+
+[addresses]
+admin = "0x1"
+
+[dependencies.AptosFramework]
+git = "https://github.com/movementlabsxyz/aptos-core.git"
+rev = "movement"
+subdir = "aptos-move/framework/aptos-framework"

--- a/movement-migration/framework-upgrades/scripts/feature-flag-reconfig.move
+++ b/movement-migration/framework-upgrades/scripts/feature-flag-reconfig.move
@@ -1,0 +1,32 @@
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::signer;
+    use std::features;
+    use std::vector;
+
+    fun main(core_resources: &signer) {
+        let core_signer = aptos_governance::get_signer_testnet_only(
+            core_resources,
+            @0000000000000000000000000000000000000000000000000000000000000001
+        );
+        //let core_address: address = signer::address_of(core_resources);
+
+        let enabled_blob: vector<u64> = vector[
+            58, // RejectUnstableBytecode
+            67, // ConcurrentFungibleBalance
+            40, // VMBinaryFormat7
+            74, // EnumTypes
+        ];
+
+        let disabled_blob: vector<u64> = vector[
+            48, // RemoveDetailedError
+            16, // PeriodicalRewardRateReduction
+            46, // KeylessAccouns
+            47, // KeylessButZklessAccounts
+            54, // KeylessAccountsWithPasskeys
+            73, // GovernedGasPool
+        ];
+
+        features::change_feature_flags(&core_signer, enabled_blob, disabled_blob);
+    }
+}

--- a/movement-migration/framework-upgrades/scripts/feature-flag-reconfig.move
+++ b/movement-migration/framework-upgrades/scripts/feature-flag-reconfig.move
@@ -24,6 +24,8 @@ script {
             46, // KeylessAccouns
             47, // KeylessButZklessAccounts
             54, // KeylessAccountsWithPasskeys
+            71, // AtomicBridge
+            72, // NativeBridge
             73, // GovernedGasPool
         ];
 

--- a/movement-migration/framework-upgrades/sources/placeholder.move
+++ b/movement-migration/framework-upgrades/sources/placeholder.move
@@ -1,0 +1,1 @@
+module admin::placeholder_for_compiling {}


### PR DESCRIPTION
## Description
- Reviewers should test against local mainnet state. Sebs EC2 instance did not have a port exposed so I went with the mainnet mirror. Which now has the feature reconfig applied.

Note that the feature `CALCULATE_TRANSACTION_FEE_FOR_DISTRIBUTION = 96` can only be enabled after Move2 upgrade. Hence why it is not enabled here (it is not available on `movement-migration` framework)

- See the script `feature-flag-reconfig.move` for what features are being enabled and disabled.

Note that after Move2 upgrade, further features to be enabled which are only available after the upgrade.

1. Compile the feature flag upgrade script
```
movement move compile --package-dir movement-migration/framework-upgrades --bytecode-version 6
```
2.Run the script 
```
movement move run-script --compiled-script-path movement-migration/framework-upgrades/build/feature-flag-reconfig/bytecode_scripts/main.mv
```
Should receive success output. 

Mainnet Mirror tx
```
Do you want to submit a transaction for a range of [11200 - 16800] Octas at a gas unit price of 100 Octas? [yes/no] >
y
Transaction submitted: https://explorer.movementlabs.xyz/txn/0x7a92eff1e1e973e881a046aaebaa72e42a1f6a1daaa3bec45167657c8d8c67ad?network=custom
{
  "Result": {
    "transaction_hash": "0x7a92eff1e1e973e881a046aaebaa72e42a1f6a1daaa3bec45167657c8d8c67ad",
    "gas_used": 112,
    "gas_unit_price": 100,
    "sender": "000000000000000000000000000000000000000000000000000000000a550c18",
    "sequence_number": 12966,
    "success": true,
    "timestamp_us": 1759411858121293,
    "version": 28646125,
    "vm_status": "Executed successfully"
  }
}
```