### PR TITLE
Add 10% APR stake test

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -3249,5 +3249,81 @@ module aptos_framework::stake {
         let (numerator, denominator) = staking_config::get_reward_rate(&staking_config::get());
         amount + amount * numerator / denominator
     }
+    
+    // Test with 10% annual reward rate to demonstrate how to calculate the reward rate from the annual APR.
+    // Use 3 validators with 50% 30% and 20% each of the stacking.
+    // Reward per epoch should gives 10% of the staking after one year.
+    // So the reward rate is:
+    // Reward_rate = (annual_rate_in_percent / 100) * (epoch_duration / num_sec_per_year) * denomonator
+    // For our test of 10%: denominator = 100000000, annual rate: 10/100, epoch_duration = 7200, 2 hours => number of epochs per year = 4380
+    // reward_rate = 10 * denominator / (100 * 4380) = 2283 and denominator = 100000000
+    #[test(
+        aptos_framework = @aptos_framework,
+        validator_1 = @aptos_framework,
+        validator_2 = @0x2,
+        validator_3 = @0x3,
+    )]
+    public entry fun test_reward_rate_with_validator(
+        aptos_framework: &signer,
+        validator_1: &signer,
+        validator_2: &signer,
+        validator_3: &signer,
+    ) acquires AllowedValidators, AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet {
+        let v1_addr = signer::address_of(validator_1);
+        let v2_addr = signer::address_of(validator_2);
+        let v3_addr = signer::address_of(validator_3);
 
+        //initialize_for_test(aptos_framework);
+        // Reward rate = 10%.
+        initialize_for_test_custom(aptos_framework, 50, 10000000, LOCKUP_CYCLE_SECONDS, true, 2283, 100000000, 100);
+
+        let (_sk_1, pk_1, pop_1) = generate_identity();
+        let (_sk_2, pk_2, pop_2) = generate_identity();
+        let (_sk_3, pk_3, pop_3) = generate_identity();
+
+        initialize_test_validator(&pk_1, &pop_1, validator_1, 500000, true, false);
+        initialize_test_validator(&pk_2, &pop_2, validator_2, 300000, true, false);
+        initialize_test_validator(&pk_3, &pop_3, validator_3, 200000, true, true);
+
+        let stake_pool = borrow_global<StakePool>(v1_addr);
+        let actual_active_stake = coin::value(&stake_pool.active);
+        std::debug::print(&actual_active_stake);
+        let stake_pool = borrow_global<StakePool>(v2_addr);
+        let actual_active_stake = coin::value(&stake_pool.active);
+        std::debug::print(&actual_active_stake);
+        let stake_pool = borrow_global<StakePool>(v3_addr);
+        let actual_active_stake = coin::value(&stake_pool.active);
+        std::debug::print(&actual_active_stake);
+
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_epoch();
+
+        let stake_pool = borrow_global<StakePool>(v1_addr);
+        let actual_active_stake = coin::value(&stake_pool.active);
+        assert!(actual_active_stake == 500011, 1); // +11 for one epoch.
+
+        let stake_pool = borrow_global<StakePool>(v2_addr);
+        let actual_active_stake = coin::value(&stake_pool.active);
+        assert!(actual_active_stake == 300006, 2); // +6 for one epoch.
+
+        let stake_pool = borrow_global<StakePool>(v3_addr);
+        let actual_active_stake = coin::value(&stake_pool.active);
+        assert!(actual_active_stake == 200004, 3); // +4 for one epoch.
+
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_epoch();
+
+        let stake_pool = borrow_global<StakePool>(v1_addr);
+        let actual_active_stake = coin::value(&stake_pool.active);
+        assert!(actual_active_stake == 500022, 4); // +22 for two epoch.
+
+        let stake_pool = borrow_global<StakePool>(v2_addr);
+        let actual_active_stake = coin::value(&stake_pool.active);
+        assert!(actual_active_stake == 300012, 5); // +12 for two epoch.
+
+        let stake_pool = borrow_global<StakePool>(v3_addr);
+        let actual_active_stake = coin::value(&stake_pool.active);
+        assert!(actual_active_stake == 200008, 8); // +8 for two epoch.
+
+    }
 }

--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -3253,10 +3253,13 @@ module aptos_framework::stake {
     // Test with 10% annual reward rate to demonstrate how to calculate the reward rate from the annual APR.
     // Use 3 validators with 50% 30% and 20% each of the stacking.
     // Reward per epoch should gives 10% of the staking after one year.
-    // So the reward rate is:
-    // Reward_rate = (annual_rate_in_percent / 100) * (epoch_duration / num_sec_per_year) * denomonator
+    // With S: initial staking, R: reward rate, N; nb epoch per year, the staking after one year equation is:
+    // S + S*10% = S(1+R)^N
+    // So to have 10% reward rate, R = (1+10%)^(1/N) -1
+    // On the validator Reward_rate = R * Denominator.
     // For our test of 10%: denominator = 100000000, annual rate: 10/100, epoch_duration = 7200, 2 hours => number of epochs per year = 4380
-    // reward_rate = 10 * denominator / (100 * 4380) = 2283 and denominator = 100000000
+    // R = 1.1^(1/4380)-1 = 0,000021761 and denominator = 100000000
+    // => Reward_rate =  0,000021761 * 100000000 = 2176
     #[test(
         aptos_framework = @aptos_framework,
         validator_1 = @aptos_framework,
@@ -3275,7 +3278,7 @@ module aptos_framework::stake {
 
         //initialize_for_test(aptos_framework);
         // Reward rate = 10%.
-        initialize_for_test_custom(aptos_framework, 50, 10000000, LOCKUP_CYCLE_SECONDS, true, 2283, 100000000, 100);
+        initialize_for_test_custom(aptos_framework, 50, 10000000, LOCKUP_CYCLE_SECONDS, true, 2176, 100000000, 100);
 
         let (_sk_1, pk_1, pop_1) = generate_identity();
         let (_sk_2, pk_2, pop_2) = generate_identity();

--- a/movement-migration/post-move2-upgrade/scripts/after-move2-upgrade.move
+++ b/movement-migration/post-move2-upgrade/scripts/after-move2-upgrade.move
@@ -22,14 +22,14 @@ script {
         // Formula: rewards_amount = stake * (rewards_rate / rewards_rate_denominator) * (successful_proposals / total_proposals)
         //
         // For 10% APY with 2-hour epochs (4,380 epochs per year):
-        // Per-epoch rate = (1.10)^(1/4380) - 1 ≈ 0.0000217 or 0.00217%
+        // Per-epoch rate = (1.10)^(1/4380) - 1 ≈ 0,000021761
         //
-        // Using high precision: 22 / 1,000,000 = 0.0022% per epoch
+        // Using high precision: Reward_rate = 0,000021761 / 100_000_000 = 2176 per epoch
         // This compounds to approximately 10% APY over 4,380 epochs
         // For 2-hour epochs (4,380 per year) targeting 10% APY:
         // Check if the new periodical_reward_rate_decrease feature is enabled
         assert!(!features::periodical_reward_rate_decrease_enabled());
-        staking_config::update_rewards_rate(&core_signer, 22, 1_000_000);
+        staking_config::update_rewards_rate(&core_signer, 2176, 100_000_000);
 
         aptos_governance::force_end_epoch(&core_signer);
     }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Add a test to demonstrate how to calculate the rewaed_rate and the denominator for a specific APR, here 10%.

To test run:
```
movement move test -f test_reward_rate_with_validator
```

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [X] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [X] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
