### PR TITLE
fix: use relative links in README instead of absolute GitHub URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ Aptos is a layer 1 blockchain bringing a paradigm shift to Web3 through better t
 
 ## Contributing
 
-You can learn more about contributing to the Aptos project by reading our [Contribution Guide](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) and by viewing our [Code of Conduct](https://github.com/aptos-labs/aptos-core/blob/main/CODE_OF_CONDUCT.md).
+You can learn more about contributing to the Aptos project by reading our [Contribution Guide](CONTRIBUTING.md) and by viewing our [Code of Conduct](CODE_OF_CONDUCT.md).
 
-Aptos Core is licensed under [Apache 2.0](https://github.com/aptos-labs/aptos-core/blob/main/LICENSE).
+Aptos Core is licensed under [Apache 2.0](LICENSE).


### PR DESCRIPTION
Update CONTRIBUTING.md, CODE_OF_CONDUCT.md, and LICENSE links to use relative paths instead of absolute GitHub URLs for better local repository navigation.

## Type of Change
- [x] Documentation update

