### PR TITLE
Render newline and quotation mark chars in Movement CLI output

### DIFF
--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -119,6 +119,8 @@ pub async fn to_common_result<T: Serialize>(
     let is_err = result.is_err();
     let result = ResultWrapper::<T>::from(result);
     let string = serde_json::to_string_pretty(&result).unwrap();
+    // Unescape newlines so they render properly in terminal output
+    let string = string.replace("\\n", "\n");
     if is_err {
         Err(string)
     } else {

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -120,10 +120,10 @@ pub async fn to_common_result<T: Serialize>(
     let is_err = result.is_err();
     let result = ResultWrapper::<T>::from(result);
     let string = serde_json::to_string_pretty(&result).unwrap();
-    // Unescape newlines so they render properly in terminal output
+    // Unescape newlines and quotes so they render properly in terminal output
     // Both Ok and Err are printed to stdout in main.rs
     let string = if std::io::stdout().is_terminal() {
-        string.replace("\\n", "\n")
+        string.replace("\\n", "\n").replace("\\\"", "\"")
     } else {
         string
     };

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -28,6 +28,7 @@ use aptos_types::{
     transaction::{authenticator::AuthenticationKey, TransactionPayload},
 };
 use itertools::Itertools;
+use std::io::IsTerminal;
 use move_core_types::{account_address::AccountAddress, language_storage::CORE_CODE_ADDRESS};
 use reqwest::Url;
 use serde::{ser::Error, Deserialize, Deserializer, Serialize, Serializer};
@@ -120,7 +121,12 @@ pub async fn to_common_result<T: Serialize>(
     let result = ResultWrapper::<T>::from(result);
     let string = serde_json::to_string_pretty(&result).unwrap();
     // Unescape newlines so they render properly in terminal output
-    let string = string.replace("\\n", "\n");
+    // Both Ok and Err are printed to stdout in main.rs
+    let string = if std::io::stdout().is_terminal() {
+        string.replace("\\n", "\n")
+    } else {
+        string
+    };
     if is_err {
         Err(string)
     } else {


### PR DESCRIPTION
## Description

In Movement CLI output, instead of a literal `\n`, render a newline, eg
```
{
  "Error": "Unexpected error: Failed to run tests: Unresolved addresses found: [\nNamed address 'mock' 
in package 'mock-tokens'\n]\nTo fix this, add an entry for each unresolved address to the [addresses] 
section of /Users/primata/movement/protocol-units/tokens/mock/testnet/suzuka/aptos/Move.toml: 
e.g.,\n[addresses]\nstd = \"0x1\"\nAlternatively, you can also define [dev-addresses] and call with the
 --dev flag"
} 
```

becomes 

```
  {
    "Error": "Unexpected error: Failed to run tests: Unresolved addresses found: [
  Named address 'mock' in package 'mock-tokens'
  ]
  To fix this, add an entry for each unresolved address to the [addresses] section of /Users/primata/movement/protocol-units/tokens/mock/testnet/suzuka/aptos/Move.toml: e.g.,
  [addresses]
  std = "0x1"
  Alternatively, you can also define [dev-addresses] and call with the --dev flag"
  }
  ```

## Type of Change
- [ x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
- manual testing
- CI passes
- can test by building `movement` with cargo build --release -p movement` and using the resulting binary to build a package and see the error output formatted. 

## Key Areas to Review

## Checklist
- [ x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
