### PR TITLE
[network] onchain discovery tool

### DIFF
--- a/tools/l1-migration/Cargo.toml
+++ b/tools/l1-migration/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = { workspace = true }
 
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 aptos-config = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-db = { workspace = true }
@@ -21,4 +21,4 @@ aptos-types = { workspace = true }
 bcs = { workspace = true }
 clap = { workspace = true }
 serde_yaml = { workspace = true }
-hex = "0.4"
+hex = { workspace = true }

--- a/tools/l1-migration/src/main.rs
+++ b/tools/l1-migration/src/main.rs
@@ -1,6 +1,9 @@
 use anyhow::Result;
 use clap::Parser;
-use l1_migration::extract_genesis_and_waypoint;
+use l1_migration::{
+    extract_genesis_and_waypoint,
+    utils::{decode_network_address, encode_network_address},
+};
 use std::path::PathBuf;
 
 /// L1 Migration Tool - Extract genesis and waypoint from database
@@ -21,6 +24,32 @@ enum Commands {
         db_path: PathBuf,
         /// Destination directory for extracted files
         destination_path: PathBuf,
+    },
+    /// Network address encoding/decoding tool
+    #[command(about = "Convert between multiaddr strings and BCS hex format")]
+    NetworkAddress {
+        #[command(subcommand)]
+        command: NetworkAddressCommands,
+    },
+}
+
+#[derive(Parser)]
+enum NetworkAddressCommands {
+    /// Encode multiaddr string to BCS hex
+    Encode {
+        /// Multiaddr string to encode to BCS hex format
+        ///
+        /// Example: /dns/validator.example.com/tcp/6180/noise-ik/a1b2c3d4e5f67890abcdef1234567890abcdef1234567890abcdef1234567890/handshake/1
+        #[arg(help = "Multiaddr string to encode to BCS hex format")]
+        multiaddr: String,
+    },
+    /// Decode BCS hex to multiaddr string
+    Decode {
+        /// BCS hex string to decode to multiaddr format
+        ///
+        /// Example: 0x013f04021576616c696461746f722e6578616d706c652e636f6d0524180720a1b2c3d4e5f67890abcdef1234567890abcdef1234567890abcdef12345678900801
+        #[arg(help = "BCS hex string to decode to multiaddr format")]
+        hex: String,
     },
 }
 
@@ -51,6 +80,10 @@ fn main() -> Result<()> {
             let destination_path_str = destination_path.to_string_lossy();
 
             extract_genesis_and_waypoint(&db_path_str, &destination_path_str)
+        },
+        Commands::NetworkAddress { command } => match command {
+            NetworkAddressCommands::Encode { multiaddr } => encode_network_address(&multiaddr),
+            NetworkAddressCommands::Decode { hex } => decode_network_address(&hex),
         },
     }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This change implements a tool that can decodes a node address into BCS format and validator can update their onchain address to make them discoverable. 

* Top level

```
adhoc command for l1 migration

Usage: l1-migration <COMMAND>

Commands:
  generate-waypoint-genesis  Generate waypoint and genesis files from database
  network-address            Convert between multiaddr strings and BCS hex format
  help                       Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```

* Network address command 

```
Convert between multiaddr strings and BCS hex format

Usage: l1-migration network-address <COMMAND>

Commands:
  encode  Encode multiaddr string to BCS hex
  decode  Decode BCS hex to multiaddr string
  help    Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help

```

* Encode

```
./l1-migration network-address encode --help
Encode multiaddr string to BCS hex

Usage: l1-migration network-address encode <MULTIADDR>

Arguments:
  <MULTIADDR>
          Multiaddr string to encode to BCS hex format

          Example: /dns/validator.example.com/tcp/6180/noise-ik/a1b2c3d4e5f67890abcdef1234567890abcdef1234567890abcdef1234567890/handshake/1

Options:
  -h, --help
          Print help (see a summary with '-h')
```

* Decode


```
./l1-migration network-address decode --help
Decode BCS hex to multiaddr string

Usage: l1-migration network-address decode <HEX>

Arguments:
  <HEX>
          BCS hex string to decode to multiaddr format

          Example:
          0x013f04021576616c696461746f722e6578616d706c652e636f6d0524180720a1b2c3d4e5f67890abcdef1234567890abcdef1234567890abcdef12345678900801

Options:
  -h, --help
          Print help (see a summary with '-h')
```

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Other (specify) tools

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Testnet address is updated onchain. everything looks good.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
