### PR TITLE
fix: remove movement and l1-migration packages for old commit compati…

### DIFF
--- a/.github/workflows/build-versions.yaml
+++ b/.github/workflows/build-versions.yaml
@@ -80,8 +80,6 @@ jobs:
       matrix:
         binary:
           - package: "aptos-node"
-          - package: "movement"
-          - package: "l1-migration"
     env:
       TARGET_FOLDER: target/${{ needs.setup.outputs.build_profile }}
     steps:
@@ -116,16 +114,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: aptos-node-${{ env.SHORT_SHA }}
-          path: ${{ env.TARGET_FOLDER }}
-      - name: Download movement binary
-        uses: actions/download-artifact@v4
-        with:
-          name: movement-${{ env.SHORT_SHA }}
-          path: ${{ env.TARGET_FOLDER }}
-      - name: Download l1-migration binary
-        uses: actions/download-artifact@v4
-        with:
-          name: l1-migration-${{ env.SHORT_SHA }}
           path: ${{ env.TARGET_FOLDER }}
       - name: List binaries
         run: ls -la ${{ env.TARGET_FOLDER }}

--- a/docker/aptos-node/Dockerfile
+++ b/docker/aptos-node/Dockerfile
@@ -20,17 +20,9 @@ WORKDIR /app
 
 ARG BINARY_PATH=target/release
 # Copy the binaries and modify their interpreter
-# Note: The CLI binary is named 'movement' (from the 'movement' package in Cargo.toml)
 COPY --chmod=0755 ${BINARY_PATH}/aptos-node /usr/local/bin/aptos-node
-COPY --chmod=0755 ${BINARY_PATH}/movement /usr/local/bin/movement
-COPY --chmod=0755 ${BINARY_PATH}/l1-migration /usr/local/bin/l1-migration
 
 RUN patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 /usr/local/bin/aptos-node
-RUN patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 /usr/local/bin/movement
-RUN patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 /usr/local/bin/l1-migration
-
-# Create symlink for backwards compatibility (aptos -> movement)
-RUN ln -s /usr/local/bin/movement /usr/local/bin/aptos
 
 # add build info
 ARG BUILD_DATE


### PR DESCRIPTION
…bility

Only build aptos-node since movement and l1-migration packages don't exist at this commit.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
