### PR TITLE
Add Movement CLI release workflow

### DIFF
--- a/.github/actions/cli-rust-setup/action.yaml
+++ b/.github/actions/cli-rust-setup/action.yaml
@@ -1,0 +1,37 @@
+name: "CLI Rust Setup"
+description: "Setup the rust toolchain and cache for the CLI build"
+inputs:
+  GIT_CREDENTIALS:
+    description: "Optional credentials to pass to git"
+    required: false
+  ADDITIONAL_KEY:
+    description: "An optional additional key to pass to rust-cache"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - uses: dsherret/rust-toolchain-file@v1
+    # rust-cache action will cache ~/.cargo and ./target
+    # https://github.com/Swatinem/rust-cache#cache-details
+    - name: Run cargo cache
+      uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # pin@v2.7.8
+      with:
+        key: ${{ inputs.ADDITIONAL_KEY }}
+    - name: Install build tools
+      shell: bash
+      run: scripts/cli/minimal_cli_build.sh
+    - run: echo "/home/runner/.cargo/bin" | tee -a $GITHUB_PATH
+      shell: bash
+    - name: Setup git credentials
+      if: inputs.GIT_CREDENTIALS != ''
+      shell: bash
+      run: |
+        git config --global credential.helper store
+        echo "${{ inputs.GIT_CREDENTIALS }}" > ~/.git-credentials
+
+    # Display the rust toolchain version being installed
+    - name: Setup rust toolchain
+      shell: bash
+      run: rustup show

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -45,7 +45,7 @@ jobs:
 
   build-macos-x86_64:
     name: "Build macOS x86_64"
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -43,6 +43,22 @@ jobs:
           name: cli-builds-linux-x86_64
           path: movement-cli-*.zip
 
+  build-macos-x86_64:
+    name: "Build macOS x86_64"
+    runs-on: macos-14-large
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.source_git_ref_override }}
+      - uses: ./.github/actions/cli-rust-setup
+      - name: Build CLI
+        run: scripts/cli/build_cli_release.sh "macOS" "${{ inputs.release_version }}" "${{ inputs.skip_checks }}" "false"
+      - name: Upload Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-builds-macos-x86_64
+          path: movement-cli-*.zip
+
   build-macos-arm64:
     name: "Build macOS ARM64"
     runs-on: macos-latest
@@ -63,6 +79,7 @@ jobs:
     name: "Create GitHub Release"
     needs:
       - build-linux-x86_64
+      - build-macos-x86_64
       - build-macos-arm64
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -1,0 +1,106 @@
+# Movement CLI Release Workflow
+# Builds and releases the Movement CLI for macOS (ARM & x86_64) and Linux (x86_64)
+# Trigger: Actions Tab -> "Release CLI" -> "Run Workflow"
+
+name: "Release CLI"
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        type: string
+        required: true
+        description: "The release version (e.g. 7.4.0)"
+      source_git_ref_override:
+        type: string
+        required: false
+        description: "Git ref override (branch, tag, or SHA). Defaults to workflow ref."
+      dry_run:
+        type: boolean
+        required: false
+        default: true
+        description: "Dry run - If checked, the release will not be created"
+      skip_checks:
+        type: boolean
+        required: false
+        default: false
+        description: "Skip version validation checks"
+
+jobs:
+  build-linux-x86_64:
+    name: "Build Linux x86_64"
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.source_git_ref_override }}
+      - uses: ./.github/actions/cli-rust-setup
+      - name: Build CLI
+        run: scripts/cli/build_cli_release.sh "Linux" "${{ inputs.release_version }}" "${{ inputs.skip_checks }}" "false"
+      - name: Upload Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-builds-linux-x86_64
+          path: movement-cli-*.zip
+
+  build-macos-x86_64:
+    name: "Build macOS x86_64"
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.source_git_ref_override }}
+      - uses: ./.github/actions/cli-rust-setup
+      - name: Build CLI
+        run: scripts/cli/build_cli_release.sh "macOS" "${{ inputs.release_version }}" "${{ inputs.skip_checks }}" "false"
+      - name: Upload Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-builds-macos-x86_64
+          path: movement-cli-*.zip
+
+  build-macos-arm64:
+    name: "Build macOS ARM64"
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.source_git_ref_override }}
+      - uses: ./.github/actions/cli-rust-setup
+      - name: Build CLI
+        run: scripts/cli/build_cli_release.sh "macOS" "${{ inputs.release_version }}" "${{ inputs.skip_checks }}" "false"
+      - name: Upload Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-builds-macos-arm64
+          path: movement-cli-*.zip
+
+  release:
+    name: "Create GitHub Release"
+    needs:
+      - build-linux-x86_64
+      - build-macos-x86_64
+      - build-macos-arm64
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: ${{ inputs.dry_run == false }}
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cli-builds-*
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -la movement-cli-*.zip
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: "movement-cli-v${{ inputs.release_version }}"
+          name: "Movement CLI v${{ inputs.release_version }}"
+          draft: false
+          prerelease: false
+          files: movement-cli-*.zip
+          generate_release_notes: true

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -43,22 +43,6 @@ jobs:
           name: cli-builds-linux-x86_64
           path: movement-cli-*.zip
 
-  build-macos-x86_64:
-    name: "Build macOS x86_64"
-    runs-on: macos-15-intel
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.source_git_ref_override }}
-      - uses: ./.github/actions/cli-rust-setup
-      - name: Build CLI
-        run: scripts/cli/build_cli_release.sh "macOS" "${{ inputs.release_version }}" "${{ inputs.skip_checks }}" "false"
-      - name: Upload Binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: cli-builds-macos-x86_64
-          path: movement-cli-*.zip
-
   build-macos-arm64:
     name: "Build macOS ARM64"
     runs-on: macos-latest
@@ -79,7 +63,6 @@ jobs:
     name: "Create GitHub Release"
     needs:
       - build-linux-x86_64
-      - build-macos-x86_64
       - build-macos-arm64
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pull-request-validation.yaml
+++ b/.github/workflows/pull-request-validation.yaml
@@ -218,8 +218,6 @@ jobs:
         include:
           - os: macos-latest
             platform: "macOS"
-          - os: macos-15-intel
-            platform: "macOS"
           - os: ubuntu-22.04
             platform: "Linux"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pull-request-validation.yaml
+++ b/.github/workflows/pull-request-validation.yaml
@@ -6,6 +6,7 @@ on:
     branches:
       - movement
       - l1-migration
+      - m1
     types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
 
 env:
@@ -208,3 +209,28 @@ jobs:
           echo "📦 Image: ghcr.io/movementlabsxyz/aptos-node:${{ env.GIT_SHA_SHORT }}"
           echo "🏷️  Tag: ${{ env.GIT_SHA_SHORT }}"
           echo "🌐 Registry: ghcr.io/movementlabsxyz/aptos-node"
+
+  # Test CLI release build to verify the release workflow will work
+  test-cli-release-build:
+    name: "Test CLI Release Build (${{ matrix.os }})"
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            platform: "macOS"
+          - os: macos-13
+            platform: "macOS"
+          - os: ubuntu-22.04
+            platform: "Linux"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cli-rust-setup
+      - name: Test CLI release build
+        run: |
+          # Build with skip_checks=true since we're just testing the build
+          scripts/cli/build_cli_release.sh "${{ matrix.platform }}" "0.0.0-test" "true" "false"
+      - name: Verify artifact
+        run: |
+          ls -la movement-cli-*.zip
+          echo "✅ CLI release build successful on ${{ matrix.os }}"

--- a/.github/workflows/pull-request-validation.yaml
+++ b/.github/workflows/pull-request-validation.yaml
@@ -218,6 +218,8 @@ jobs:
         include:
           - os: macos-latest
             platform: "macOS"
+          - os: macos-14-large
+            platform: "macOS"
           - os: ubuntu-22.04
             platform: "Linux"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pull-request-validation.yaml
+++ b/.github/workflows/pull-request-validation.yaml
@@ -218,7 +218,7 @@ jobs:
         include:
           - os: macos-latest
             platform: "macOS"
-          - os: macos-13
+          - os: macos-15-intel
             platform: "macOS"
           - os: ubuntu-22.04
             platform: "Linux"

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -209,7 +209,7 @@ impl FrameworkPackageArgs {
         const APTOS_FRAMEWORK: &str = "AptosFramework";
         const APTOS_GIT_PATH: &str = "https://github.com/movementlabsxyz/aptos-core.git";
         const SUBDIR_PATH: &str = "aptos-move/framework/aptos-framework";
-        const DEFAULT_BRANCH: &str = "movement";
+        const DEFAULT_BRANCH: &str = "m1";
 
         let move_toml = package_dir.join(SourcePackageLayout::Manifest.path());
         check_if_file_exists(move_toml.as_path(), prompt_options)?;

--- a/scripts/cli/build_cli_release.sh
+++ b/scripts/cli/build_cli_release.sh
@@ -16,8 +16,8 @@
 
 set -e
 
-NAME='aptos-cli'
-CRATE_NAME='aptos'
+NAME='movement-cli'
+CRATE_NAME='movement'
 CARGO_PATH="crates/$CRATE_NAME/Cargo.toml"
 PLATFORM_NAME="$1"
 EXPECTED_VERSION="$2"
@@ -43,7 +43,7 @@ if [[ "$SKIP_CHECKS" != "true" ]]; then
   fi
 
   # Check that the release doesn't already exist
-  if curl -s --stderr /dev/null --output /dev/null --head -f "https://github.com/aptos-labs/aptos-core/releases/download/aptos-cli-v$EXPECTED_VERSION/aptos-cli-$EXPECTED_VERSION-Ubuntu-22.04-x86_64.zip"; then
+  if curl -s --stderr /dev/null --output /dev/null --head -f "https://github.com/movementlabsxyz/aptos-core/releases/download/movement-cli-v$EXPECTED_VERSION/movement-cli-$EXPECTED_VERSION-Linux-x86_64.zip"; then
     echo "$EXPECTED_VERSION already released"
     exit 3
   fi


### PR DESCRIPTION
Adds GitHub Actions workflow to build and release Movement CLI for macOS (ARM & x86_64) and Linux x86_64.

Changes:
- Add .github/workflows/cli-release.yaml - manual workflow to build and publish releases
- Add .github/actions/cli-rust-setup/action.yaml - local Rust setup action (no external dependencies)
- Update scripts/cli/build_cli_release.sh - use movement-cli naming
- Update default framework rev from movement to m1 in movement move init

Usage:
1. Go to Actions → "Release CLI" → Run workflow
2. Enter version (must match Cargo.toml)
3. Uncheck "dry run" to publish
4. Follow the instructions in the [tap repo]( https://github.com/moveindustries/homebrew-movement) README to update the tap.
  
Testing: 
- All three "Test CI Release Build" checks pass. 
- Question for reviewers: test-cli-release-build can be removed from .github/workflows/pull-request-validation.yaml if desired... I think it could be prudent to keep in, but don't want to add too much CI overhead. What do you think?