### PR TITLE
How to activate the staking

### DIFF
--- a/aptos-move/move-examples/scripts/update_reconfiguration/sources/change_epoch_duration.move
+++ b/aptos-move/move-examples/scripts/update_reconfiguration/sources/change_epoch_duration.move
@@ -2,8 +2,9 @@ script {
     use aptos_framework::aptos_governance;
     use aptos_framework::block;
 
-    fun main(core_resources: &signer) {
+    // for new_epoch_duration 200_000_000 indicate 200secs.
+    fun change_epoch_duration(core_resources: &signer, new_epoch_duration: u64) {
         let core_signer = aptos_governance::get_signer_testnet_only(core_resources, @0000000000000000000000000000000000000000000000000000000000000001);
-        block::update_epoch_interval_microsecs(&core_signer, 200_000_000); // 200 secs
+        block::update_epoch_interval_microsecs(&core_signer, new_epoch_duration);
     }
 }

--- a/aptos-move/move-examples/scripts/update_reconfiguration/sources/initialize_governed_gas_pool_extension.move
+++ b/aptos-move/move-examples/scripts/update_reconfiguration/sources/initialize_governed_gas_pool_extension.move
@@ -1,0 +1,9 @@
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::governed_gas_pool;
+
+    fun initialize_governed_gas_pool_extension(core_resources: &signer) {
+        let core_signer = aptos_governance::get_signer_testnet_only(core_resources, @0000000000000000000000000000000000000000000000000000000000000001);
+        governed_gas_pool::initialize_governed_gas_pool_extension(&core_signer);
+    }
+}

--- a/aptos-move/move-examples/scripts/update_reconfiguration/sources/update_rewards_rate.move
+++ b/aptos-move/move-examples/scripts/update_reconfiguration/sources/update_rewards_rate.move
@@ -1,0 +1,13 @@
+script {
+    use aptos_framework::staking_config;
+    use aptos_framework::aptos_governance;
+
+    /// Update the reward rate. Reward rate must be >0 to start getting rewards.
+    /// Example of values: new_rewards_rate :15981 new_rewards_rate_denominator: 1000000000
+    fun update_rewards_rate(core_resources: &signer, new_rewards_rate: u64, new_rewards_rate_denominator: u64) {
+        let core_signer = aptos_governance::get_signer_testnet_only(core_resources, @0000000000000000000000000000000000000000000000000000000000000001);
+        staking_config::update_rewards_rate(&core_signer, new_rewards_rate, new_rewards_rate_denominator);
+
+        aptos_governance::reconfigure(&core_signer);
+    }
+}


### PR DESCRIPTION
## Description
This PR adds/updates some scripts and describes how to activate staking from a node loaded with the Movement DB.

If one or several steps have already been applied to your node, skip them.

The staking activation procedure is:
It uses the Aptos CLI built from the l1-migration branch. It is accessible in the Path.
The commands are executed in the root directory of the repo.
The default profile has been configured with the core resource signer.
The validator profile has been configured with the validator node identity.

### 1 Update features
Build and execute the feature update script.

```
aptos move compile --package-dir movement-migration/framework-upgrades --bytecode-version 6
aptos run-script --compiled-script-path movement-migration/framework-upgrades/build/feature-flag-reconfig/bytecode_scripts/main.mv
```
### 2 Update the framework
- Regenerate the update script

```
cargo run --profile performance -p aptos-release-builder -- generate-proposals --release-config aptos-move/aptos-release-builder/data/release.yaml --output-dir proposals
```
Change all script with main function signature and framework_signer var with the code:
```
    fun main(core_resources: &signer){
        let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @0x1);
```
The default generated code is wrong. For the 3 and 4 script set the address to @0x3 and @0x4.

- Execute all update scripts in the right order, from 0 to 4
Replace the vX.XX with the version generated.

```
aptos move run-script --script-path proposals/sources/vX.XX/step_1_upgrade_framework/0-move-stdlib.move  --bytecode-version 6 --sender-account 0xa550c18 --framework-local-dir aptos-move/framework/aptos-framework
aptos move run-script --script-path proposals/sources/vX.XX/step_1_upgrade_framework/1-aptos-stdlib.move  --bytecode-version 6 --sender-account 0xa550c18 --framework-local-dir aptos-move/framework/aptos-framework
aptos move run-script --script-path proposals/sources/vX.XX/step_1_upgrade_framework/2-aptos-framework.move  --bytecode-version 6 --sender-account 0xa550c18 --framework-local-dir aptos-move/framework/aptos-framework
aptos move run-script --script-path proposals/sources/vX.XX/step_1_upgrade_framework/3-aptos-token.move  --bytecode-version 6 --sender-account 0xa550c18 --framework-local-dir aptos-move/framework/aptos-framework
aptos move run-script --script-path proposals/sources/vX.XX/step_1_upgrade_framework/4-aptos-token-objects.move  --bytecode-version 6 --sender-account 0xa550c18 --framework-local-dir aptos-move/framework/aptos-framework
```
### 3 Activate Epoch and update its duration
- Get the current epoch with 
CURRENT_EPOCH= $( curl http://localhost:8080/v1 )

- Get current TS:

```
python3 - <<'PY'
import time
print(time.time_ns() // 1_000) # microseconds since epoch
PY
```
- Build all scripts

```
aptos move compile --package-dir aptos-move/move-examples/scripts/update_reconfiguration --bytecode-version 6
```
With the move2 framework upgrade just done, the `--bytecode-version 6` parameter shouldn't be necessary. I didn't test.

- Initiate epoch

```
aptos move run-script --compiled-script-path aptos-move/move-examples/scripts/update_reconfiguration/build/UpdateReconfiguration/bytecode_scripts/update_epoch.mv --args u64:$CURRENT_EPOCH u64:$TS
```

- Update epoch duration
Example for 200 seconds.

```
aptos move run-script --compiled-script-path aptos-move/move-examples/scripts/update_reconfiguration/build/UpdateReconfiguration/bytecode_scripts/main.mv --args u64:200000000
```
After this Tx execution, the epoch should change every 200s.

### Activate staking
- Build all scripts if not done.

```
aptos move compile --package-dir aptos-move/move-examples/scripts/update_reconfiguration --bytecode-version 6
```

- Initiate GGP staking

```
aptos move run-script --compiled-script-path aptos-move/move-examples/scripts/update_reconfiguration/build/UpdateReconfiguration/bytecode_scripts/initialize_governed_gas_pool_extension.mv
```

- Deposit treasury to the pool.
The profile `treasury-owner` should be init with the account that will fill the staking treasury.
TREASURY_AMOUNT contains the amount of treasury to deposit in the GGP.
```
aptos move run --function-id 0x1::governed_gas_pool::deposit_treasury --args u64:$TREASURY_AMOUNT --profile treasury-owner
```

- Update reward rate
This is an example with the values of the Aptos  mainnet 

```
aptos move run-script --compiled-script-path aptos-move/move-examples/scripts/update_reconfiguration/build/UpdateReconfiguration/bytecode_scripts/update_rewards_rate.mv --args u64:15981 u64:1000000000
```
After this Tx execution, the registered validators should receive rewards.

### Some utilities function to verify.
- Inspect framework resource used by the staking.

Verify the staking config:
```
curl -sS "http://localhost:8080/v1/accounts/0x1/resource/0x1::staking_config::StakingConfig"
```
Set declared validators:
```
curl -sS "http://localhost:8080/v1/accounts/0x1/resource/0x1::stake::ValidatorSet" | jq
```
See reward config
```
curl -sS "http://localhost:8080/v1/accounts/0x1/resource/0x1::stake::StakingRewardsConfig" | jq
```
See if the GGP initialization has been done correctly
``` 
curl -sS "http://localhost:8080/v1/accounts/0x1/resource/0x1::governed_gas_pool::GovernedGasPoolExtension" | jq
```
Treasury balance
```
aptos move view --function-id 0x1::governed_gas_pool::get_balance --type-args 0x1::aptos_coin::AptosCoin
```
- Command related to the validator. 

Get the validator stake pool.
```
curl -sS "http://localhost:8080/v1/accounts/<Validator pool address>/resource/0x1::stake::StakePool"  | jq
```
or
```
aptos node get-stake-pool --owner-address <Validator pool address>
```
Get rewards distribution events:
```
curl -sS "http://localhost:8080/v1/accounts/<Validator pool address>/events/0x1::stake::StakePool/distribute_rewards_events"  | jq
```
Get validator stake configuration
```
curl -sS "http://localhost:8080/v1/accounts/<Validator pool address>/resource/0x1::stake::ValidatorConfig"  | jq
```
Add stake
```
.aptos/bin/movement stake add-stake --amount 40000000 --profile operator
```
Withdraw stake
```
.aptos/bin/movement stake withdraw-stake --amount 40000000 --profile owner
```


