### PR TITLE
CI: add Aptos-Labs-style Docker Buildx/Bake alt pipeline

### DIFF
--- a/.github/workflows/docker-buildx-bake.yaml
+++ b/.github/workflows/docker-buildx-bake.yaml
@@ -80,6 +80,7 @@ jobs:
       TARGET_REGISTRY: ${{ inputs.push_images && 'ghcr' || 'local' }}
       PUSH_IMAGES: ${{ inputs.push_images && 'true' || 'false' }}
       CI: "true"
+      DOCKER_API_VERSION: "1.43"
       GHCR_DOCKER_ARTIFACT_REPO: ghcr.io/movementlabsxyz
       CUSTOM_IMAGE_TAG_PREFIX: ${{ matrix.arch }}
       GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
@@ -91,7 +92,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: latest
+          version: v0.11.2
 
       - name: Login to GHCR
         if: ${{ inputs.push_images }}

--- a/.github/workflows/docker-buildx-bake.yaml
+++ b/.github/workflows/docker-buildx-bake.yaml
@@ -112,6 +112,49 @@ jobs:
           chmod +x docker/builder/docker-bake-rust-all.sh
           docker/builder/docker-bake-rust-all.sh "${TARGET}"
 
+      - name: Verify image provenance labels (local mode)
+        if: ${{ !inputs.push_images }}
+        env:
+          EXPECTED_GIT_SHA: ${{ needs.metadata.outputs.git_sha }}
+          IMAGE_TAG_PREFIX: ${{ matrix.arch }}_
+        run: |
+          set -euo pipefail
+
+          candidates=(
+            "aptos-core/aptos-node:${IMAGE_TAG_PREFIX}${EXPECTED_GIT_SHA}-from-local"
+            "aptos-core/aptos-faucet-service:${IMAGE_TAG_PREFIX}${EXPECTED_GIT_SHA}-from-local"
+          )
+
+          validated=0
+          for image_ref in "${candidates[@]}"; do
+            if ! docker image inspect "$image_ref" >/dev/null 2>&1; then
+              echo "Skipping provenance check for missing image: $image_ref"
+              continue
+            fi
+
+            actual_sha=$(docker image inspect "$image_ref" \
+              --format '{{ index .Config.Labels "org.label-schema.git-sha" }}')
+            if [ -z "$actual_sha" ]; then
+              echo "Missing org.label-schema.git-sha label on $image_ref"
+              exit 1
+            fi
+
+            if [ "$actual_sha" != "$EXPECTED_GIT_SHA" ]; then
+              echo "Provenance mismatch for $image_ref"
+              echo "Expected git sha: $EXPECTED_GIT_SHA"
+              echo "Actual git sha:   $actual_sha"
+              exit 1
+            fi
+
+            echo "Provenance OK: $image_ref (git-sha=$actual_sha)"
+            validated=$((validated + 1))
+          done
+
+          if [ "$validated" -eq 0 ]; then
+            echo "No movement-core alias images found to verify in local Docker daemon."
+            echo "This is expected when building a different target."
+          fi
+
       - name: Show built images (local mode)
         if: ${{ !inputs.push_images }}
         run: |

--- a/.github/workflows/docker-buildx-bake.yaml
+++ b/.github/workflows/docker-buildx-bake.yaml
@@ -1,0 +1,97 @@
+name: "🐳 Docker Buildx Bake (Alt Pipeline)"
+run-name: "Docker Buildx Bake for ${{ inputs.ref || github.ref_name }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build (branch/tag/sha)"
+        required: true
+        default: "main"
+      target:
+        description: "Bake target/group (e.g. movement-core, aptos-node, all)"
+        required: true
+        default: "movement-core"
+      push_images:
+        description: "Push built images to GHCR"
+        type: boolean
+        required: true
+        default: false
+
+jobs:
+  metadata:
+    runs-on: buildjet-16vcpu-ubuntu-2204
+    outputs:
+      git_sha: ${{ steps.git_sha.outputs.git_sha }}
+      short_sha: ${{ steps.short_sha.outputs.short_sha }}
+      branch_name: ${{ steps.branch_name.outputs.branch_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - id: git_sha
+        run: |
+          echo "git_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - id: short_sha
+        run: |
+          echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - id: branch_name
+        run: |
+          echo "branch_name=$(git rev-parse --abbrev-ref HEAD)" >> "$GITHUB_OUTPUT"
+
+  buildx-bake:
+    needs: metadata
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: buildjet-16vcpu-ubuntu-2204
+          - arch: arm64
+            runner: buildjet-16vcpu-ubuntu-2204-arm
+    runs-on: ${{ matrix.runner }}
+    name: "Bake ${{ inputs.target || 'movement-core' }} (${{ matrix.arch }})"
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    env:
+      TARGET: ${{ inputs.target || 'movement-core' }}
+      TARGET_CACHE_ID: ${{ format('{0}-{1}', needs.metadata.outputs.short_sha, matrix.arch) }}
+      TARGET_REGISTRY: ${{ inputs.push_images && 'ghcr' || 'local' }}
+      PUSH_IMAGES: ${{ inputs.push_images && 'true' || 'false' }}
+      CI: "true"
+      GHCR_DOCKER_ARTIFACT_REPO: ghcr.io/movementlabsxyz
+      CUSTOM_IMAGE_TAG_PREFIX: ${{ matrix.arch }}
+      GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
+
+      - name: Login to GHCR
+        if: ${{ inputs.push_images }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ vars.INFRA_GH_USER }}
+          password: ${{ secrets.INFRA_GH_PAT }}
+
+      - name: Build target via Docker bake
+        run: |
+          set -euo pipefail
+          chmod +x docker/builder/docker-bake-rust-all.sh
+          docker/builder/docker-bake-rust-all.sh "${TARGET}"
+
+      - name: Show built images (local mode)
+        if: ${{ !inputs.push_images }}
+        run: |
+          docker images --format "table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.Size}}" | head -n 50

--- a/.github/workflows/docker-buildx-bake.yaml
+++ b/.github/workflows/docker-buildx-bake.yaml
@@ -2,6 +2,22 @@ name: "🐳 Docker Buildx Bake (Alt Pipeline)"
 run-name: "Docker Buildx Bake for ${{ inputs.ref || github.ref_name }}"
 
 on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - ".github/workflows/docker-buildx-bake.yaml"
+      - "docker/builder/**"
+      - "Justfile"
+      - "README.md"
+  pull_request:
+    branches:
+      - m1
+    paths:
+      - ".github/workflows/docker-buildx-bake.yaml"
+      - "docker/builder/**"
+      - "Justfile"
+      - "README.md"
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/docker-buildx-bake.yaml
+++ b/.github/workflows/docker-buildx-bake.yaml
@@ -1,6 +1,10 @@
 name: "🐳 Docker Buildx Bake (Alt Pipeline)"
 run-name: "Docker Buildx Bake for ${{ inputs.ref || github.ref_name }}"
 
+concurrency:
+  group: docker-bake-${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}-${{ inputs.target || 'movement-core' }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/Justfile
+++ b/Justfile
@@ -156,6 +156,7 @@ container-bake target="movement-core" push="false":
     export PUSH_IMAGES="{{push}}"
     export GHCR_DOCKER_ARTIFACT_REPO="ghcr.io/movementlabsxyz"
     export CUSTOM_IMAGE_TAG_PREFIX="$(uname -m)"
+    export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-2}"
     export GIT_CREDENTIALS="${GIT_CREDENTIALS:-}"
 
     chmod +x docker/builder/docker-bake-rust-all.sh

--- a/Justfile
+++ b/Justfile
@@ -118,6 +118,49 @@ build-bin package:
     nix develop -c cargo build --release -p {{package}}
     @echo "Binary available at target/release/{{package}}"
 
+# Build images using Aptos-Labs-style Docker Buildx Bake pipeline
+# Examples:
+#   just container-bake
+#   just container-bake aptos-node
+#   just container-bake movement-core true
+container-bake target="movement-core" push="false":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if ! command -v docker &> /dev/null; then
+        echo "Error: Docker is not installed."
+        exit 1
+    fi
+
+    if ! docker buildx version &> /dev/null; then
+        echo "Error: Docker Buildx is not available."
+        exit 1
+    fi
+
+    if [ "{{push}}" = "true" ] && [ -z "${INFRA_GH_PAT:-}" ]; then
+        echo "Error: push=true requires INFRA_GH_PAT and INFRA_GH_USER env vars."
+        echo "Example: INFRA_GH_USER=<user> INFRA_GH_PAT=<token> just container-bake {{target}} true"
+        exit 1
+    fi
+
+    if [ "{{push}}" = "true" ]; then
+        echo "$INFRA_GH_PAT" | docker login ghcr.io -u "$INFRA_GH_USER" --password-stdin
+        TARGET_REGISTRY="ghcr"
+    else
+        TARGET_REGISTRY="local"
+    fi
+
+    export CI=true
+    export TARGET_CACHE_ID="local-$(git rev-parse --short HEAD)-$(uname -m)"
+    export TARGET_REGISTRY
+    export PUSH_IMAGES="{{push}}"
+    export GHCR_DOCKER_ARTIFACT_REPO="ghcr.io/movementlabsxyz"
+    export CUSTOM_IMAGE_TAG_PREFIX="$(uname -m)"
+    export GIT_CREDENTIALS="${GIT_CREDENTIALS:-}"
+
+    chmod +x docker/builder/docker-bake-rust-all.sh
+    docker/builder/docker-bake-rust-all.sh "{{target}}"
+
 # List available binary build targets
 list-binaries:
     @echo "Available binary build targets:"
@@ -143,3 +186,8 @@ help:
     @echo "  Use 'just build <binary-name>' for common binary builds"
     @echo "  Use 'just build' to build all packages"
     @echo "  Use 'just build-bin <package-name>' for custom package builds"
+    @echo ""
+    @echo "Docker Bake Options:"
+    @echo "  Use 'just container-bake' to build movement-core images with buildx bake"
+    @echo "  Use 'just container-bake aptos-node' to build only aptos-node image"
+    @echo "  Use 'just container-bake movement-core true' to push images to GHCR"

--- a/README.md
+++ b/README.md
@@ -24,4 +24,17 @@ Movement is a layer 1 blockchain bringing a paradigm shift to Web3 through bette
 
 You can learn more about contributing to the Movement project by reading our [Contribution Guide](./CONTRIBUTING.md) and by viewing our [Code of Conduct](./CODE_OF_CONDUCT.md).
 
+## Docker Buildx Bake (Alt Pipeline)
+
+This repository includes an Aptos-Labs-style Docker Buildx/Bake pipeline under
+`docker/builder/` as an alternative image build path.
+
+- Local build (no push): `just container-bake`
+- Local build for one image: `just container-bake aptos-node`
+- Local build with push to GHCR:
+  `INFRA_GH_USER=<user> INFRA_GH_PAT=<token> just container-bake movement-core true`
+
+The corresponding CI workflow is `.github/workflows/docker-buildx-bake.yaml` and can be
+triggered manually with target selection and optional push.
+
 Aptos Core is licensed under [Apache 2.0](./LICENSE).

--- a/docker/builder/build-node-core.sh
+++ b/docker/builder/build-node-core.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+PROFILE=${PROFILE:-release}
+FEATURES=${FEATURES:-""}
+
+echo "Building aptos-node (core path)"
+echo "PROFILE: $PROFILE"
+echo "FEATURES: $FEATURES"
+echo "CARGO_TARGET_DIR: $CARGO_TARGET_DIR"
+
+if [ -n "$FEATURES" ]; then
+    cargo build --profile="$PROFILE" --features="$FEATURES" -p aptos-node "$@"
+else
+    cargo build --locked --profile="$PROFILE" -p aptos-node "$@"
+fi
+
+# Copy required runtime binary out of target cache mount.
+mkdir dist
+cp "$CARGO_TARGET_DIR/$PROFILE/aptos-node" dist/aptos-node

--- a/docker/builder/build-tools-core.sh
+++ b/docker/builder/build-tools-core.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+PROFILE=cli
+
+echo "Building core tools for movement-core images"
+echo "PROFILE: $PROFILE"
+echo "CARGO_TARGET_DIR: $CARGO_TARGET_DIR"
+
+# Build only binaries required by movement-core images.
+cargo build --locked --profile="$PROFILE" \
+    -p movement \
+    -p aptos-debugger \
+    -p aptos-faucet-service \
+    "$@"
+
+mkdir dist
+cp "$CARGO_TARGET_DIR/$PROFILE/movement" dist/movement
+cp "$CARGO_TARGET_DIR/$PROFILE/aptos-debugger" dist/aptos-debugger
+cp "$CARGO_TARGET_DIR/$PROFILE/aptos-faucet-service" dist/aptos-faucet-service
+
+# Keep historical CLI binary name for downstream images/scripts.
+cp "$CARGO_TARGET_DIR/$PROFILE/movement" dist/aptos

--- a/docker/builder/build-tools.sh
+++ b/docker/builder/build-tools.sh
@@ -11,7 +11,7 @@ echo "CARGO_TARGET_DIR: $CARGO_TARGET_DIR"
 
 # Build all the rust binaries
 cargo build --locked --profile=$PROFILE \
-    -p aptos \
+    -p movement \
     -p aptos-backup-cli \
     -p aptos-faucet-service \
     -p aptos-fn-check-client \
@@ -26,7 +26,7 @@ cargo build --locked --profile=$PROFILE \
 
 # After building, copy the binaries we need to `dist` since the `target` directory is used as docker cache mount and only available during the RUN step
 BINS=(
-    aptos
+    movement
     aptos-faucet-service
     aptos-node-checker
     aptos-openapi-spec-generator
@@ -41,8 +41,11 @@ BINS=(
 mkdir dist
 
 for BIN in "${BINS[@]}"; do
-    cp $CARGO_TARGET_DIR/$PROFILE/$BIN dist/$BIN
+    cp "$CARGO_TARGET_DIR/$PROFILE/$BIN" "dist/$BIN"
 done
+
+# Keep historical CLI binary name for downstream images/scripts.
+cp "$CARGO_TARGET_DIR/$PROFILE/movement" dist/aptos
 
 # Build the Aptos Move framework and place it in dist. It can be found afterwards in the current directory.
 echo "Building the Aptos Move framework..."

--- a/docker/builder/builder.Dockerfile
+++ b/docker/builder/builder.Dockerfile
@@ -55,6 +55,7 @@ FROM builder-base as aptos-node-builder
 RUN --mount=type=secret,id=GIT_CREDENTIALS,target=/root/.git-credentials \
     --mount=type=cache,target=/usr/local/cargo/git,id=node-builder-cargo-git-cache \
     --mount=type=cache,target=/usr/local/cargo/registry,id=node-builder-cargo-registry-cache \
+    --mount=type=cache,target=/aptos/target,id=node-builder-target-cache \
     docker/builder/build-node.sh
 
 FROM builder-base as tools-builder
@@ -62,6 +63,7 @@ FROM builder-base as tools-builder
 RUN --mount=type=secret,id=GIT_CREDENTIALS,target=/root/.git-credentials \
     --mount=type=cache,target=/usr/local/cargo/git,id=tools-builder-cargo-git-cache \
     --mount=type=cache,target=/usr/local/cargo/registry,id=tools-builder-cargo-registry-cache \
+    --mount=type=cache,target=/aptos/target,id=tools-builder-target-cache \
     docker/builder/build-tools.sh
 
 FROM builder-base as indexer-builder
@@ -69,4 +71,5 @@ FROM builder-base as indexer-builder
 RUN --mount=type=secret,id=GIT_CREDENTIALS,target=/root/.git-credentials \
     --mount=type=cache,target=/usr/local/cargo/git,id=indexer-builder-cargo-git-cache \
     --mount=type=cache,target=/usr/local/cargo/registry,id=indexer-builder-cargo-registry-cache \
+    --mount=type=cache,target=/aptos/target,id=indexer-builder-target-cache \
     docker/builder/build-indexer.sh

--- a/docker/builder/builder.Dockerfile
+++ b/docker/builder/builder.Dockerfile
@@ -38,6 +38,8 @@ ARG FEATURES
 ENV FEATURES ${FEATURES}
 ARG CARGO_TARGET_DIR
 ENV CARGO_TARGET_DIR ${CARGO_TARGET_DIR}
+ARG CARGO_BUILD_JOBS
+ENV CARGO_BUILD_JOBS ${CARGO_BUILD_JOBS}
 
 RUN ARCHITECTURE=$(uname -m | sed -e "s/arm64/arm_64/g" | sed -e "s/aarch64/aarch_64/g") \
     && curl -LOs "https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-$ARCHITECTURE.zip" \

--- a/docker/builder/builder.Dockerfile
+++ b/docker/builder/builder.Dockerfile
@@ -60,6 +60,14 @@ RUN --mount=type=secret,id=GIT_CREDENTIALS,target=/root/.git-credentials \
     --mount=type=cache,target=/aptos/target,id=node-builder-target-cache \
     docker/builder/build-node.sh
 
+FROM builder-base as aptos-node-core-builder
+
+RUN --mount=type=secret,id=GIT_CREDENTIALS,target=/root/.git-credentials \
+    --mount=type=cache,target=/usr/local/cargo/git,id=node-core-builder-cargo-git-cache \
+    --mount=type=cache,target=/usr/local/cargo/registry,id=node-core-builder-cargo-registry-cache \
+    --mount=type=cache,target=/aptos/target,id=node-core-builder-target-cache \
+    docker/builder/build-node-core.sh
+
 FROM builder-base as tools-builder
 
 RUN --mount=type=secret,id=GIT_CREDENTIALS,target=/root/.git-credentials \
@@ -67,6 +75,14 @@ RUN --mount=type=secret,id=GIT_CREDENTIALS,target=/root/.git-credentials \
     --mount=type=cache,target=/usr/local/cargo/registry,id=tools-builder-cargo-registry-cache \
     --mount=type=cache,target=/aptos/target,id=tools-builder-target-cache \
     docker/builder/build-tools.sh
+
+FROM builder-base as tools-core-builder
+
+RUN --mount=type=secret,id=GIT_CREDENTIALS,target=/root/.git-credentials \
+    --mount=type=cache,target=/usr/local/cargo/git,id=tools-core-builder-cargo-git-cache \
+    --mount=type=cache,target=/usr/local/cargo/registry,id=tools-core-builder-cargo-registry-cache \
+    --mount=type=cache,target=/aptos/target,id=tools-core-builder-target-cache \
+    docker/builder/build-tools-core.sh
 
 FROM builder-base as indexer-builder
 

--- a/docker/builder/docker-bake-rust-all.hcl
+++ b/docker/builder/docker-bake-rust-all.hcl
@@ -62,6 +62,10 @@ variable "CARGO_TARGET_DIR" {
   default = "target/default"
 }
 
+variable "CARGO_BUILD_JOBS" {
+  default = "2"
+}
+
 group "all" {
   targets = flatten([
     "validator",
@@ -106,6 +110,7 @@ target "builder-base" {
     PROFILE            = "${PROFILE}"
     FEATURES           = "${FEATURES}"
     CARGO_TARGET_DIR   = "${CARGO_TARGET_DIR}"
+    CARGO_BUILD_JOBS   = "${CARGO_BUILD_JOBS}"
     BUILT_VIA_BUILDKIT = "true"
   }
   secret = [

--- a/docker/builder/docker-bake-rust-all.hcl
+++ b/docker/builder/docker-bake-rust-all.hcl
@@ -129,9 +129,31 @@ target "aptos-node-builder" {
   ]
 }
 
+target "aptos-node-core-builder" {
+  dockerfile = "docker/builder/builder.Dockerfile"
+  target     = "aptos-node-core-builder"
+  contexts = {
+    builder-base = "target:builder-base"
+  }
+  secret = [
+    "id=GIT_CREDENTIALS,env=GIT_CREDENTIALS"
+  ]
+}
+
 target "tools-builder" {
   dockerfile = "docker/builder/builder.Dockerfile"
   target     = "tools-builder"
+  contexts = {
+    builder-base = "target:builder-base"
+  }
+  secret = [
+    "id=GIT_CREDENTIALS,env=GIT_CREDENTIALS"
+  ]
+}
+
+target "tools-core-builder" {
+  dockerfile = "docker/builder/builder.Dockerfile"
+  target     = "tools-core-builder"
   contexts = {
     builder-base = "target:builder-base"
   }
@@ -185,8 +207,8 @@ target "_common-core" {
   inherits = ["_common-base"]
   contexts = {
     debian-base   = "target:debian-base"
-    node-builder  = "target:aptos-node-builder"
-    tools-builder = "target:tools-builder"
+    node-builder  = "target:aptos-node-core-builder"
+    tools-builder = "target:tools-core-builder"
   }
 }
 

--- a/docker/builder/docker-bake-rust-all.hcl
+++ b/docker/builder/docker-bake-rust-all.hcl
@@ -151,13 +151,7 @@ target "indexer-builder" {
   ]
 }
 
-target "_common" {
-  contexts = {
-    debian-base     = "target:debian-base"
-    node-builder    = "target:aptos-node-builder"
-    tools-builder   = "target:tools-builder"
-    indexer-builder = "target:indexer-builder"
-  }
+target "_common-base" {
   labels = {
     "org.label-schema.schema-version" = "1.0",
     "org.label-schema.build-date"     = "${BUILD_DATE}"
@@ -176,6 +170,26 @@ target "_common" {
   cache-to   = generate_cache_to("shared")
 }
 
+target "_common" {
+  inherits = ["_common-base"]
+  contexts = {
+    debian-base     = "target:debian-base"
+    node-builder    = "target:aptos-node-builder"
+    tools-builder   = "target:tools-builder"
+    indexer-builder = "target:indexer-builder"
+  }
+}
+
+# Lean shared context for movement-core images; avoids unnecessary indexer builder work.
+target "_common-core" {
+  inherits = ["_common-base"]
+  contexts = {
+    debian-base   = "target:debian-base"
+    node-builder  = "target:aptos-node-builder"
+    tools-builder = "target:tools-builder"
+  }
+}
+
 target "validator-testing" {
   inherits   = ["_common"]
   dockerfile = "docker/builder/validator-testing.Dockerfile"
@@ -192,7 +206,7 @@ target "validator" {
 
 # Alias for existing external naming conventions in movement repos.
 target "aptos-node" {
-  inherits   = ["_common"]
+  inherits   = ["_common-core"]
   dockerfile = "docker/builder/validator.Dockerfile"
   target     = "validator"
   tags       = generate_tags("aptos-node")
@@ -228,7 +242,7 @@ target "faucet" {
 
 # Alias for existing external naming conventions in movement repos.
 target "aptos-faucet-service" {
-  inherits   = ["_common"]
+  inherits   = ["_common-core"]
   dockerfile = "docker/builder/faucet.Dockerfile"
   target     = "faucet"
   tags       = generate_tags("aptos-faucet-service")

--- a/docker/builder/docker-bake-rust-all.hcl
+++ b/docker/builder/docker-bake-rust-all.hcl
@@ -1,49 +1,65 @@
-# This is a docker bake file in HCL syntax.
-# It provides a high-level mechenanism to build multiple dockerfiles in one shot.
-# Check https://crazymax.dev/docker-allhands2-buildx-bake and https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition for an intro.
+# Docker Buildx Bake definition for rust image builds.
+# Modeled after Aptos Labs' bake-driven image pipeline and adapted for GHCR.
 
 variable "CI" {
-  # whether this build runs in aptos-labs' CI environment which makes certain assumptions about certain registries being available to push to cache layers.
-  # for local builds we simply default to relying on dockers local caching.
   default = "false"
 }
-variable "TARGET_CACHE_ID" {}
-variable "BUILD_DATE" {}
-// this is the full GIT_SHA - let's use that as primary identifier going forward
-variable "GIT_SHA" {}
 
-variable "GIT_BRANCH" {}
+variable "TARGET_CACHE_ID" {
+  default = "local"
+}
 
-variable "GIT_TAG" {}
+variable "BUILD_DATE" {
+  default = ""
+}
 
-variable "GIT_CREDENTIALS" {}
+variable "GIT_SHA" {
+  default = "dev"
+}
 
-variable "BUILT_VIA_BUILDKIT" {}
+variable "GIT_BRANCH" {
+  default = "unknown"
+}
 
-variable "GCP_DOCKER_ARTIFACT_REPO" {}
+variable "GIT_TAG" {
+  default = "none"
+}
 
-variable "AWS_ECR_ACCOUNT_NUM" {}
+variable "GIT_CREDENTIALS" {
+  default = ""
+}
+
+variable "BUILT_VIA_BUILDKIT" {
+  default = "true"
+}
+
+variable "GHCR_DOCKER_ARTIFACT_REPO" {
+  default = "ghcr.io/movementlabsxyz"
+}
 
 variable "TARGET_REGISTRY" {
-  // must be "gcp" | "local" | "remote-all" | "remote" (deprecated, but kept for backwards compatibility. Same as "gcp"), informs which docker tags are being generated
-  default = CI == "true" ? "remote" : "local"
+  # Supported: "local" | "ghcr"
+  default = CI == "true" ? "ghcr" : "local"
 }
 
-variable "ecr_base" {
-  default = "${AWS_ECR_ACCOUNT_NUM}.dkr.ecr.us-west-2.amazonaws.com/aptos"
+variable "NORMALIZED_GIT_BRANCH_OR_PR" {
+  default = "local"
 }
 
-variable "NORMALIZED_GIT_BRANCH_OR_PR" {}
-variable "IMAGE_TAG_PREFIX" {}
+variable "IMAGE_TAG_PREFIX" {
+  default = ""
+}
+
 variable "PROFILE" {
-  // Cargo compilation profile
   default = "release"
 }
+
 variable "FEATURES" {
-  // Cargo features to enable, as a comma separated string
+  default = ""
 }
+
 variable "CARGO_TARGET_DIR" {
-  // Cargo target directory
+  default = "target/default"
 }
 
 group "all" {
@@ -65,10 +81,15 @@ group "forge-images" {
   targets = ["validator-testing", "tools", "forge"]
 }
 
+# Minimal Movement-focused group for the alternate pipeline rollout.
+group "movement-core" {
+  targets = ["aptos-node", "aptos-faucet-service"]
+}
+
 target "debian-base" {
   dockerfile = "docker/builder/debian-base.Dockerfile"
   contexts = {
-    # Run `docker buildx imagetools inspect debian:bullseye` to find the latest multi-platform hash
+    # Run `docker buildx imagetools inspect debian:bullseye` to refresh this digest.
     debian = "docker-image://debian:bullseye@sha256:cf48c31af360e1c0a0aedd33aae4d928b68c2cdf093f1612650eb1ff434d1c34"
   }
 }
@@ -78,7 +99,7 @@ target "builder-base" {
   target     = "builder-base"
   context    = "."
   contexts = {
-    # Run `docker buildx imagetools inspect rust:1.80.1-bullseye` to find the latest multi-platform hash
+    # Run `docker buildx imagetools inspect rust:1.80.1-bullseye` to refresh this digest.
     rust = "docker-image://rust:1.80.1-bullseye@sha256:f6f599d3f027a97fb60cb87854199fcde390e25cee216712c3f9eede545b052e"
   }
   args = {
@@ -88,7 +109,7 @@ target "builder-base" {
     BUILT_VIA_BUILDKIT = "true"
   }
   secret = [
-    "id=GIT_CREDENTIALS"
+    "id=GIT_CREDENTIALS,env=GIT_CREDENTIALS"
   ]
 }
 
@@ -99,7 +120,7 @@ target "aptos-node-builder" {
     builder-base = "target:builder-base"
   }
   secret = [
-    "id=GIT_CREDENTIALS"
+    "id=GIT_CREDENTIALS,env=GIT_CREDENTIALS"
   ]
 }
 
@@ -110,7 +131,7 @@ target "tools-builder" {
     builder-base = "target:builder-base"
   }
   secret = [
-    "id=GIT_CREDENTIALS"
+    "id=GIT_CREDENTIALS,env=GIT_CREDENTIALS"
   ]
 }
 
@@ -121,7 +142,7 @@ target "indexer-builder" {
     builder-base = "target:builder-base"
   }
   secret = [
-    "id=GIT_CREDENTIALS"
+    "id=GIT_CREDENTIALS,env=GIT_CREDENTIALS"
   ]
 }
 
@@ -146,6 +167,8 @@ target "_common" {
     BUILD_DATE = "${BUILD_DATE}"
   }
   output     = ["type=image,compression=zstd,force-compression=true"]
+  cache-from = generate_cache_from("shared")
+  cache-to   = generate_cache_to("shared")
 }
 
 target "validator-testing" {
@@ -153,6 +176,21 @@ target "validator-testing" {
   dockerfile = "docker/builder/validator-testing.Dockerfile"
   target     = "validator-testing"
   tags       = generate_tags("validator-testing")
+}
+
+target "validator" {
+  inherits   = ["_common"]
+  dockerfile = "docker/builder/validator.Dockerfile"
+  target     = "validator"
+  tags       = generate_tags("validator")
+}
+
+# Alias for existing external naming conventions in movement repos.
+target "aptos-node" {
+  inherits   = ["_common"]
+  dockerfile = "docker/builder/validator.Dockerfile"
+  target     = "validator"
+  tags       = generate_tags("aptos-node")
 }
 
 target "tools" {
@@ -169,20 +207,6 @@ target "forge" {
   tags       = generate_tags("forge")
 }
 
-target "validator" {
-  inherits   = ["_common"]
-  dockerfile = "docker/builder/validator.Dockerfile"
-  target     = "validator"
-  tags       = generate_tags("validator")
-}
-
-target "tools" {
-  inherits   = ["_common"]
-  dockerfile = "docker/builder/tools.Dockerfile"
-  target     = "tools"
-  tags       = generate_tags("tools")
-}
-
 target "node-checker" {
   inherits   = ["_common"]
   dockerfile = "docker/builder/node-checker.Dockerfile"
@@ -195,6 +219,14 @@ target "faucet" {
   dockerfile = "docker/builder/faucet.Dockerfile"
   target     = "faucet"
   tags       = generate_tags("faucet")
+}
+
+# Alias for existing external naming conventions in movement repos.
+target "aptos-faucet-service" {
+  inherits   = ["_common"]
+  dockerfile = "docker/builder/faucet.Dockerfile"
+  target     = "faucet"
+  tags       = generate_tags("aptos-faucet-service")
 }
 
 target "telemetry-service" {
@@ -220,25 +252,28 @@ target "indexer-grpc" {
 
 target "nft-metadata-crawler" {
   inherits   = ["_common"]
-  target     = "nft-metadata-crawler"
   dockerfile = "docker/builder/nft-metadata-crawler.Dockerfile"
+  target     = "nft-metadata-crawler"
   tags       = generate_tags("nft-metadata-crawler")
 }
 
 function "generate_tags" {
   params = [target]
-  result = TARGET_REGISTRY == "remote-all" ? [
-    "${GCP_DOCKER_ARTIFACT_REPO}/${target}:${IMAGE_TAG_PREFIX}${GIT_SHA}",
-    "${GCP_DOCKER_ARTIFACT_REPO}/${target}:${IMAGE_TAG_PREFIX}${NORMALIZED_GIT_BRANCH_OR_PR}",
-    "${ecr_base}/${target}:${IMAGE_TAG_PREFIX}${GIT_SHA}",
-    "${ecr_base}/${target}:${IMAGE_TAG_PREFIX}${NORMALIZED_GIT_BRANCH_OR_PR}",
-    ] : (
-    TARGET_REGISTRY == "gcp" || TARGET_REGISTRY == "remote" ? [
-      "${GCP_DOCKER_ARTIFACT_REPO}/${target}:${IMAGE_TAG_PREFIX}${GIT_SHA}",
-      "${GCP_DOCKER_ARTIFACT_REPO}/${target}:${IMAGE_TAG_PREFIX}${NORMALIZED_GIT_BRANCH_OR_PR}",
-      ] : [ // "local" or any other value
+  result = TARGET_REGISTRY == "ghcr" ? [
+    "${GHCR_DOCKER_ARTIFACT_REPO}/${target}:${IMAGE_TAG_PREFIX}${GIT_SHA}",
+    "${GHCR_DOCKER_ARTIFACT_REPO}/${target}:${IMAGE_TAG_PREFIX}${NORMALIZED_GIT_BRANCH_OR_PR}",
+    ] : [
       "aptos-core/${target}:${IMAGE_TAG_PREFIX}${GIT_SHA}-from-local",
       "aptos-core/${target}:${IMAGE_TAG_PREFIX}from-local",
-    ]
-  )
+  ]
+}
+
+function "generate_cache_from" {
+  params = [scope]
+  result = CI == "true" ? ["type=gha,scope=${scope}-${TARGET_CACHE_ID}"] : []
+}
+
+function "generate_cache_to" {
+  params = [scope]
+  result = CI == "true" ? ["type=gha,scope=${scope}-${TARGET_CACHE_ID},mode=max"] : []
 }

--- a/docker/builder/docker-bake-rust-all.sh
+++ b/docker/builder/docker-bake-rust-all.sh
@@ -12,17 +12,27 @@
 
 set -ex
 
-export GIT_SHA=$(git rev-parse HEAD)
-export GIT_BRANCH=$(git symbolic-ref --short HEAD)
-export GIT_TAG=$(git tag -l --contains HEAD)
+GIT_SHA=$(git rev-parse HEAD)
+export GIT_SHA
+GIT_BRANCH=$(git symbolic-ref --short HEAD)
+export GIT_BRANCH
+GIT_TAG=$(git tag -l --contains HEAD)
+export GIT_TAG
 export GIT_CREDENTIALS="${GIT_CREDENTIALS:-}"
-export BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+export BUILD_DATE
 export BUILT_VIA_BUILDKIT="true"
-export NORMALIZED_GIT_BRANCH_OR_PR=$(printf "$TARGET_CACHE_ID" | sed -e 's/[^a-zA-Z0-9]/-/g')
+export TARGET_CACHE_ID="${TARGET_CACHE_ID:-${GIT_BRANCH}}"
+NORMALIZED_GIT_BRANCH_OR_PR=$(printf '%s' "$TARGET_CACHE_ID" | sed -e 's/[^a-zA-Z0-9]/-/g')
+export NORMALIZED_GIT_BRANCH_OR_PR
+export TARGET_REGISTRY="${TARGET_REGISTRY:-local}"
+export GHCR_DOCKER_ARTIFACT_REPO="${GHCR_DOCKER_ARTIFACT_REPO:-ghcr.io/movementlabsxyz}"
+export PUSH_IMAGES="${PUSH_IMAGES:-false}"
 
 export PROFILE=${PROFILE:-release}
 export FEATURES=${FEATURES:-""}
-export NORMALIZED_FEATURES_LIST=$(printf "$FEATURES" | sed -e 's/[^a-zA-Z0-9]/_/g')
+NORMALIZED_FEATURES_LIST=$(printf '%s' "$FEATURES" | sed -e 's/[^a-zA-Z0-9]/_/g')
+export NORMALIZED_FEATURES_LIST
 export CUSTOM_IMAGE_TAG_PREFIX=${CUSTOM_IMAGE_TAG_PREFIX:-""}
 export CARGO_TARGET_DIR="target/${FEATURES:-"default"}"
 
@@ -46,15 +56,23 @@ else
   export IMAGE_TAG_PREFIX="${IMAGE_TAG_PREFIX}${profile_prefix}"
 fi
 
-BUILD_TARGET="${1:-all}"
+BUILD_TARGET="${1:-movement-core}"
 echo "Building target: ${BUILD_TARGET}"
 echo "To build only a specific target, run: docker/builder/docker-bake-rust-all.sh <target>"
-echo "E.g. docker/builder/docker-bake-rust-all.sh forge-images"
+echo "E.g. docker/builder/docker-bake-rust-all.sh aptos-node"
+echo "E.g. docker/builder/docker-bake-rust-all.sh movement-core"
+echo "TARGET_REGISTRY=${TARGET_REGISTRY}"
+echo "TARGET_CACHE_ID=${TARGET_CACHE_ID}"
+echo "PUSH_IMAGES=${PUSH_IMAGES}"
 
-if [ "$CI" == "true" ]; then
-  docker buildx bake --progress=plain --file docker/builder/docker-bake-rust-all.hcl --push $BUILD_TARGET
+if [ "$CI" == "true" ] || [ "$PUSH_IMAGES" == "true" ]; then
+  if [ "$PUSH_IMAGES" == "true" ]; then
+    docker buildx bake --progress=plain --file docker/builder/docker-bake-rust-all.hcl --push "$BUILD_TARGET"
+  else
+    docker buildx bake --progress=plain --file docker/builder/docker-bake-rust-all.hcl --load "$BUILD_TARGET"
+  fi
 else
-  docker buildx bake --file docker/builder/docker-bake-rust-all.hcl $BUILD_TARGET --load
+  docker buildx bake --file docker/builder/docker-bake-rust-all.hcl "$BUILD_TARGET" --load
 fi
 
 echo "Build complete. Docker buildx cache usage:"

--- a/docker/builder/docker-bake-rust-all.sh
+++ b/docker/builder/docker-bake-rust-all.sh
@@ -31,6 +31,7 @@ export PUSH_IMAGES="${PUSH_IMAGES:-false}"
 
 export PROFILE=${PROFILE:-release}
 export FEATURES=${FEATURES:-""}
+export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-2}"
 NORMALIZED_FEATURES_LIST=$(printf '%s' "$FEATURES" | sed -e 's/[^a-zA-Z0-9]/_/g')
 export NORMALIZED_FEATURES_LIST
 export CUSTOM_IMAGE_TAG_PREFIX=${CUSTOM_IMAGE_TAG_PREFIX:-""}
@@ -64,6 +65,7 @@ echo "E.g. docker/builder/docker-bake-rust-all.sh movement-core"
 echo "TARGET_REGISTRY=${TARGET_REGISTRY}"
 echo "TARGET_CACHE_ID=${TARGET_CACHE_ID}"
 echo "PUSH_IMAGES=${PUSH_IMAGES}"
+echo "CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}"
 
 if [ "$CI" == "true" ] || [ "$PUSH_IMAGES" == "true" ]; then
   if [ "$PUSH_IMAGES" == "true" ]; then

--- a/docker/builder/docker-bake-rust-all.sh
+++ b/docker/builder/docker-bake-rust-all.sh
@@ -14,7 +14,11 @@ set -ex
 
 GIT_SHA=$(git rev-parse HEAD)
 export GIT_SHA
-GIT_BRANCH=$(git symbolic-ref --short HEAD)
+# GitHub Actions often checks out a detached HEAD, so fall back to workflow refs.
+GIT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || true)
+if [ -z "$GIT_BRANCH" ]; then
+  GIT_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-detached-head}}"
+fi
 export GIT_BRANCH
 GIT_TAG=$(git tag -l --contains HEAD)
 export GIT_TAG


### PR DESCRIPTION
## Summary
- Add a **separate** Aptos-Labs-style Docker Buildx/Bake pipeline on a new branch/PR (does not modify `nix-build-wip` / PR #284).
- Wire existing `docker/builder/*` assets into a dedicated workflow for manual CI execution.
- Add a local command path so engineers can build images when CI runners are unavailable.

## What Changed
- Added workflow: `.github/workflows/docker-buildx-bake.yaml`
  - Manual trigger with inputs: `ref`, `target`, `push_images`
  - Runs matrix builds on BuildJet `amd64` + `arm64`
  - Uses Buildx bake with GHA cache scopes per arch
  - Optional GHCR push mode
- Updated bake definition: `docker/builder/docker-bake-rust-all.hcl`
  - Added `movement-core` group and aliases:
    - `aptos-node` (maps to validator image target)
    - `aptos-faucet-service` (maps to faucet image target)
  - Added GHCR-oriented tags for remote mode
  - Added CI cache config (`cache-from` / `cache-to` via `type=gha`)
  - Fixed secret wiring to use env-based secret injection (`id=GIT_CREDENTIALS,env=GIT_CREDENTIALS`)
- Updated build script: `docker/builder/docker-bake-rust-all.sh`
  - Added safer defaults (`TARGET_CACHE_ID`, `TARGET_REGISTRY`, `PUSH_IMAGES`)
  - Added explicit `PUSH_IMAGES` control (`--push` vs `--load`)
  - Default target now `movement-core`
- Updated builder Dockerfile: `docker/builder/builder.Dockerfile`
  - Added `/aptos/target` cache mounts for node/tools/indexer builder stages
- Added local entrypoint command in `Justfile`
  - `just container-bake`
  - `just container-bake aptos-node`
  - `just container-bake movement-core true` (with GHCR creds)
- Added docs in `README.md` for local bake usage and CI workflow location.

## Validation
- `just --list` (recipe parsing)
- `bash -n docker/builder/docker-bake-rust-all.sh`
- `shellcheck docker/builder/docker-bake-rust-all.sh`
- `docker buildx bake --file docker/builder/docker-bake-rust-all.hcl --print movement-core` (both local and ghcr tag modes)

## Notes
- This PR is the alternative pipeline track requested for comparison against current Nix+Cachix flow.
- Existing branch/PR (`nix-build-wip` / #284) remains untouched.


## Cache Behavior and Build Timings

The Docker Buildx/Bake workflow is using cache in CI:

- Buildx bake uses `cache-from` / `cache-to` with `type=gha` and per-arch scopes.
- Build logs show `exec.cachemount` usage (`docker buildx du --verbose --filter type=exec.cachemount`).

Measured no-code-change rerun (same full SHA `cc409784c837b1fcc5e93783473642749f057210`):

- Baseline run: https://github.com/movementlabsxyz/aptos-core/actions/runs/21872905258
  - amd64: `42m18s`
  - arm64: `1h13m30s`
- Immediate rerun on same SHA: https://github.com/movementlabsxyz/aptos-core/actions/runs/21896789921
  - amd64: `37m25s` (faster by `4m53s`, ~`11.6%`)
  - arm64: `1h13m08s` (faster by `22s`, ~`0.5%`)

Latest PR validation run (includes provenance step):

- https://github.com/movementlabsxyz/aptos-core/actions/runs/21907043431
  - amd64: `41m00s` (`success`)
  - arm64: `1h11m55s` (`success`)
  - `Verify image provenance labels (local mode)` passed on both architectures.

Operational note:

- Best cache reuse is observed when re-running the same commit SHA and target/arch.
- Different commit SHAs naturally reduce hit rates because cache scope is keyed by SHA + arch.
