### PR TITLE
[Bugfix] Use full transaction size in computing transaction metadata

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -295,7 +295,7 @@ impl AptosVM {
     }
 
     #[inline(always)]
-    fn timed_features(&self) -> &TimedFeatures {
+    pub(crate) fn timed_features(&self) -> &TimedFeatures {
         self.move_vm.env.timed_features()
     }
 
@@ -1915,7 +1915,7 @@ impl AptosVM {
         G: AptosGasMeter,
         F: FnOnce(u64, VMGasParameters, StorageGasParameters, bool, Gas, &'a C) -> G,
     {
-        let txn_metadata = TransactionMetadata::new(txn);
+        let txn_metadata = TransactionMetadata::new(txn, self.timed_features());
 
         let is_approved_gov_script = is_approved_gov_script(resolver, txn, &txn_metadata);
 
@@ -2803,7 +2803,7 @@ impl VMValidator for AptosVM {
                 return VMValidatorResult::error(StatusCode::INVALID_SIGNATURE);
             },
         };
-        let txn_data = TransactionMetadata::new(&txn);
+        let txn_data = TransactionMetadata::new(&txn, self.timed_features());
 
         let resolver = self.as_move_resolver(&state_view);
         let is_approved_gov_script = is_approved_gov_script(&resolver, &txn, &txn_data);

--- a/aptos-move/aptos-vm/src/testing.rs
+++ b/aptos-move/aptos-vm/src/testing.rs
@@ -80,7 +80,7 @@ impl AptosVM {
         use crate::gas::make_prod_gas_meter;
         use move_vm_runtime::module_traversal::{TraversalContext, TraversalStorage};
 
-        let txn_data = TransactionMetadata::new(txn);
+        let txn_data = TransactionMetadata::new(txn, self.timed_features());
         let log_context = AdapterLogSchema::new(state_view.id(), 0);
 
         let vm_gas_params = self

--- a/aptos-move/aptos-vm/src/transaction_metadata.rs
+++ b/aptos-move/aptos-vm/src/transaction_metadata.rs
@@ -5,9 +5,15 @@
 use aptos_crypto::HashValue;
 use aptos_gas_algebra::{FeePerGasUnit, Gas, NumBytes};
 use aptos_types::{
-    account_address::AccountAddress, chain_id::ChainId, on_chain_config::{TimedFeatureFlag, TimedFeatures}, transaction::{
-        EntryFunction, Multisig, MultisigTransactionPayload, ReplayProtector, SignedTransaction, TransactionExecutable, TransactionExecutableRef, TransactionExtraConfig, TransactionPayload, TransactionPayloadInner, authenticator::AuthenticationProof, user_transaction_context::UserTransactionContext
-    }
+    account_address::AccountAddress,
+    chain_id::ChainId,
+    on_chain_config::{TimedFeatureFlag, TimedFeatures},
+    transaction::{
+        authenticator::AuthenticationProof, user_transaction_context::UserTransactionContext,
+        EntryFunction, Multisig, MultisigTransactionPayload, ReplayProtector, SignedTransaction,
+        TransactionExecutable, TransactionExecutableRef, TransactionExtraConfig,
+        TransactionPayload, TransactionPayloadInner,
+    },
 };
 
 pub struct TransactionMetadata {
@@ -34,7 +40,9 @@ pub struct TransactionMetadata {
 
 impl TransactionMetadata {
     pub fn new(txn: &SignedTransaction, timed_features: &TimedFeatures) -> Self {
-        let txn_size = if timed_features.is_enabled(TimedFeatureFlag::UseFullTransactionSizeForTransactionMetadata) {
+        let txn_size = if timed_features
+            .is_enabled(TimedFeatureFlag::UseFullTransactionSizeForTransactionMetadata)
+        {
             txn.txn_bytes_len()
         } else {
             txn.raw_txn_bytes_len()

--- a/aptos-move/aptos-vm/src/transaction_metadata.rs
+++ b/aptos-move/aptos-vm/src/transaction_metadata.rs
@@ -5,14 +5,9 @@
 use aptos_crypto::HashValue;
 use aptos_gas_algebra::{FeePerGasUnit, Gas, NumBytes};
 use aptos_types::{
-    account_address::AccountAddress,
-    chain_id::ChainId,
-    transaction::{
-        authenticator::AuthenticationProof, user_transaction_context::UserTransactionContext,
-        EntryFunction, Multisig, MultisigTransactionPayload, ReplayProtector, SignedTransaction,
-        TransactionExecutable, TransactionExecutableRef, TransactionExtraConfig,
-        TransactionPayload, TransactionPayloadInner,
-    },
+    account_address::AccountAddress, chain_id::ChainId, on_chain_config::{TimedFeatureFlag, TimedFeatures}, transaction::{
+        EntryFunction, Multisig, MultisigTransactionPayload, ReplayProtector, SignedTransaction, TransactionExecutable, TransactionExecutableRef, TransactionExtraConfig, TransactionPayload, TransactionPayloadInner, authenticator::AuthenticationProof, user_transaction_context::UserTransactionContext
+    }
 };
 
 pub struct TransactionMetadata {
@@ -38,7 +33,12 @@ pub struct TransactionMetadata {
 }
 
 impl TransactionMetadata {
-    pub fn new(txn: &SignedTransaction) -> Self {
+    pub fn new(txn: &SignedTransaction, timed_features: &TimedFeatures) -> Self {
+        let txn_size = if timed_features.is_enabled(TimedFeatureFlag::UseFullTransactionSizeForTransactionMetadata) {
+            txn.txn_bytes_len()
+        } else {
+            txn.raw_txn_bytes_len()
+        };
         Self {
             sender: txn.sender(),
             authentication_proof: txn.authenticator().sender().authentication_proof(),
@@ -57,7 +57,7 @@ impl TransactionMetadata {
                 .map(|signer| signer.authentication_proof()),
             max_gas_amount: txn.max_gas_amount().into(),
             gas_unit_price: txn.gas_unit_price().into(),
-            transaction_size: (txn.raw_txn_bytes_len() as u64).into(),
+            transaction_size: (txn_size as u64).into(),
             expiration_timestamp_secs: txn.expiration_timestamp_secs(),
             chain_id: txn.chain_id(),
             script_hash: if let Ok(TransactionExecutableRef::Script(s)) =

--- a/aptos-move/e2e-move-tests/src/tests/cryptoalgebra.rs
+++ b/aptos-move/e2e-move-tests/src/tests/cryptoalgebra.rs
@@ -9,7 +9,10 @@ use aptos_types::{
 
 fn deep_type_tag(harness: &mut MoveHarness) -> TransactionStatus {
     let account = harness.new_account_at(AccountAddress::from_hex_literal("0x42").unwrap());
-    assert_success!(harness.publish_package(&account, &common::test_dir_path("cryptoalgebra.data/large_type_tag"),));
+    assert_success!(harness.publish_package(
+        &account,
+        &common::test_dir_path("cryptoalgebra.data/large_type_tag"),
+    ));
     harness.run_entry_function(
         &account,
         str::parse("0x42::test::main").unwrap(),
@@ -31,10 +34,8 @@ fn test_deep_type_tag() {
     h.new_epoch();
     let result = deep_type_tag(&mut h);
 
-    assert!(
-        matches!(
-            result,
-            TransactionStatus::Keep(ExecutionStatus::MoveAbort { .. })
-        ),
-    );
+    assert!(matches!(
+        result,
+        TransactionStatus::Keep(ExecutionStatus::MoveAbort { .. })
+    ),);
 }

--- a/aptos-move/framework/src/natives/cryptography/algebra/hash_to_structure.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/hash_to_structure.rs
@@ -4,7 +4,9 @@
 use crate::{
     abort_unless_feature_flag_enabled,
     natives::cryptography::algebra::{
-        AlgebraContext, E_TOO_MUCH_MEMORY_USED, HashToStructureSuite, MEMORY_LIMIT_IN_BYTES, MOVE_ABORT_CODE_NOT_IMPLEMENTED, MOVE_ABORT_CODE_TYPE_TAG_CONVERSION_FAILED, Structure
+        AlgebraContext, HashToStructureSuite, Structure, E_TOO_MUCH_MEMORY_USED,
+        MEMORY_LIMIT_IN_BYTES, MOVE_ABORT_CODE_NOT_IMPLEMENTED,
+        MOVE_ABORT_CODE_TYPE_TAG_CONVERSION_FAILED,
     },
     store_element, structure_from_ty_arg,
 };
@@ -49,11 +51,11 @@ fn suite_from_ty_arg(
 ) -> SafeNativeResult<Option<HashToStructureSuite>> {
     if context.timed_feature_enabled(TimedFeatureFlag::FixCryptoAlgebraNativesTypeTagConversion) {
         if let Ok(type_tag) = context.type_to_type_tag(ty) {
-            return Ok(HashToStructureSuite::try_from(type_tag).ok());
+            Ok(HashToStructureSuite::try_from(type_tag).ok())
         } else {
-            return Err(SafeNativeError::Abort {
+            Err(SafeNativeError::Abort {
                 abort_code: MOVE_ABORT_CODE_TYPE_TAG_CONVERSION_FAILED,
-            });
+            })
         }
     } else {
         let type_tag = context.type_to_type_tag(ty).unwrap();

--- a/types/src/on_chain_config/timed_features.rs
+++ b/types/src/on_chain_config/timed_features.rs
@@ -26,6 +26,9 @@ pub enum TimedFeatureFlag {
 
     /// Fixes the bug in deep type tag conversion.
     FixCryptoAlgebraNativesTypeTagConversion,
+
+    /// Uses full transaction size when computing transaction metadata.
+    UseFullTransactionSizeForTransactionMetadata,
 }
 
 /// Representation of features that are gated by the block timestamps.
@@ -139,6 +142,9 @@ impl TimedFeatureFlag {
             (FixCryptoAlgebraNativesTypeTagConversion, _) => {
                 Utc.with_ymd_and_hms(1970, 1, 1, 1, 0, 0).unwrap()
             },
+
+            // Irrelevant for us except for testing
+            (UseFullTransactionSizeForTransactionMetadata, _) => BEGINNING_OF_TIME,
 
             // For chains other than testnet and mainnet, a timed feature is considered enabled from
             // the very beginning, if left unspecified.


### PR DESCRIPTION
## Description

Before this fix, transaction_size in TransactionMetadata was computed as only the RawTransaction BCS bytes — the authenticator was completely invisible to gas accounting.

This means:

- Size limit checks only counted the raw payload, not the authenticator bytes.
- Intrinsic gas charging and IO gas charging only charged for raw payload bytes — authenticator bytes were free.

We now also count for the authenticator size.


## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine
