### PR TITLE
Movement CLI: JSON output for AI agents (--output json, MOVEMENT_OUTPUT env var)

### DIFF
--- a/crates/aptos/CONTRIBUTING.md
+++ b/crates/aptos/CONTRIBUTING.md
@@ -243,13 +243,20 @@ still having output converted for the total CLI.
 It's an anti-pattern to `panic`, please avoid panicking, and instead provide `CliError` or `CliError` conversion for the
 current types.
 
-All output from the CLI should use `eprintln!()`, rather than `println!()`.  `stdout` is reserved for the JSON output at
-the end of the command, `stderr` is used for the rest of the output.
+**Streams:** `main` prints the final JSON envelope to **stdout** (success and error strings from `to_common_result`).
+Prefer **stderr** for diagnostics, progress, and prompts so the envelope stays the primary stdout payload. For human-only
+text (progress, tables, prompts that are not part of the serialized result), use the `human_println!` / `human_eprintln!`
+macros in `common/cli_output.rs` so **`--output json` / `MOVEMENT_OUTPUT=json`** can suppress them. Use raw `eprintln!` /
+`println!` only when output must appear regardless of mode (e.g. interactive prompts, hardware-wallet instructions, large
+listings directed to stderr, or error context before returning `Err`). Avoid raw `println!` for incidental chatter.
 
 ## Agent and automation output
 
 - **Global flags:** `movement --output json …` or environment variable `MOVEMENT_OUTPUT=json` set the CLI to machine-oriented mode (CLI flag wins when both are set). Default is `human` and preserves historical behavior (pretty JSON envelope, terminal-oriented formatting).
-- **Envelope:** Serialized commands print a single JSON document to stdout: either `{"Result":…}` or `{"Error":…}` (see `to_common_result` in `common/utils.rs`). In `json` mode the document is compact and auxiliary human messages avoid stdout where feasible.
+- **Envelope:** Serialized commands print a single JSON document to stdout: either `{"Result":…}` or `{"Error":…}` (see
+  `to_common_result` in `common/utils.rs`). Integrators should **parse stdout** for that document and use the **process
+  exit code**; treat **stderr** as ancillary unless a command documents otherwise. In `json` mode the document is compact
+  and auxiliary human messages avoid stdout where feasible.
 - **Explorer links:** On successful submission paths, `TransactionSummary` may include `explorer_url` so automation does not need to parse stderr.
 - **Schema:** `movement meta commands-schema` emits a JSON description of the command tree (names, arguments, help text).
 - **Dry-run:** Transaction-accepting flows that use `TransactionOptions` support `--dry-run` to simulate without submitting.

--- a/crates/aptos/CONTRIBUTING.md
+++ b/crates/aptos/CONTRIBUTING.md
@@ -245,3 +245,12 @@ current types.
 
 All output from the CLI should use `eprintln!()`, rather than `println!()`.  `stdout` is reserved for the JSON output at
 the end of the command, `stderr` is used for the rest of the output.
+
+## Agent and automation output
+
+- **Global flags:** `movement --output json …` or environment variable `MOVEMENT_OUTPUT=json` set the CLI to machine-oriented mode (CLI flag wins when both are set). Default is `human` and preserves historical behavior (pretty JSON envelope, terminal-oriented formatting).
+- **Envelope:** Serialized commands print a single JSON document to stdout: either `{"Result":…}` or `{"Error":…}` (see `to_common_result` in `common/utils.rs`). In `json` mode the document is compact and auxiliary human messages avoid stdout where feasible.
+- **Explorer links:** On successful submission paths, `TransactionSummary` may include `explorer_url` so automation does not need to parse stderr.
+- **Schema:** `movement meta commands-schema` emits a JSON description of the command tree (names, arguments, help text).
+- **Dry-run:** Transaction-accepting flows that use `TransactionOptions` support `--dry-run` to simulate without submitting.
+- **Destructive confirmation:** Non-interactive replacement of sensitive files uses explicit phrases documented on the relevant flags (e.g. genesis `--confirm-overwrite`, localnet `--destructive-confirm`), in addition to existing `--assume-yes`.

--- a/crates/aptos/README.md
+++ b/crates/aptos/README.md
@@ -3,3 +3,5 @@
 The `movement` tool is a command line interface (CLI) for debugging, development, and node operation.
 
 See [Movement CLI Documentation](https://docs.movementnetwork.xyz/) for how to install the `movement` CLI tool and how to use it.
+
+**Automation:** use `--output json` or env `MOVEMENT_OUTPUT=json` for compact JSON on stdout; run `movement meta commands-schema` for a machine-readable command tree. Contributor-oriented details are in [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -36,6 +36,6 @@ impl CliCommand<TransactionSummary> for CreateAccount {
         self.txn_options
             .submit_transaction(aptos_stdlib::aptos_account_create_account(address))
             .await
-            .map(TransactionSummary::from)
+            .map(|t| self.txn_options.summarize_submitted_transaction(t))
     }
 }

--- a/crates/aptos/src/account/create_resource_account.rs
+++ b/crates/aptos/src/account/create_resource_account.rs
@@ -80,12 +80,16 @@ impl CliCommand<CreateResourceAccountSummary> for CreateResourceAccount {
         } else {
             vec![]
         };
-        self.txn_options
+        let txn = self
+            .txn_options
             .submit_transaction(resource_account_create_resource_account(
                 self.seed_args.seed()?,
                 authentication_key,
             ))
-            .await
-            .map(CreateResourceAccountSummary::from)
+            .await?;
+        let mut summary = CreateResourceAccountSummary::from(txn);
+        self.txn_options
+            .attach_explorer_url(&mut summary.transaction_summary);
+        Ok(summary)
     }
 }

--- a/crates/aptos/src/account/key_rotation.rs
+++ b/crates/aptos/src/account/key_rotation.rs
@@ -1,11 +1,15 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::types::{
-    account_address_from_auth_key, account_address_from_public_key, AuthenticationKeyInputOptions,
-    CliCommand, CliConfig, CliError, CliTypedResult, ConfigSearchMode, EncodingOptions,
-    ExtractEd25519PublicKey, HardwareWalletOptions, ParseEd25519PrivateKey, ProfileConfig,
-    ProfileOptions, PublicKeyInputOptions, RestOptions, TransactionOptions, TransactionSummary,
+use crate::{
+    common::types::{
+        account_address_from_auth_key, account_address_from_public_key,
+        AuthenticationKeyInputOptions, CliCommand, CliConfig, CliError, CliTypedResult,
+        ConfigSearchMode, EncodingOptions, ExtractEd25519PublicKey, HardwareWalletOptions,
+        ParseEd25519PrivateKey, ProfileConfig, ProfileOptions, PublicKeyInputOptions, RestOptions,
+        TransactionOptions, TransactionSummary,
+    },
+    human_eprintln,
 };
 use aptos_cached_packages::aptos_stdlib;
 use aptos_crypto::{
@@ -248,7 +252,7 @@ impl CliCommand<RotateSummary> for RotateKey {
         if current_derivation_path.is_some() {
             eprintln!("Approve transaction on your Ledger device");
         };
-        let txn_summary = self
+        let txn = self
             .txn_options
             .submit_transaction(aptos_stdlib::account_rotate_authentication_key(
                 0,
@@ -260,12 +264,12 @@ impl CliCommand<RotateSummary> for RotateKey {
                     .to_vec(),
                 rotation_proof_signed_by_new_private_key.to_bytes().to_vec(),
             ))
-            .await
-            .map(TransactionSummary::from)?;
+            .await?;
+        let txn_summary = self.txn_options.summarize_submitted_transaction_ref(&txn);
 
         let txn_string = serde_json::to_string_pretty(&txn_summary)
             .map_err(|err| CliError::UnableToParse("transaction summary", err.to_string()))?;
-        eprintln!("{}", txn_string);
+        human_eprintln!("{}", txn_string);
 
         if let Some(txn_success) = txn_summary.success {
             if !txn_success {

--- a/crates/aptos/src/account/multisig_account.rs
+++ b/crates/aptos/src/account/multisig_account.rs
@@ -88,7 +88,8 @@ impl CliCommand<CreateSummary> for Create {
     }
 
     async fn execute(self) -> CliTypedResult<CreateSummary> {
-        self.txn_options
+        let txn = self
+            .txn_options
             .submit_transaction(aptos_stdlib::multisig_account_create_with_owners(
                 self.additional_owners,
                 self.num_signatures_required,
@@ -96,8 +97,11 @@ impl CliCommand<CreateSummary> for Create {
                 vec![],
                 vec![],
             ))
-            .await
-            .map(CreateSummary::from)
+            .await?;
+        let mut summary = CreateSummary::from(txn);
+        self.txn_options
+            .attach_explorer_url(&mut summary.transaction_summary);
+        Ok(summary)
     }
 }
 
@@ -142,7 +146,7 @@ impl CliCommand<TransactionSummary> for CreateTransaction {
         self.txn_options
             .submit_transaction(transaction_payload)
             .await
-            .map(|inner| inner.into())
+            .map(|t| self.txn_options.summarize_submitted_transaction(t))
     }
 }
 
@@ -251,7 +255,7 @@ impl CliCommand<TransactionSummary> for Approve {
                 self.multisig_account_with_sequence_number.sequence_number,
             ))
             .await
-            .map(|inner| inner.into())
+            .map(|t| self.txn_options.summarize_submitted_transaction(t))
     }
 }
 
@@ -283,7 +287,7 @@ impl CliCommand<TransactionSummary> for Reject {
                 self.multisig_account_with_sequence_number.sequence_number,
             ))
             .await
-            .map(|inner| inner.into())
+            .map(|t| self.txn_options.summarize_submitted_transaction(t))
     }
 }
 
@@ -310,7 +314,7 @@ impl CliCommand<TransactionSummary> for Execute {
                 transaction_payload: None,
             }))
             .await
-            .map(|inner| inner.into())
+            .map(|t| self.txn_options.summarize_submitted_transaction(t))
     }
 }
 
@@ -330,14 +334,21 @@ impl CliCommand<TransactionSummary> for ExecuteWithPayload {
     }
 
     async fn execute(self) -> CliTypedResult<TransactionSummary> {
-        self.execute
-            .txn_options
+        let ExecuteWithPayload {
+            execute:
+                Execute {
+                    multisig_account,
+                    txn_options,
+                },
+            entry_function_args,
+        } = self;
+        txn_options
             .submit_transaction(TransactionPayload::Multisig(Multisig {
-                multisig_address: self.execute.multisig_account.multisig_address,
-                transaction_payload: Some(self.entry_function_args.try_into()?),
+                multisig_address: multisig_account.multisig_address,
+                transaction_payload: Some(entry_function_args.try_into()?),
             }))
             .await
-            .map(|inner| inner.into())
+            .map(|t| txn_options.summarize_submitted_transaction(t))
     }
 }
 
@@ -365,6 +376,6 @@ impl CliCommand<TransactionSummary> for ExecuteReject {
                 self.multisig_account.multisig_address,
             ))
             .await
-            .map(|inner| inner.into())
+            .map(|t| self.txn_options.summarize_submitted_transaction(t))
     }
 }

--- a/crates/aptos/src/common/cli_output.rs
+++ b/crates/aptos/src/common/cli_output.rs
@@ -1,0 +1,99 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Global CLI output mode (human vs machine-oriented JSON).
+
+use clap::{Parser, ValueEnum};
+use std::sync::OnceLock;
+
+static CLI_OUTPUT_MODE: OnceLock<CliOutputMode> = OnceLock::new();
+
+/// How the Movement CLI formats its primary envelope and auxiliary output.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "lower")]
+pub enum CliOutputMode {
+    /// Default: pretty-printed JSON envelope, terminal-oriented escapes, progress on stderr.
+    #[default]
+    Human,
+    /// Automation / agents: compact JSON envelope; avoid printing non-result text to stdout.
+    Json,
+}
+
+impl CliOutputMode {
+    /// Install resolved mode for this process (typically from [`MovementCli`](crate::MovementCli)).
+    pub fn install(mode: Self) {
+        let _ = CLI_OUTPUT_MODE.set(mode);
+    }
+
+    /// Mode used when [`install`](Self::install) was never called (e.g. unit tests, library use).
+    #[inline]
+    pub fn current() -> Self {
+        CLI_OUTPUT_MODE.get().copied().unwrap_or(Self::Human)
+    }
+
+    #[inline]
+    pub fn is_json_agent_mode(self) -> bool {
+        matches!(self, Self::Json)
+    }
+}
+
+/// Options parsed on every invocation (global arguments).
+#[derive(Parser, Debug, Clone)]
+pub struct GlobalOptions {
+    /// Primary output style. Overridden by the `MOVEMENT_OUTPUT` environment variable when this
+    /// flag is omitted (clap: explicit CLI wins over env).
+    #[clap(
+        long,
+        global = true,
+        value_enum,
+        value_name = "MODE",
+        env = "MOVEMENT_OUTPUT"
+    )]
+    pub output: Option<CliOutputMode>,
+}
+
+impl GlobalOptions {
+    #[inline]
+    pub fn resolved_output_mode(&self) -> CliOutputMode {
+        self.output.unwrap_or(CliOutputMode::Human)
+    }
+}
+
+/// Print to stdout only in human mode so agent/json mode can reserve stdout for the JSON envelope.
+#[macro_export]
+macro_rules! human_println {
+    ($($arg:tt)*) => {{
+        if !$crate::common::cli_output::CliOutputMode::current().is_json_agent_mode() {
+            println!($($arg)*);
+        }
+    }};
+}
+
+/// Like [`human_println`] but without a trailing newline (`print!` vs `println!`).
+#[macro_export]
+macro_rules! human_print {
+    ($($arg:tt)*) => {{
+        if !$crate::common::cli_output::CliOutputMode::current().is_json_agent_mode() {
+            print!($($arg)*);
+        }
+    }};
+}
+
+/// Progress on stderr; hidden in agent/json mode to keep stderr minimal for log aggregation.
+#[macro_export]
+macro_rules! human_eprintln {
+    ($($arg:tt)*) => {{
+        if !$crate::common::cli_output::CliOutputMode::current().is_json_agent_mode() {
+            eprintln!($($arg)*);
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! human_eprint {
+    ($($arg:tt)*) => {{
+        if !$crate::common::cli_output::CliOutputMode::current().is_json_agent_mode() {
+            eprint!($($arg)*);
+        }
+    }};
+}

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -15,6 +15,7 @@ use crate::{
             strip_private_key_prefix,
         },
     },
+    human_eprintln,
 };
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, ValidCryptoMaterialStringExt};
 use aptos_ledger;
@@ -101,11 +102,11 @@ impl CliCommand<()> for InitTool {
         } else {
             ProfileConfig::default()
         };
-        eprintln!("Configuring for profile {}", profile_name);
+        human_eprintln!("Configuring for profile {}", profile_name);
 
         // Choose a network
         let network = if let Some(network) = self.network {
-            eprintln!("Configuring for network {:?}", network);
+            human_eprintln!("Configuring for network {:?}", network);
             network
         } else {
             eprintln!(
@@ -114,7 +115,7 @@ impl CliCommand<()> for InitTool {
             let input = read_line("network")?;
             let input = input.trim();
             if input.is_empty() {
-                eprintln!("No network given, using testnet...");
+                human_eprintln!("No network given, using testnet...");
                 Network::Testnet
             } else {
                 Network::from_str(input)?
@@ -208,7 +209,7 @@ impl CliCommand<()> for InitTool {
                 .private_key_options
                 .extract_private_key_cli(self.encoding_options.encoding)?
             {
-                eprintln!("Using command line argument for private key");
+                human_eprintln!("Using command line argument for private key");
                 key
             } else {
                 eprintln!("Enter your private key as a hex literal (0x...) [Current: {} | No input: Generate new key (or keep one if present)]", profile_config.private_key.as_ref().map(|_| "Redacted").unwrap_or("None"));
@@ -216,10 +217,10 @@ impl CliCommand<()> for InitTool {
                 let input = input.trim();
                 if input.is_empty() {
                     if let Some(key) = profile_config.private_key {
-                        eprintln!("No key given, keeping existing key...");
+                        human_eprintln!("No key given, keeping existing key...");
                         key
                     } else {
-                        eprintln!("No key given, generating key...");
+                        human_eprintln!("No key given, generating key...");
                         self.rng_args
                             .key_generator()?
                             .generate_ed25519_private_key()
@@ -291,11 +292,12 @@ impl CliCommand<()> for InitTool {
 
         if let Some(faucet_url) = maybe_faucet_url {
             if funded {
-                eprintln!("Account {} has been already funded onchain", address);
+                human_eprintln!("Account {} has been already funded onchain", address);
             } else {
-                eprintln!(
+                human_eprintln!(
                     "Account {} is not funded, funding it with {} Octas",
-                    address, NUM_DEFAULT_OCTAS
+                    address,
+                    NUM_DEFAULT_OCTAS
                 );
                 fund_account(
                     client,
@@ -306,14 +308,14 @@ impl CliCommand<()> for InitTool {
                     NUM_DEFAULT_OCTAS,
                 )
                 .await?;
-                eprintln!("Account {} funded successfully", address);
+                human_eprintln!("Account {} funded successfully", address);
             }
         } else if funded {
-            eprintln!("Account {} has been already funded onchain", address);
+            human_eprintln!("Account {} has been already funded onchain", address);
         } else if network == Network::Mainnet || network == Network::Testnet {
             // Do nothing, we print information later.
         } else {
-            eprintln!("Account {} has been initialized locally, but you must transfer coins to it to send transactions", address);
+            human_eprintln!("Account {} has been initialized locally, but you must transfer coins to it to send transactions", address);
         }
 
         // Ensure the loaded config has profiles setup for a possible empty file
@@ -332,7 +334,7 @@ impl CliCommand<()> for InitTool {
             .profile_name()
             .unwrap_or(DEFAULT_PROFILE);
 
-        eprintln!(
+        human_eprintln!(
             "\n---\nMovement CLI is now set up for account {} as profile {}!\n See the account here: {}\n 
             Run `movement --help` for more information about commands. \n 
             Visit https://faucet.movementlabs.xyz to use the testnet faucet.",
@@ -350,7 +352,7 @@ impl InitTool {
     fn custom_network(&self, profile_config: &mut ProfileConfig) -> CliTypedResult<()> {
         // Rest Endpoint
         let rest_url = if let Some(ref rest_url) = self.rest_url {
-            eprintln!("Using command line argument for rest URL {}", rest_url);
+            human_eprintln!("Using command line argument for rest URL {}", rest_url);
             Some(rest_url.to_string())
         } else {
             let current = profile_config.rest_url.as_deref();
@@ -362,10 +364,10 @@ impl InitTool {
             let input = input.trim();
             if input.is_empty() {
                 if let Some(current) = current {
-                    eprintln!("No rest url given, keeping the existing url...");
+                    human_eprintln!("No rest url given, keeping the existing url...");
                     Some(current.to_string())
                 } else {
-                    eprintln!("No rest url given, exiting...");
+                    human_eprintln!("No rest url given, exiting...");
                     return Err(CliError::AbortedError);
                 }
             } else {
@@ -380,10 +382,10 @@ impl InitTool {
 
         // Faucet Endpoint
         let faucet_url = if self.skip_faucet {
-            eprintln!("Not configuring a faucet because --skip-faucet was provided");
+            human_eprintln!("Not configuring a faucet because --skip-faucet was provided");
             None
         } else if let Some(ref faucet_url) = self.faucet_options.faucet_url {
-            eprintln!("Using command line argument for faucet URL {}", faucet_url);
+            human_eprintln!("Using command line argument for faucet URL {}", faucet_url);
             Some(faucet_url.to_string())
         } else {
             let current = profile_config.faucet_url.as_deref();
@@ -396,14 +398,14 @@ impl InitTool {
             let input = input.trim();
             if input.is_empty() {
                 if let Some(current) = current {
-                    eprintln!("No faucet url given, keeping the existing url...");
+                    human_eprintln!("No faucet url given, keeping the existing url...");
                     Some(current.to_string())
                 } else {
-                    eprintln!("No faucet url given, skipping faucet...");
+                    human_eprintln!("No faucet url given, skipping faucet...");
                     None
                 }
             } else if input.to_lowercase() == "skip" {
-                eprintln!("Skipping faucet...");
+                human_eprintln!("Skipping faucet...");
                 None
             } else {
                 Some(

--- a/crates/aptos/src/common/local_simulation.rs
+++ b/crates/aptos/src/common/local_simulation.rs
@@ -1,7 +1,10 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::types::{CliError, CliTypedResult};
+use crate::{
+    common::types::{CliError, CliTypedResult},
+    human_println,
+};
 use aptos_crypto::HashValue;
 use aptos_gas_profiling::FrameName;
 use aptos_move_debugger::aptos_debugger::AptosDebugger;
@@ -101,8 +104,8 @@ pub fn benchmark_transaction_using_debugger(
         times[n / 2]
     };
 
-    println!("Running time (cold code cache): {:?}", time_cold);
-    println!("Running time (warm code cache): {:?}", time_warm);
+    human_println!("Running time (cold code cache): {:?}", time_cold);
+    human_println!("Running time (warm code cache): {:?}", time_warm);
 
     Ok((vm_status, vm_output))
 }
@@ -142,7 +145,7 @@ pub fn profile_transaction_using_debugger(
     let path = Path::new("gas-profiling").join(raw_file_name);
     gas_log.generate_html_report(&path, format!("Gas Report - {}", human_readable_name))?;
 
-    println!("Gas report saved to {}.", path.display());
+    human_println!("Gas report saved to {}.", path.display());
 
     Ok((vm_status, vm_output))
 }

--- a/crates/aptos/src/common/mod.rs
+++ b/crates/aptos/src/common/mod.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod cli_output;
 pub mod init;
 pub mod local_simulation;
 pub mod transactions;

--- a/crates/aptos/src/common/transactions.rs
+++ b/crates/aptos/src/common/transactions.rs
@@ -1,14 +1,17 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::{
-    local_simulation,
-    types::{
-        AccountType, CliConfig, CliError, CliTypedResult, ConfigSearchMode, EncodingOptions,
-        ExtractEd25519PublicKey, GasOptions, PrivateKeyInputOptions, ProfileOptions, PromptOptions,
-        RestOptions, TransactionSummary, ACCEPTED_CLOCK_SKEW_US, US_IN_SECS,
+use crate::{
+    common::{
+        local_simulation,
+        types::{
+            AccountType, CliConfig, CliError, CliTypedResult, ConfigSearchMode, EncodingOptions,
+            ExtractEd25519PublicKey, GasOptions, PrivateKeyInputOptions, ProfileOptions,
+            PromptOptions, RestOptions, TransactionSummary, ACCEPTED_CLOCK_SKEW_US, US_IN_SECS,
+        },
+        utils::{get_account_with_state, get_sequence_number},
     },
-    utils::{get_account_with_state, get_sequence_number},
+    human_eprintln, human_println,
 };
 use aptos_api_types::ViewFunction;
 use aptos_crypto::{
@@ -162,7 +165,7 @@ impl TxnOptions {
         // Warn local user that clock is skewed behind the blockchain.
         // There will always be a little lag from real time to blockchain time
         if now_usecs < state.timestamp_usecs - ACCEPTED_CLOCK_SKEW_US {
-            eprintln!("Local clock is is skewed from blockchain clock.  Clock is more than {} seconds behind the blockchain {}", ACCEPTED_CLOCK_SKEW_US, state.timestamp_usecs / US_IN_SECS );
+            human_eprintln!("Local clock is is skewed from blockchain clock.  Clock is more than {} seconds behind the blockchain {}", ACCEPTED_CLOCK_SKEW_US, state.timestamp_usecs / US_IN_SECS );
         }
         let expiration_time_secs = now + self.gas_options.expiration_secs;
 
@@ -205,6 +208,7 @@ impl TxnOptions {
             timestamp_us: None,
             version: Some(simulated_txn.version),
             vm_status: Some(format!("{:?}", simulated_txn.info.status())), // TODO: add proper status
+            explorer_url: None,
         })
     }
 
@@ -281,6 +285,7 @@ impl TxnOptions {
             timestamp_us: None,
             version: Some(version), // The transaction is not committed so there is no new version.
             vm_status: Some(vm_status.to_string()),
+            explorer_url: None,
         })
     }
 
@@ -289,8 +294,8 @@ impl TxnOptions {
         &self,
         payload: TransactionPayload,
     ) -> CliTypedResult<TransactionSummary> {
-        println!();
-        println!("Simulating transaction locally...");
+        human_println!();
+        human_println!("Simulating transaction locally...");
 
         self.simulate_using_debugger(payload, local_simulation::run_transaction_using_debugger)
             .await
@@ -303,8 +308,8 @@ impl TxnOptions {
         &self,
         payload: TransactionPayload,
     ) -> CliTypedResult<TransactionSummary> {
-        println!();
-        println!("Benchmarking transaction locally...");
+        human_println!();
+        human_println!("Benchmarking transaction locally...");
 
         self.simulate_using_debugger(
             payload,
@@ -318,8 +323,8 @@ impl TxnOptions {
         &self,
         payload: TransactionPayload,
     ) -> CliTypedResult<TransactionSummary> {
-        println!();
-        println!("Simulating transaction locally using the gas profiler...");
+        human_println!();
+        human_println!("Simulating transaction locally using the gas profiler...");
 
         self.simulate_using_debugger(
             payload,

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -17,6 +17,7 @@ use crate::{
     },
     config::GlobalConfig,
     genesis::git::from_yaml,
+    human_eprintln, human_println,
     move_tool::{ArgWithType, FunctionArgType, MemberId},
 };
 use anyhow::{bail, Context};
@@ -442,7 +443,7 @@ impl CliConfig {
         // As a cleanup, delete the old if it exists
         let legacy_config_file = aptos_folder.join(LEGACY_CONFIG_FILE);
         if legacy_config_file.exists() {
-            eprintln!("Removing legacy config file {}", LEGACY_CONFIG_FILE);
+            human_eprintln!("Removing legacy config file {}", LEGACY_CONFIG_FILE);
             let _ = std::fs::remove_file(legacy_config_file);
         }
         Ok(())
@@ -1504,6 +1505,8 @@ pub struct TransactionSummary {
     pub version: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vm_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub explorer_url: Option<String>,
 }
 
 impl From<Transaction> for TransactionSummary {
@@ -1525,6 +1528,7 @@ impl From<&Transaction> for TransactionSummary {
                 version: None,
                 vm_status: None,
                 timestamp_us: None,
+                explorer_url: None,
             },
             Transaction::UserTransaction(txn) => TransactionSummary {
                 transaction_hash: txn.info.hash,
@@ -1537,6 +1541,7 @@ impl From<&Transaction> for TransactionSummary {
                 sequence_number: Some(txn.request.sequence_number.0),
                 timestamp_us: Some(txn.timestamp.0),
                 pending: None,
+                explorer_url: None,
             },
             Transaction::GenesisTransaction(txn) => TransactionSummary {
                 transaction_hash: txn.info.hash,
@@ -1549,6 +1554,7 @@ impl From<&Transaction> for TransactionSummary {
                 pending: None,
                 sequence_number: None,
                 timestamp_us: None,
+                explorer_url: None,
             },
             Transaction::BlockMetadataTransaction(txn) => TransactionSummary {
                 transaction_hash: txn.info.hash,
@@ -1561,6 +1567,7 @@ impl From<&Transaction> for TransactionSummary {
                 gas_unit_price: None,
                 pending: None,
                 sequence_number: None,
+                explorer_url: None,
             },
             Transaction::StateCheckpointTransaction(txn) => TransactionSummary {
                 transaction_hash: txn.info.hash,
@@ -1573,6 +1580,7 @@ impl From<&Transaction> for TransactionSummary {
                 gas_unit_price: None,
                 pending: None,
                 sequence_number: None,
+                explorer_url: None,
             },
             Transaction::BlockEpilogueTransaction(txn) => TransactionSummary {
                 transaction_hash: txn.info.hash,
@@ -1585,6 +1593,7 @@ impl From<&Transaction> for TransactionSummary {
                 gas_unit_price: None,
                 pending: None,
                 sequence_number: None,
+                explorer_url: None,
             },
             Transaction::ValidatorTransaction(txn) => TransactionSummary {
                 transaction_hash: txn.transaction_info().hash,
@@ -1597,6 +1606,7 @@ impl From<&Transaction> for TransactionSummary {
                 timestamp_us: Some(txn.timestamp().0),
                 version: Some(txn.transaction_info().version.0),
                 vm_status: Some(txn.transaction_info().vm_status.clone()),
+                explorer_url: None,
             },
         }
     }
@@ -1781,9 +1791,62 @@ pub struct TransactionOptions {
     /// flamegraphs that reflect the gas usage.
     #[clap(long)]
     pub(crate) profile_gas: bool,
+
+    /// Simulate the transaction on the connected network and return results without submitting.
+    #[clap(long)]
+    pub dry_run: bool,
 }
 
 impl TransactionOptions {
+    /// Explorer network hint for transaction links, inferred from the profile when possible.
+    pub fn explorer_network(&self) -> Option<Network> {
+        self.profile_options.profile().ok().and_then(|profile| {
+            if let Some(network) = profile.network {
+                Some(network)
+            } else {
+                match profile.rest_url {
+                    None => None,
+                    Some(url) => {
+                        if url.contains("mainnet") {
+                            Some(Network::Mainnet)
+                        } else if url.contains("testnet") {
+                            Some(Network::Testnet)
+                        } else if url.contains("devnet") {
+                            Some(Network::Devnet)
+                        } else if url.contains("localhost") || url.contains("127.0.0.1") {
+                            Some(Network::Local)
+                        } else {
+                            None
+                        }
+                    },
+                }
+            }
+        })
+    }
+
+    /// Build a [`TransactionSummary`] after submission (or final state), including an explorer URL.
+    pub fn summarize_submitted_transaction(&self, transaction: Transaction) -> TransactionSummary {
+        self.summarize_submitted_transaction_ref(&transaction)
+    }
+
+    /// [`summarize_submitted_transaction`](Self::summarize_submitted_transaction) for a borrowed transaction.
+    pub fn summarize_submitted_transaction_ref(
+        &self,
+        transaction: &Transaction,
+    ) -> TransactionSummary {
+        let mut summary = TransactionSummary::from(transaction);
+        self.attach_explorer_url(&mut summary);
+        summary
+    }
+
+    /// Fills [`TransactionSummary::explorer_url`] from this transaction context.
+    pub fn attach_explorer_url(&self, summary: &mut TransactionSummary) {
+        summary.explorer_url = Some(explorer_transaction_link(
+            summary.transaction_hash.into(),
+            self.explorer_network(),
+        ));
+    }
+
     /// Builds a rest client
     pub fn rest_client(&self) -> CliTypedResult<Client> {
         self.rest_options.client(&self.profile_options)
@@ -1897,7 +1960,7 @@ impl TransactionOptions {
         // Warn local user that clock is skewed behind the blockchain.
         // There will always be a little lag from real time to blockchain time
         if now_usecs < state.timestamp_usecs - ACCEPTED_CLOCK_SKEW_US {
-            eprintln!("Local clock is is skewed from blockchain clock.  Clock is more than {} seconds behind the blockchain {}", ACCEPTED_CLOCK_SKEW_US, state.timestamp_usecs / US_IN_SECS );
+            human_eprintln!("Local clock is is skewed from blockchain clock.  Clock is more than {} seconds behind the blockchain {}", ACCEPTED_CLOCK_SKEW_US, state.timestamp_usecs / US_IN_SECS );
         }
         let expiration_time_secs = now + self.gas_options.expiration_secs;
 
@@ -1991,36 +2054,26 @@ impl TransactionOptions {
             Err(err) => return Err(err),
         };
 
+        if self.dry_run {
+            let txns = client
+                .simulate_with_gas_estimation(&transaction, true, false)
+                .await
+                .map_err(|err| CliError::ApiError(err.to_string()))?
+                .into_inner();
+            let user_txn = txns.into_iter().next().ok_or_else(|| {
+                CliError::UnexpectedError("Empty simulation response from dry-run".to_string())
+            })?;
+            return Ok(Transaction::UserTransaction(user_txn));
+        }
+
         // Submit the transaction, printing out a useful transaction link
         client
             .submit_bcs(&transaction)
             .await
             .map_err(|err| CliError::ApiError(err.to_string()))?;
         let transaction_hash = transaction.clone().committed_hash();
-        let network = self.profile_options.profile().ok().and_then(|profile| {
-            if let Some(network) = profile.network {
-                Some(network)
-            } else {
-                // Approximate network from URL
-                match profile.rest_url {
-                    None => None,
-                    Some(url) => {
-                        if url.contains("mainnet") {
-                            Some(Network::Mainnet)
-                        } else if url.contains("testnet") {
-                            Some(Network::Testnet)
-                        } else if url.contains("devnet") {
-                            Some(Network::Devnet)
-                        } else if url.contains("localhost") || url.contains("127.0.0.1") {
-                            Some(Network::Local)
-                        } else {
-                            None
-                        }
-                    },
-                }
-            }
-        });
-        eprintln!(
+        let network = self.explorer_network();
+        human_eprintln!(
             "Transaction submitted: {}",
             explorer_transaction_link(transaction_hash, network)
         );
@@ -2105,6 +2158,7 @@ impl TransactionOptions {
             timestamp_us: None,
             version: Some(version), // The transaction is not comitted so there is no new version.
             vm_status: Some(vm_status.to_string()),
+            explorer_url: None,
         };
 
         Ok(summary)
@@ -2115,8 +2169,8 @@ impl TransactionOptions {
         &self,
         payload: TransactionPayload,
     ) -> CliTypedResult<TransactionSummary> {
-        println!();
-        println!("Simulating transaction locally...");
+        human_println!();
+        human_println!("Simulating transaction locally...");
 
         self.simulate_using_debugger(payload, local_simulation::run_transaction_using_debugger)
             .await
@@ -2129,8 +2183,8 @@ impl TransactionOptions {
         &self,
         payload: TransactionPayload,
     ) -> CliTypedResult<TransactionSummary> {
-        println!();
-        println!("Benchmarking transaction locally...");
+        human_println!();
+        human_println!("Benchmarking transaction locally...");
 
         self.simulate_using_debugger(
             payload,
@@ -2144,8 +2198,8 @@ impl TransactionOptions {
         &self,
         payload: TransactionPayload,
     ) -> CliTypedResult<TransactionSummary> {
-        println!();
-        println!("Simulating transaction locally using the gas profiler...");
+        human_println!();
+        human_println!("Simulating transaction locally using the gas profiler...");
 
         self.simulate_using_debugger(
             payload,

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     common::{
+        cli_output::CliOutputMode,
         init::Network,
         types::{
             account_address_from_public_key, CliError, CliTypedResult, PromptOptions,
@@ -28,10 +29,10 @@ use aptos_types::{
     transaction::{authenticator::AuthenticationKey, TransactionPayload},
 };
 use itertools::Itertools;
-use std::io::IsTerminal;
 use move_core_types::{account_address::AccountAddress, language_storage::CORE_CODE_ADDRESS};
 use reqwest::Url;
 use serde::{ser::Error, Deserialize, Deserializer, Serialize, Serializer};
+use std::io::IsTerminal;
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 use std::{
@@ -119,10 +120,15 @@ pub async fn to_common_result<T: Serialize>(
 
     let is_err = result.is_err();
     let result = ResultWrapper::<T>::from(result);
-    let string = serde_json::to_string_pretty(&result).unwrap();
+    let agent_json = CliOutputMode::current().is_json_agent_mode();
+    let string = if agent_json {
+        serde_json::to_string(&result).unwrap()
+    } else {
+        serde_json::to_string_pretty(&result).unwrap()
+    };
     // Unescape newlines and quotes so they render properly in terminal output
     // Both Ok and Err are printed to stdout in main.rs
-    let string = if std::io::stdout().is_terminal() {
+    let string = if !agent_json && std::io::stdout().is_terminal() {
         string.replace("\\n", "\n").replace("\\\"", "\"")
     } else {
         string
@@ -196,6 +202,36 @@ pub fn check_if_file_exists(file: &Path, prompt_options: PromptOptions) -> CliTy
     }
 
     Ok(())
+}
+
+/// Like [`check_if_file_exists`], but accepts an exact confirmation phrase for non-interactive use.
+pub fn check_if_file_exists_with_confirm(
+    file: &Path,
+    prompt_options: PromptOptions,
+    confirm_phrase: Option<&str>,
+    expected_phrase: &'static str,
+) -> CliTypedResult<()> {
+    if !file.exists() {
+        return Ok(());
+    }
+    if prompt_options.assume_yes {
+        return Ok(());
+    }
+    if let Some(phrase) = confirm_phrase {
+        if phrase == expected_phrase {
+            return Ok(());
+        }
+        return Err(CliError::CommandArgumentError(format!(
+            "`--confirm-overwrite` must be exactly `{expected_phrase}` when replacing an existing file"
+        )));
+    }
+    prompt_yes_with_override(
+        &format!(
+            "{:?} already exists, are you sure you want to overwrite it?",
+            file.as_os_str(),
+        ),
+        prompt_options,
+    )
 }
 
 pub fn prompt_yes_with_override(prompt: &str, prompt_options: PromptOptions) -> CliTypedResult<()> {
@@ -529,7 +565,7 @@ pub async fn profile_or_submit(
         txn_options_ref
             .submit_transaction(payload)
             .await
-            .map(TransactionSummary::from)
+            .map(|t| txn_options_ref.summarize_submitted_transaction(t))
     }
 }
 

--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -10,7 +10,7 @@ use crate::{
         utils::{create_dir_if_not_exist, current_dir, read_from_file, write_to_user_only_file},
     },
     genesis::git::{from_yaml, to_yaml},
-    Tool,
+    MovementCli,
 };
 use aptos_cli_common::generate_cli_completions;
 use aptos_crypto::ValidCryptoMaterialStringExt;
@@ -71,7 +71,7 @@ impl CliCommand<()> for GenerateShellCompletions {
     }
 
     async fn execute(self) -> CliTypedResult<()> {
-        generate_cli_completions::<Tool>("movement", self.shell, self.output_file.as_path())
+        generate_cli_completions::<MovementCli>("movement", self.shell, self.output_file.as_path())
             .map_err(|err| CliError::IO(self.output_file.display().to_string(), err))
     }
 }

--- a/crates/aptos/src/genesis/git.rs
+++ b/crates/aptos/src/genesis/git.rs
@@ -6,7 +6,7 @@ use crate::{
         types::{CliError, CliTypedResult},
         utils::{create_dir_if_not_exist, write_to_file},
     },
-    CliCommand,
+    human_eprintln, CliCommand,
 };
 use aptos_config::config::Token;
 use aptos_framework::ReleaseBundle;
@@ -168,7 +168,7 @@ impl Client {
                     ));
                 }
 
-                eprintln!("Reading {}", path.display());
+                human_eprintln!("Reading {}", path.display());
                 let mut file = std::fs::File::open(path.as_path())
                     .map_err(|e| CliError::IO(path.display().to_string(), e))?;
 

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -10,7 +10,7 @@ pub mod tools;
 use crate::{
     common::{
         types::{CliError, CliTypedResult, PromptOptions},
-        utils::{check_if_file_exists, dir_default_to_current, write_to_file},
+        utils::{check_if_file_exists_with_confirm, dir_default_to_current, write_to_file},
     },
     genesis::git::{
         Client, GitOptions, BALANCES_FILE, EMPLOYEE_VESTING_ACCOUNTS_FILE, LAYOUT_FILE,
@@ -48,6 +48,9 @@ use std::{
 
 const WAYPOINT_FILE: &str = "waypoint.txt";
 const GENESIS_FILE: &str = "genesis.blob";
+
+/// Pass this exact string to `--confirm-overwrite` to replace existing `genesis.blob` / `waypoint.txt` without `--assume-yes`.
+pub const CONFIRM_OVERWRITE_GENESIS_ARTIFACTS: &str = "overwrite-genesis-artifacts";
 
 /// Tool for setting up an Aptos chain Genesis transaction
 ///
@@ -97,6 +100,10 @@ pub struct GenerateGenesis {
     prompt_options: PromptOptions,
     #[clap(flatten)]
     git_options: GitOptions,
+
+    /// When output files already exist, pass exactly `overwrite-genesis-artifacts` to proceed without `--assume-yes`.
+    #[clap(long)]
+    confirm_overwrite: Option<String>,
 }
 
 #[async_trait]
@@ -109,8 +116,18 @@ impl CliCommand<Vec<PathBuf>> for GenerateGenesis {
         let output_dir = dir_default_to_current(self.output_dir.clone())?;
         let genesis_file = output_dir.join(GENESIS_FILE);
         let waypoint_file = output_dir.join(WAYPOINT_FILE);
-        check_if_file_exists(genesis_file.as_path(), self.prompt_options)?;
-        check_if_file_exists(waypoint_file.as_path(), self.prompt_options)?;
+        check_if_file_exists_with_confirm(
+            genesis_file.as_path(),
+            self.prompt_options,
+            self.confirm_overwrite.as_deref(),
+            CONFIRM_OVERWRITE_GENESIS_ARTIFACTS,
+        )?;
+        check_if_file_exists_with_confirm(
+            waypoint_file.as_path(),
+            self.prompt_options,
+            self.confirm_overwrite.as_deref(),
+            CONFIRM_OVERWRITE_GENESIS_ARTIFACTS,
+        )?;
 
         // Generate genesis and waypoint files
         let (genesis_bytes, waypoint) = if self.mainnet {

--- a/crates/aptos/src/genesis/tests.rs
+++ b/crates/aptos/src/genesis/tests.rs
@@ -87,24 +87,27 @@ async fn test_mainnet_genesis_e2e_flow() {
     // Create initial balances and employee vesting account files.
     let git_dir = git_options.local_repository_dir.as_ref().unwrap().as_path();
 
-    create_account_balances_file(PathBuf::from(git_dir), vec![
-        owner_identity1.account_address,
-        owner_identity2.account_address,
-        operator_identity1.account_address,
-        operator_identity2.account_address,
-        voter_identity1.account_address,
-        voter_identity2.account_address,
-        account_1,
-        account_2,
-        employee_1,
-        employee_2,
-        employee_3,
-        employee_4,
-        admin_identity1.account_address,
-        admin_identity2.account_address,
-        employee_operator_identity1.account_address,
-        employee_operator_identity2.account_address,
-    ])
+    create_account_balances_file(
+        PathBuf::from(git_dir),
+        vec![
+            owner_identity1.account_address,
+            owner_identity2.account_address,
+            operator_identity1.account_address,
+            operator_identity2.account_address,
+            voter_identity1.account_address,
+            voter_identity2.account_address,
+            account_1,
+            account_2,
+            employee_1,
+            employee_2,
+            employee_3,
+            employee_4,
+            admin_identity1.account_address,
+            admin_identity2.account_address,
+            employee_operator_identity1.account_address,
+            employee_operator_identity2.account_address,
+        ],
+    )
     .await;
     create_employee_vesting_accounts_file(
         PathBuf::from(git_dir),
@@ -215,6 +218,7 @@ async fn generate_genesis(git_options: GitOptions, output_dir: PathBuf, mainnet:
         git_options,
         output_dir: Some(output_dir),
         mainnet,
+        confirm_overwrite: None,
     };
     let _ = command.execute().await.unwrap();
 }

--- a/crates/aptos/src/governance/delegation_pool.rs
+++ b/crates/aptos/src/governance/delegation_pool.rs
@@ -1,7 +1,10 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::governance::{utils::*, *};
+use crate::{
+    governance::{utils::*, *},
+    human_println,
+};
 use clap::Subcommand;
 
 /// Tool for on-chain governance from delegation pools
@@ -80,7 +83,11 @@ impl CliCommand<ProposalSubmissionSummary> for SubmitProposal {
             ))
             .await?;
         let proposal_id = extract_proposal_id(&txn)?;
-        summaries.push(TransactionSummary::from(&txn));
+        summaries.push(
+            self.args
+                .txn_options
+                .summarize_submitted_transaction_ref(&txn),
+        );
         Ok(ProposalSubmissionSummary {
             proposal_id,
             txn_summaries: summaries,
@@ -162,7 +169,7 @@ impl CliCommand<Vec<TransactionSummary>> for SubmitVote {
                     vote,
                 ))
                 .await
-                .map(TransactionSummary::from)?,
+                .map(|t| self.args.txn_options.summarize_submitted_transaction(t))?,
         );
 
         Ok(summaries)
@@ -192,14 +199,16 @@ async fn delegation_pool_governance_precheck(
     if is_partial_governance_voting_enabled_for_delegation_pool(client, pool_address).await? {
         Ok(None)
     } else {
-        println!("Partial governance voting for delegation pool {} hasn't been enabled yet. Enabling it now...",
-                 pool_address);
-        let txn_summary = txn_options
+        human_println!(
+            "Partial governance voting for delegation pool {} hasn't been enabled yet. Enabling it now...",
+            pool_address
+        );
+        let txn = txn_options
             .submit_transaction(
                 aptos_stdlib::delegation_pool_enable_partial_governance_voting(pool_address),
             )
-            .await
-            .map(TransactionSummary::from)?;
+            .await?;
+        let txn_summary = txn_options.summarize_submitted_transaction_ref(&txn);
         Ok(Some(txn_summary))
     }
 }

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -15,6 +15,7 @@ use crate::{
         utils::prompt_yes_with_override,
     },
     governance::utils::*,
+    human_eprintln, human_println,
     move_tool::{FrameworkPackageArgs, IncludedArtifacts},
     CliCommand, CliResult,
 };
@@ -196,9 +197,10 @@ impl CliCommand<Vec<ProposalSummary>> for ListProposals {
             match bcs::from_bytes::<CreateProposalFullEvent>(event.event.event_data()) {
                 Ok(valid_event) => proposals.push(valid_event.into()),
                 Err(err) => {
-                    eprintln!(
+                    human_eprintln!(
                         "Event: {:?} cannot be parsed as a proposal: {:?}",
-                        event, err
+                        event,
+                        err
                     )
                 },
             }
@@ -331,9 +333,11 @@ impl SubmitProposalArgs {
         // Validate the proposal metadata
         let (metadata, metadata_hash) = self.get_metadata().await?;
 
-        println!(
+        human_println!(
             "{}\n\tMetadata Hash: {}\n\tScript Hash: {}",
-            metadata, metadata_hash, script_hash
+            metadata,
+            metadata_hash,
+            script_hash
         );
         Ok((script_hash, metadata_hash))
     }
@@ -408,7 +412,10 @@ impl CliCommand<ProposalSubmissionSummary> for SubmitProposal {
                 ))
                 .await?
         };
-        let txn_summary = TransactionSummary::from(&txn);
+        let txn_summary = self
+            .args
+            .txn_options
+            .summarize_submitted_transaction_ref(&txn);
         let proposal_id = extract_proposal_id(&txn)?;
         Ok(ProposalSubmissionSummary {
             proposal_id,
@@ -564,7 +571,7 @@ impl SubmitVote {
                 false
             };
             if voted {
-                println!("Stake pool {} already voted", *pool_address);
+                human_println!("Stake pool {} already voted", *pool_address);
                 continue;
             }
 
@@ -593,7 +600,7 @@ impl SubmitVote {
                         vote,
                     ))
                     .await
-                    .map(TransactionSummary::from)?,
+                    .map(|t| self.args.txn_options.summarize_submitted_transaction(t))?,
             );
         }
         Ok(summaries)
@@ -658,11 +665,12 @@ impl SubmitVote {
                 .parse()
                 .unwrap();
             if remaining_voting_power == 0 {
-                println!(
+                human_println!(
                     "Stake pool {} has no voting power on proposal {}. This is because the \
                     stake pool has already voted before enabling partial governance voting, or the \
                     stake pool has already used all its voting power.",
-                    *pool_address, proposal_id
+                    *pool_address,
+                    proposal_id
                 );
                 continue;
             }
@@ -689,7 +697,7 @@ impl SubmitVote {
                         vote,
                     ))
                     .await
-                    .map(TransactionSummary::from)?,
+                    .map(|t| self.args.txn_options.summarize_submitted_transaction(t))?,
             );
         }
         Ok(summaries)
@@ -741,13 +749,13 @@ impl CliCommand<TransactionSummary> for ApproveExecutionHash {
     }
 
     async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
-        Ok(self
+        let t = self
             .txn_options
             .submit_transaction(
                 aptos_stdlib::aptos_governance_add_approved_script_hash_script(self.proposal_id),
             )
-            .await
-            .map(TransactionSummary::from)?)
+            .await?;
+        Ok(self.txn_options.summarize_submitted_transaction_ref(&t))
     }
 }
 
@@ -894,7 +902,7 @@ impl CliCommand<TransactionSummary> for ExecuteProposal {
         self.txn_options
             .submit_transaction(txn)
             .await
-            .map(TransactionSummary::from)
+            .map(|t| self.txn_options.summarize_submitted_transaction(t))
     }
 }
 

--- a/crates/aptos/src/governance/utils.rs
+++ b/crates/aptos/src/governance/utils.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{governance::*, *};
+use crate::{governance::*, human_println, *};
 use aptos_types::on_chain_config::FeatureFlag;
 
 pub fn vote_to_string(vote: bool) -> &'static str {
@@ -19,7 +19,7 @@ pub fn check_remaining_voting_power(
     let mut voting_power = remaining_voting_power;
     if let Some(specified_voting_power) = specified_voting_power {
         if specified_voting_power > voting_power {
-            println!(
+            human_println!(
                 "Stake pool only has {} voting power on proposal.",
                 voting_power
             );

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -8,6 +8,7 @@ pub mod common;
 pub mod config;
 pub mod genesis;
 pub mod governance;
+pub mod meta;
 pub mod move_tool;
 pub mod node;
 pub mod op;
@@ -17,18 +18,40 @@ pub mod test;
 pub mod update;
 pub mod workspace;
 
+pub use common::types::{CliResult, CliTypedResult};
+
 use crate::common::{
-    types::{CliCommand, CliResult, CliTypedResult},
+    cli_output::{CliOutputMode, GlobalOptions},
+    types::CliCommand,
     utils::cli_build_information,
 };
 use aptos_workspace_server::WorkspaceCommand;
 use async_trait::async_trait;
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use std::collections::BTreeMap;
 
 /// Command Line Interface (CLI) for developing and interacting with the Movement blockchain
 #[derive(Parser)]
 #[clap(name = "movement", author, version, propagate_version = true, styles = aptos_cli_common::aptos_cli_style())]
+pub struct MovementCli {
+    #[clap(flatten)]
+    pub global: GlobalOptions,
+    #[clap(subcommand)]
+    pub tool: Tool,
+}
+
+impl MovementCli {
+    /// Apply [`GlobalOptions`] such as output mode. Call once before [`execute`](Self::execute).
+    pub fn install_output_mode(&self) {
+        CliOutputMode::install(self.global.resolved_output_mode());
+    }
+
+    pub async fn execute(self) -> CliResult {
+        self.tool.execute().await
+    }
+}
+
+#[derive(Subcommand)]
 pub enum Tool {
     #[clap(subcommand)]
     Account(account::AccountTool),
@@ -42,6 +65,8 @@ pub enum Tool {
     Init(common::init::InitTool),
     #[clap(subcommand)]
     Key(op::key::KeyTool),
+    #[clap(subcommand)]
+    Meta(meta::MetaTool),
     #[clap(subcommand)]
     Move(move_tool::MoveTool),
     #[clap(subcommand)]
@@ -68,6 +93,7 @@ impl Tool {
             // TODO: Replace entirely with config init
             Init(tool) => tool.execute_serialized_success().await,
             Key(tool) => tool.execute().await,
+            Meta(tool) => tool.execute().await,
             Move(tool) => tool.execute().await,
             Multisig(tool) => tool.execute().await,
             Node(tool) => tool.execute().await,
@@ -98,5 +124,5 @@ impl CliCommand<BTreeMap<String, String>> for InfoTool {
 #[test]
 fn verify_tool() {
     use clap::CommandFactory;
-    Tool::command().debug_assert()
+    MovementCli::command().debug_assert()
 }

--- a/crates/aptos/src/main.rs
+++ b/crates/aptos/src/main.rs
@@ -10,7 +10,7 @@
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use clap::Parser;
-use movement::{move_tool, Tool};
+use movement::{move_tool, MovementCli};
 use std::{process::exit, time::Duration};
 
 fn main() {
@@ -23,8 +23,11 @@ fn main() {
         .build()
         .unwrap();
 
+    let cli = MovementCli::parse();
+    cli.install_output_mode();
+
     // Run the corresponding tool.
-    let result = runtime.block_on(Tool::parse().execute());
+    let result = runtime.block_on(cli.execute());
 
     // Shutdown the runtime with a timeout. We do this to make sure that we don't sit
     // here waiting forever waiting for tasks that sometimes don't want to exit on

--- a/crates/aptos/src/meta/mod.rs
+++ b/crates/aptos/src/meta/mod.rs
@@ -1,0 +1,105 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Machine-readable CLI metadata for automation and agents.
+
+use crate::common::types::{CliCommand, CliResult, CliTypedResult};
+use async_trait::async_trait;
+use clap::{CommandFactory, Parser, Subcommand};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// Introspection and schema helpers for the CLI.
+#[derive(Subcommand)]
+pub enum MetaTool {
+    /// Emit the full command tree, arguments, and help text as JSON (for agents and tooling).
+    CommandsSchema(CommandsSchemaArgs),
+}
+
+impl MetaTool {
+    pub async fn execute(self) -> CliResult {
+        match self {
+            MetaTool::CommandsSchema(c) => c.execute_serialized().await,
+        }
+    }
+}
+
+/// Arguments for `movement meta commands-schema`.
+#[derive(Parser, Default)]
+pub struct CommandsSchemaArgs {}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct CommandSchemaNode {
+    pub name: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
+    pub about: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<ArgSchema>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub subcommands: Vec<CommandSchemaNode>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct ArgSchema {
+    pub id: String,
+    pub long: Option<String>,
+    pub short: Option<char>,
+    pub help: Option<String>,
+    pub required: bool,
+    pub num_args: String,
+}
+
+fn command_schema_tree(cmd: &clap::Command) -> CommandSchemaNode {
+    let mut args = Vec::new();
+    for arg in cmd.get_arguments() {
+        let id = arg.get_id().as_str();
+        if id == "help" || id == "version" {
+            continue;
+        }
+        let long = arg.get_long().map(String::from);
+        let short = arg.get_short();
+        let help = arg.get_help().map(|h| h.to_string());
+        args.push(ArgSchema {
+            id: id.to_string(),
+            long,
+            short,
+            help,
+            required: arg.is_required_set(),
+            num_args: format!("{:?}", arg.get_num_args()),
+        });
+    }
+    args.sort_by(|a, b| a.id.cmp(&b.id));
+
+    let mut subcommands: Vec<CommandSchemaNode> = cmd
+        .get_subcommands()
+        .map(|s| command_schema_tree(s))
+        .collect();
+    subcommands.sort_by(|a, b| a.name.cmp(&b.name));
+
+    CommandSchemaNode {
+        name: cmd.get_name().to_string(),
+        aliases: cmd.get_aliases().map(String::from).collect(),
+        about: cmd.get_about().map(|s| s.to_string()),
+        args,
+        subcommands,
+    }
+}
+
+/// Build a JSON value describing `cmd` and all nested subcommands.
+pub fn command_schema_value(cmd: &clap::Command) -> Value {
+    let tree = command_schema_tree(cmd);
+    serde_json::to_value(tree).unwrap_or(json!({ "Error": "failed to serialize schema" }))
+}
+
+#[async_trait]
+impl CliCommand<Value> for CommandsSchemaArgs {
+    fn command_name(&self) -> &'static str {
+        "MetaCommandsSchema"
+    }
+
+    async fn execute(self) -> CliTypedResult<Value> {
+        let cmd = crate::MovementCli::command();
+        Ok(command_schema_value(&cmd))
+    }
+}

--- a/crates/aptos/src/meta/mod.rs
+++ b/crates/aptos/src/meta/mod.rs
@@ -3,7 +3,7 @@
 
 //! Machine-readable CLI metadata for automation and agents.
 
-use crate::common::types::{CliCommand, CliResult, CliTypedResult};
+use crate::common::types::{CliCommand, CliError, CliResult, CliTypedResult};
 use async_trait::async_trait;
 use clap::{CommandFactory, Parser, Subcommand};
 use serde::{Deserialize, Serialize};
@@ -26,13 +26,21 @@ impl MetaTool {
 
 /// Arguments for `movement meta commands-schema`.
 #[derive(Parser, Default)]
-pub struct CommandsSchemaArgs {}
+pub struct CommandsSchemaArgs {
+    /// Only emit the subcommand at this path (space-separated names, e.g. `move publish`).
+    #[clap(long, value_name = "PATH")]
+    pub path: Option<String>,
+    /// Omit `help` and `about` text; keep structural fields only (smaller JSON for agents).
+    #[clap(long)]
+    pub brief: bool,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct CommandSchemaNode {
     pub name: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub aliases: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub about: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<ArgSchema>,
@@ -45,12 +53,13 @@ pub(crate) struct ArgSchema {
     pub id: String,
     pub long: Option<String>,
     pub short: Option<char>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub help: Option<String>,
     pub required: bool,
     pub num_args: String,
 }
 
-fn command_schema_tree(cmd: &clap::Command) -> CommandSchemaNode {
+fn command_schema_tree(cmd: &clap::Command, brief: bool) -> CommandSchemaNode {
     let mut args = Vec::new();
     for arg in cmd.get_arguments() {
         let id = arg.get_id().as_str();
@@ -59,7 +68,11 @@ fn command_schema_tree(cmd: &clap::Command) -> CommandSchemaNode {
         }
         let long = arg.get_long().map(String::from);
         let short = arg.get_short();
-        let help = arg.get_help().map(|h| h.to_string());
+        let help = if brief {
+            None
+        } else {
+            arg.get_help().map(|h| h.to_string())
+        };
         args.push(ArgSchema {
             id: id.to_string(),
             long,
@@ -73,22 +86,57 @@ fn command_schema_tree(cmd: &clap::Command) -> CommandSchemaNode {
 
     let mut subcommands: Vec<CommandSchemaNode> = cmd
         .get_subcommands()
-        .map(|s| command_schema_tree(s))
+        .map(|s| command_schema_tree(s, brief))
         .collect();
     subcommands.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let about = if brief {
+        None
+    } else {
+        cmd.get_about().map(|s| s.to_string())
+    };
 
     CommandSchemaNode {
         name: cmd.get_name().to_string(),
         aliases: cmd.get_aliases().map(String::from).collect(),
-        about: cmd.get_about().map(|s| s.to_string()),
+        about,
         args,
         subcommands,
     }
 }
 
+/// Walk from `root` along subcommand names in `path` (whitespace-separated).
+fn resolve_command_path<'a>(
+    root: &'a clap::Command,
+    path: &str,
+) -> Result<&'a clap::Command, CliError> {
+    let segments: Vec<&str> = path.split_whitespace().filter(|s| !s.is_empty()).collect();
+    if segments.is_empty() {
+        return Err(CliError::CommandArgumentError(
+            "commands-schema: --path must contain at least one subcommand name".to_string(),
+        ));
+    }
+    let mut current = root;
+    for seg in &segments {
+        current = current
+            .get_subcommands()
+            .find(|s| s.get_name() == *seg)
+            .ok_or_else(|| {
+                let names: Vec<_> = current.get_subcommands().map(|s| s.get_name()).collect();
+                CliError::CommandArgumentError(format!(
+                    "commands-schema: no subcommand {:?} under {:?}; valid: {}",
+                    seg,
+                    current.get_name(),
+                    names.join(", ")
+                ))
+            })?;
+    }
+    Ok(current)
+}
+
 /// Build a JSON value describing `cmd` and all nested subcommands.
-pub fn command_schema_value(cmd: &clap::Command) -> Value {
-    let tree = command_schema_tree(cmd);
+pub fn command_schema_value(cmd: &clap::Command, brief: bool) -> Value {
+    let tree = command_schema_tree(cmd, brief);
     serde_json::to_value(tree).unwrap_or(json!({ "Error": "failed to serialize schema" }))
 }
 
@@ -99,7 +147,16 @@ impl CliCommand<Value> for CommandsSchemaArgs {
     }
 
     async fn execute(self) -> CliTypedResult<Value> {
-        let cmd = crate::MovementCli::command();
-        Ok(command_schema_value(&cmd))
+        let root = crate::MovementCli::command();
+        let target = match self
+            .path
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            None => &root,
+            Some(p) => resolve_command_path(&root, p)?,
+        };
+        Ok(command_schema_value(target, self.brief))
     }
 }

--- a/crates/aptos/src/move_tool/bytecode.rs
+++ b/crates/aptos/src/move_tool/bytecode.rs
@@ -9,6 +9,7 @@ use crate::{
             write_to_user_only_file,
         },
     },
+    human_println,
     update::get_revela_path,
 };
 use anyhow::Context;
@@ -253,7 +254,7 @@ impl BytecodeCommand {
                 compilation_metadata: get_compilation_metadata(&module).unwrap_or(v1_metadata),
             }
         };
-        println!(
+        human_println!(
             "Metadata: {}",
             serde_json::to_string_pretty(&metadata).expect("expect metadata")
         );

--- a/crates/aptos/src/move_tool/coverage.rs
+++ b/crates/aptos/src/move_tool/coverage.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    common::types::{CliCommand, CliError, CliResult, CliTypedResult, MovePackageOptions},
+    common::{
+        cli_output::CliOutputMode,
+        types::{CliCommand, CliError, CliResult, CliTypedResult, MovePackageOptions},
+    },
+    human_println,
     move_tool::fix_bytecode_version,
 };
 use aptos_framework::extended_checks;
@@ -59,12 +63,30 @@ impl SummaryCoverage {
             })
             .collect();
         let coverage_map = coverage_map.to_unified_exec_map();
+        let agent_stdout_clean = CliOutputMode::current().is_json_agent_mode();
         if self.output_csv {
-            format_csv_summary(
+            if agent_stdout_clean {
+                format_csv_summary(
+                    modules.as_slice(),
+                    &coverage_map,
+                    summarize_inst_cov,
+                    &mut std::io::stderr(),
+                )
+            } else {
+                format_csv_summary(
+                    modules.as_slice(),
+                    &coverage_map,
+                    summarize_inst_cov,
+                    &mut std::io::stdout(),
+                )
+            }
+        } else if agent_stdout_clean {
+            format_human_summary(
                 modules.as_slice(),
                 &coverage_map,
                 summarize_inst_cov,
-                &mut std::io::stdout(),
+                &mut std::io::stderr(),
+                self.summarize_functions,
             )
         } else {
             format_human_summary(
@@ -134,8 +156,11 @@ impl CliCommand<()> for SourceCoverage {
             .collect();
         let source_coverage = SourceCoverageBuilder::new(&coverage_map, source_map, root_modules);
         let source_coverage = source_coverage.compute_source_coverage(source_path);
-        let output_result =
-            source_coverage.output_source_coverage(&mut std::io::stdout(), self.color, self.tag);
+        let output_result = if CliOutputMode::current().is_json_agent_mode() {
+            source_coverage.output_source_coverage(&mut std::io::stderr(), self.color, self.tag)
+        } else {
+            source_coverage.output_source_coverage(&mut std::io::stdout(), self.color, self.tag)
+        };
         output_result
             .map_err(|err| CliError::UnexpectedError(format!("Failed to get coverage {}", err)))
     }
@@ -161,7 +186,12 @@ impl CliCommand<()> for BytecodeCoverage {
         let unit = package.get_module_by_name_from_root(&self.module_name)?;
         let mut disassembler = Disassembler::from_unit(&unit.unit);
         disassembler.add_coverage_map(coverage_map.to_unified_exec_map());
-        println!("{}", disassembler.disassemble()?);
+        let listing = disassembler.disassemble()?;
+        if CliOutputMode::current().is_json_agent_mode() {
+            eprintln!("{}", listing);
+        } else {
+            human_println!("{}", listing);
+        }
         Ok(())
     }
 }

--- a/crates/aptos/src/move_tool/fmt.rs
+++ b/crates/aptos/src/move_tool/fmt.rs
@@ -6,6 +6,7 @@ use crate::{
         types::{CliCommand, CliError, CliTypedResult},
         utils::dir_default_to_current,
     },
+    human_eprint, human_eprintln,
     update::get_movefmt_path,
 };
 use async_trait::async_trait;
@@ -211,10 +212,10 @@ impl FmtCommand {
                     String::from_utf8(out.stderr).unwrap_or_default()
                 )));
             } else {
-                eprintln!("Formatting file: {}", file.display());
+                human_eprintln!("Formatting file: {}", file.display());
                 match String::from_utf8(out.stdout) {
                     Ok(output) => {
-                        eprint!("{}", output);
+                        human_eprint!("{}", output);
                     },
                     Err(err) => {
                         return Err(CliError::UnexpectedError(format!(

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -19,6 +19,7 @@ use crate::{
         },
     },
     governance::CompileScriptFunction,
+    human_println,
     move_tool::{
         bytecode::{Decompile, Disassemble},
         coverage::SummaryCoverage,
@@ -641,7 +642,7 @@ impl CliCommand<&'static str> for TestPackage {
             };
             summary.coverage()?;
 
-            println!("Please use `aptos move coverage -h` for more detailed source or bytecode test coverage of this package");
+            human_println!("Please use `aptos move coverage -h` for more detailed source or bytecode test coverage of this package");
         }
 
         match result {
@@ -816,7 +817,7 @@ impl TryInto<PackagePublicationData> for &PublishPackage {
             create_package_publication_data(package, PublishType::AccountDeploy, None)?;
 
         let size = bcs::serialized_size(&package_publication_data.payload)?;
-        println!("package size {} bytes", size);
+        human_println!("package size {} bytes", size);
         if !self.override_size_check_option.override_size_check && size > MAX_PUBLISH_PACKAGE_SIZE {
             return Err(CliError::PackageSizeExceeded(
                 size,
@@ -858,7 +859,7 @@ impl AsyncTryInto<ChunkedPublishPayloads> for &PublishPackage {
             .iter()
             .map(bcs::serialized_size)
             .sum::<Result<usize, _>>()?;
-        println!("package size {} bytes", size);
+        human_println!("package size {} bytes", size);
 
         Ok(chunked_publish_payloads)
     }
@@ -1049,7 +1050,7 @@ impl CliCommand<TransactionSummary> for PublishPackage {
             let chunked_package_payloads: ChunkedPublishPayloads = (&self).async_try_into().await?;
 
             let message = format!("Publishing package in chunked mode will submit {} transactions for staging and publishing code.\n", &chunked_package_payloads.payloads.len());
-            println!("{}", message.bold());
+            human_println!("{}", message.bold());
             submit_chunked_publish_transactions(
                 chunked_package_payloads.payloads,
                 &self.txn_options,
@@ -1211,9 +1212,9 @@ impl CliCommand<TransactionSummary> for CreateObjectAndPublishPackage {
                 .iter()
                 .map(bcs::serialized_size)
                 .sum::<Result<usize, _>>()?;
-            println!("package size {} bytes", size);
+            human_println!("package size {} bytes", size);
             let message = format!("Publishing package in chunked mode will submit {} transactions for staging and publishing code.\n", &payloads.len());
-            println!("{}", message.bold());
+            human_println!("{}", message.bold());
 
             submit_chunked_publish_transactions(
                 payloads,
@@ -1229,7 +1230,7 @@ impl CliCommand<TransactionSummary> for CreateObjectAndPublishPackage {
             )?
             .payload;
             let size = bcs::serialized_size(&payload)?;
-            println!("package size {} bytes", size);
+            human_println!("package size {} bytes", size);
 
             if !self.override_size_check_option.override_size_check
                 && size > MAX_PUBLISH_PACKAGE_SIZE
@@ -1242,11 +1243,11 @@ impl CliCommand<TransactionSummary> for CreateObjectAndPublishPackage {
             self.txn_options
                 .submit_transaction(payload)
                 .await
-                .map(TransactionSummary::from)
+                .map(|t| self.txn_options.summarize_submitted_transaction(t))
         };
 
         if result.is_ok() {
-            println!(
+            human_println!(
                 "Code was successfully deployed to object address {}",
                 object_address
             );
@@ -1330,9 +1331,9 @@ impl CliCommand<TransactionSummary> for UpgradeObjectPackage {
                 .iter()
                 .map(bcs::serialized_size)
                 .sum::<Result<usize, _>>()?;
-            println!("package size {} bytes", size);
+            human_println!("package size {} bytes", size);
             let message = format!("Upgrading package in chunked mode will submit {} transactions for staging and upgrading code.\n", &payloads.len());
-            println!("{}", message.bold());
+            human_println!("{}", message.bold());
             submit_chunked_publish_transactions(
                 payloads,
                 &self.txn_options,
@@ -1348,7 +1349,7 @@ impl CliCommand<TransactionSummary> for UpgradeObjectPackage {
             .payload;
 
             let size = bcs::serialized_size(&payload)?;
-            println!("package size {} bytes", size);
+            human_println!("package size {} bytes", size);
 
             if !self.override_size_check_option.override_size_check
                 && size > MAX_PUBLISH_PACKAGE_SIZE
@@ -1361,11 +1362,11 @@ impl CliCommand<TransactionSummary> for UpgradeObjectPackage {
             self.txn_options
                 .submit_transaction(payload)
                 .await
-                .map(TransactionSummary::from)
+                .map(|t| self.txn_options.summarize_submitted_transaction(t))
         };
 
         if result.is_ok() {
-            println!(
+            human_println!(
                 "Code was successfully upgraded at object address {}",
                 self.object_address
             );
@@ -1463,9 +1464,9 @@ impl CliCommand<TransactionSummary> for DeployObjectCode {
                 .iter()
                 .map(bcs::serialized_size)
                 .sum::<Result<usize, _>>()?;
-            println!("package size {} bytes", size);
+            human_println!("package size {} bytes", size);
             let message = format!("Publishing package in chunked mode will submit {} transactions for staging and publishing code.\n", &payloads.len());
-            println!("{}", message.bold());
+            human_println!("{}", message.bold());
 
             submit_chunked_publish_transactions(
                 payloads,
@@ -1482,7 +1483,7 @@ impl CliCommand<TransactionSummary> for DeployObjectCode {
             .payload;
 
             let size = bcs::serialized_size(&payload)?;
-            println!("package size {} bytes", size);
+            human_println!("package size {} bytes", size);
 
             if !self.override_size_check_option.override_size_check
                 && size > MAX_PUBLISH_PACKAGE_SIZE
@@ -1495,11 +1496,11 @@ impl CliCommand<TransactionSummary> for DeployObjectCode {
             self.txn_options
                 .submit_transaction(payload)
                 .await
-                .map(TransactionSummary::from)
+                .map(|t| self.txn_options.summarize_submitted_transaction(t))
         };
 
         if result.is_ok() {
-            println!(
+            human_println!(
                 "Code was successfully deployed to object address {}",
                 object_address
             );
@@ -1588,9 +1589,9 @@ impl CliCommand<TransactionSummary> for UpgradeCodeObject {
                 .iter()
                 .map(bcs::serialized_size)
                 .sum::<Result<usize, _>>()?;
-            println!("package size {} bytes", size);
+            human_println!("package size {} bytes", size);
             let message = format!("Upgrading package in chunked mode will submit {} transactions for staging and upgrading code.\n", &payloads.len());
-            println!("{}", message.bold());
+            human_println!("{}", message.bold());
             submit_chunked_publish_transactions(
                 payloads,
                 &self.txn_options,
@@ -1606,7 +1607,7 @@ impl CliCommand<TransactionSummary> for UpgradeCodeObject {
             .payload;
 
             let size = bcs::serialized_size(&payload)?;
-            println!("package size {} bytes", size);
+            human_println!("package size {} bytes", size);
 
             if !self.override_size_check_option.override_size_check
                 && size > MAX_PUBLISH_PACKAGE_SIZE
@@ -1619,11 +1620,11 @@ impl CliCommand<TransactionSummary> for UpgradeCodeObject {
             self.txn_options
                 .submit_transaction(payload)
                 .await
-                .map(TransactionSummary::from)
+                .map(|t| self.txn_options.summarize_submitted_transaction(t))
         };
 
         if result.is_ok() {
-            println!(
+            human_println!(
                 "Code was successfully upgraded at object address {}",
                 self.object_address
             );
@@ -1663,16 +1664,16 @@ async fn submit_chunked_publish_transactions(
             large_packages_module_address, account_address,
         )
             .bold();
-        println!("{}", message);
+        human_println!("{}", message);
         prompt_yes_with_override("Do you want to proceed?", txn_options.prompt_options)?;
     }
 
     for (idx, payload) in payloads.into_iter().enumerate() {
-        println!("Transaction {} of {}", idx + 1, payloads_length);
+        human_println!("Transaction {} of {}", idx + 1, payloads_length);
         let result = txn_options
             .submit_transaction(payload)
             .await
-            .map(TransactionSummary::from);
+            .map(|t| txn_options.summarize_submitted_transaction(t));
 
         match result {
             Ok(tx_summary) => {
@@ -1684,13 +1685,13 @@ async fn submit_chunked_publish_transactions(
                         "Failed".to_string()
                     }
                 });
-                println!("Transaction executed: {} ({})\n", status, &tx_hash);
+                human_println!("Transaction executed: {} ({})\n", status, &tx_hash);
                 tx_hashes.push(tx_hash);
                 publishing_result = Ok(tx_summary);
             },
 
             Err(e) => {
-                println!("{}", "Caution: An error occurred while submitting chunked publish transactions. \
+                human_println!("{}", "Caution: An error occurred while submitting chunked publish transactions. \
                 \nDue to this error, there may be incomplete data left in the `StagingArea` resource. \
                 \nThis could cause further errors if you attempt to run the chunked publish command again. \
                 \nTo avoid this, use the `aptos move clear-staging-area` command to clean up the `StagingArea` resource under your account before retrying.".bold());
@@ -1699,7 +1700,7 @@ async fn submit_chunked_publish_transactions(
         }
     }
 
-    println!(
+    human_println!(
         "{}",
         "All Transactions Submitted Successfully.".bold().green()
     );
@@ -1711,7 +1712,7 @@ async fn submit_chunked_publish_transactions(
             .collect::<Vec<_>>()
             .join(",\n    ")
     );
-    println!("\n{}\n", tx_hash_formatted);
+    human_println!("\n{}\n", tx_hash_formatted);
     publishing_result
 }
 
@@ -1769,15 +1770,16 @@ impl CliCommand<TransactionSummary> for ClearStagingArea {
             .large_packages_module
             .large_packages_module_address(&self.txn_options.rest_client()?)
             .await?;
-        println!(
+        human_println!(
             "Cleaning up resource {}::large_packages::StagingArea under account {}.",
-            &large_packages_module_address, account_address,
+            &large_packages_module_address,
+            account_address,
         );
         let payload = large_packages_cleanup_staging_area(large_packages_module_address);
         self.txn_options
             .submit_transaction(payload)
             .await
-            .map(TransactionSummary::from)
+            .map(|t| self.txn_options.summarize_submitted_transaction(t))
     }
 }
 
@@ -1858,7 +1860,7 @@ impl CliCommand<TransactionSummary> for CreateResourceAccountAndPublishPackage {
             compiled_units,
         );
         let size = bcs::serialized_size(&payload)?;
-        println!("package size {} bytes", size);
+        human_println!("package size {} bytes", size);
         if !override_size_check_option.override_size_check && size > MAX_PUBLISH_PACKAGE_SIZE {
             return Err(CliError::UnexpectedError(format!(
                 "The package is larger than {} bytes ({} bytes)! To lower the size \
@@ -1870,7 +1872,7 @@ impl CliCommand<TransactionSummary> for CreateResourceAccountAndPublishPackage {
         txn_options
             .submit_transaction(payload)
             .await
-            .map(TransactionSummary::from)
+            .map(|t| txn_options.summarize_submitted_transaction(t))
     }
 }
 
@@ -1928,7 +1930,7 @@ impl CliCommand<&'static str> for DownloadPackage {
             ));
         }
         if self.print_metadata {
-            println!("{}", package);
+            human_println!("{}", package);
         }
         let package_path = output_dir.join(package.name());
         package
@@ -1941,7 +1943,7 @@ impl CliCommand<&'static str> for DownloadPackage {
                 }
             }
         };
-        println!(
+        human_println!(
             "Saved package with {} module(s) to `{}`",
             package.module_names().len(),
             package_path.display()
@@ -2071,11 +2073,11 @@ impl CliCommand<&'static str> for ListPackage {
             MoveListQuery::Packages => {
                 for name in registry.package_names() {
                     let data = registry.get_package(name).await?;
-                    println!("package {}", data.name());
-                    println!("  upgrade_policy: {}", data.upgrade_policy());
-                    println!("  upgrade_number: {}", data.upgrade_number());
-                    println!("  source_digest: {}", data.source_digest());
-                    println!("  modules: {}", data.module_names().into_iter().join(", "));
+                    human_println!("package {}", data.name());
+                    human_println!("  upgrade_policy: {}", data.upgrade_policy());
+                    human_println!("  upgrade_number: {}", data.upgrade_number());
+                    human_println!("  source_digest: {}", data.source_digest());
+                    human_println!("  modules: {}", data.module_names().into_iter().join(", "));
                 }
             },
         }
@@ -2347,7 +2349,7 @@ impl CliCommand<TransactionSummary> for Replay {
 
         // Execute the transaction.
         let (vm_status, vm_output) = if self.profile_gas {
-            println!("Profiling transaction...");
+            human_println!("Profiling transaction...");
             local_simulation::profile_transaction_using_debugger(
                 &debugger,
                 self.txn_id,
@@ -2355,7 +2357,7 @@ impl CliCommand<TransactionSummary> for Replay {
                 hash,
             )?
         } else if self.benchmark {
-            println!("Benchmarking transaction...");
+            human_println!("Benchmarking transaction...");
             local_simulation::benchmark_transaction_using_debugger(
                 &debugger,
                 self.txn_id,
@@ -2363,7 +2365,7 @@ impl CliCommand<TransactionSummary> for Replay {
                 hash,
             )?
         } else {
-            println!("Replaying transaction...");
+            human_println!("Replaying transaction...");
             local_simulation::run_transaction_using_debugger(
                 &debugger,
                 self.txn_id,
@@ -2408,6 +2410,7 @@ impl CliCommand<TransactionSummary> for Replay {
             timestamp_us: None,
             version: Some(self.txn_id),
             vm_status: Some(vm_status.to_string()),
+            explorer_url: None,
         };
 
         Ok(summary)

--- a/crates/aptos/src/move_tool/stored_package.rs
+++ b/crates/aptos/src/move_tool/stored_package.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::human_println;
 use anyhow::bail;
 use aptos_framework::{
     natives::code::{ModuleMetadata, PackageMetadata, PackageRegistry, UpgradePolicy},
@@ -169,7 +170,7 @@ impl CachedPackageMetadata<'_> {
         for module in &self.metadata.modules {
             match module.source.is_empty() {
                 true => {
-                    println!("module without code: {}", module.name);
+                    human_println!("module without code: {}", module.name);
                 },
                 false => {
                     let source = unzip_metadata_str(&module.source)?;

--- a/crates/aptos/src/node/analyze/analyze_validators.rs
+++ b/crates/aptos/src/node/analyze/analyze_validators.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::fetch_metadata::ValidatorInfo;
+use crate::{human_print, human_println};
 use anyhow::Result;
 use aptos_bitvec::BitVec;
 use aptos_logger::error;
@@ -326,7 +327,7 @@ impl AnalyzeValidators {
             let end = raw_events.len() < batch;
             for raw_event in raw_events {
                 if cursor <= raw_event.event.v1()?.sequence_number() {
-                    println!(
+                    human_println!(
                         "Duplicate event found for {} : {:?}",
                         cursor,
                         raw_event.event.v1()?.sequence_number()
@@ -402,13 +403,17 @@ impl AnalyzeValidators {
         ]
         .into_iter()
         .map(|v| {
-            (v, VecDeque::new(), MaxTpsStats {
-                tps: 0.0,
-                end_version: 0,
-                txns: 0,
-                blocks: 0,
-                duration: 0.0,
-            })
+            (
+                v,
+                VecDeque::new(),
+                MaxTpsStats {
+                    tps: 0.0,
+                    end_version: 0,
+                    txns: 0,
+                    blocks: 0,
+                    duration: 0.0,
+                },
+            )
         })
         .collect::<Vec<_>>();
         let mut trimmed_rounds = 0;
@@ -423,9 +428,10 @@ impl AnalyzeValidators {
             let expected_round =
                 previous_round + u64::from(!is_nil) + event.failed_proposer_indices().len() as u64;
             if event.round() != expected_round {
-                println!(
+                human_println!(
                     "Missing failed AccountAddresss : {} {:?}",
-                    previous_round, &event
+                    previous_round,
+                    &event
                 );
                 assert!(expected_round < event.round());
                 trimmed_rounds += event.round() - expected_round;
@@ -530,13 +536,16 @@ impl AnalyzeValidators {
             validator_stats: validators
                 .iter()
                 .map(|validator| {
-                    (validator.address, ValidatorStats {
-                        proposal_successes: *successes.get(&validator.address).unwrap_or(&0),
-                        proposal_failures: *failures.get(&validator.address).unwrap_or(&0),
-                        votes: *votes.get(&validator.address).unwrap_or(&0),
-                        transactions: *transactions.get(&validator.address).unwrap_or(&0),
-                        voting_power: validator.voting_power,
-                    })
+                    (
+                        validator.address,
+                        ValidatorStats {
+                            proposal_successes: *successes.get(&validator.address).unwrap_or(&0),
+                            proposal_failures: *failures.get(&validator.address).unwrap_or(&0),
+                            votes: *votes.get(&validator.address).unwrap_or(&0),
+                            transactions: *transactions.get(&validator.address).unwrap_or(&0),
+                            voting_power: validator.voting_power,
+                        },
+                    )
                 })
                 .collect(),
             total_rounds,
@@ -632,13 +641,13 @@ impl AnalyzeValidators {
         extra: Option<(&str, &HashMap<AccountAddress, String>)>,
         sort_by_health: bool,
     ) {
-        println!(
+        human_println!(
             "Rounds: {} successes, {} failures, {} NIL blocks, failure rate: {}%, nil block rate: {}%",
             epoch_stats.round_successes, epoch_stats.round_failures, epoch_stats.nil_blocks,
             100.0 * epoch_stats.round_failures as f32 / epoch_stats.total_rounds as f32,
             100.0 * epoch_stats.nil_blocks as f32 / epoch_stats.total_rounds as f32,
         );
-        println!(
+        human_println!(
             "{: <10} | {: <10} | {: <10} | {: <10} | {: <10} | {: <10} | {: <10} | {: <30}",
             "elected",
             "% rounds",
@@ -676,7 +685,7 @@ impl AnalyzeValidators {
 
         for validator in validator_order {
             let cur_stats = epoch_stats.validator_stats.get(validator).unwrap();
-            println!(
+            human_println!(
                 "{: <10} | {:5.2}%     | {:7.3}%   | {: <10} | {: <10} | {: <10} | {: <10} | {}",
                 cur_stats.proposal_failures + cur_stats.proposal_successes,
                 100.0 * (cur_stats.proposal_failures + cur_stats.proposal_successes) as f32
@@ -724,7 +733,7 @@ impl AnalyzeValidators {
         });
 
         for validator in sorted_validators {
-            print!(
+            human_print!(
                 "{}:  ",
                 if let Some(extra_map) = extra {
                     format!(
@@ -737,12 +746,12 @@ impl AnalyzeValidators {
                 }
             );
             for cur_epoch in epochs.iter() {
-                print!(
+                human_print!(
                     "{}",
                     stats.get(cur_epoch).unwrap().to_state(&validator).to_char()
                 );
             }
-            println!();
+            human_println!();
         }
     }
 
@@ -752,7 +761,7 @@ impl AnalyzeValidators {
     ) {
         let epochs = stats.keys().sorted();
 
-        println!(
+        human_println!(
             "{: <8} | {: <10} | {: <10} | {: <10} | {: <10} | {: <10} | {: <10} | {: <10} | {: <10} | {: <10}",
             "epoch",
             "reliable",
@@ -781,7 +790,7 @@ impl AnalyzeValidators {
                 })
                 .sum();
 
-            println!(
+            human_println!(
                 "{: <8} | {: <10} | {: <10} | {: <10} | {: <10} | {: <10} | {: <10} | {: <10} | {:10.2} | {:10.2}",
                 cur_epoch,
                 counts.get(&NodeState::Reliable).unwrap_or(&0),
@@ -805,12 +814,12 @@ impl AnalyzeValidators {
     {
         let gap_info = Self::analyze_gap(blocks);
 
-        println!(
+        human_println!(
             "Max non-epoch-change gaps: {}, {}.",
             gap_info.non_epoch_round_gap.to_string_as_round(),
             gap_info.non_epoch_time_gap.to_string_as_time(),
         );
-        println!(
+        human_println!(
             "Max epoch-change gaps: {}, {}.",
             gap_info.epoch_round_gap.to_string_as_round(),
             gap_info.epoch_time_gap.to_string_as_time(),

--- a/crates/aptos/src/node/analyze/fetch_metadata.rs
+++ b/crates/aptos/src/node/analyze/fetch_metadata.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::human_println;
 use anyhow::{anyhow, Result};
 use aptos_rest_client::{
     aptos_api_types::{IdentifierWrapper, MoveResource, WriteSetChange},
@@ -159,7 +160,7 @@ impl FetchMetadata {
                 .ok_or_else(|| anyhow!("No blocks at oldest_block_height {}", start_seq_num))?;
             let oldest_fetchable_epoch = std::cmp::max(oldest_event.event.epoch() + 1, 2);
             if oldest_fetchable_epoch > wanted_start_epoch as u64 {
-                println!(
+                human_println!(
                     "Oldest full epoch that can be retreived is {} ",
                     oldest_fetchable_epoch
                 );
@@ -208,7 +209,7 @@ impl FetchMetadata {
 
         let mut batch_index = 0;
 
-        println!(
+        human_println!(
             "Fetching {} to {} sequence number, wanting epochs [{}, {}), last version: {} and epoch: {}",
             start_seq_num, last_seq_num, wanted_start_epoch, wanted_end_epoch, state.version, state.epoch,
         );
@@ -228,7 +229,7 @@ impl FetchMetadata {
                 .await;
 
             if response.is_err() {
-                println!(
+                human_println!(
                     "Failed to read new_block_events beyond {}, stopping. {:?}",
                     cursor,
                     response.unwrap_err()
@@ -312,7 +313,7 @@ impl FetchMetadata {
             }
 
             if batch_index % 100 == 0 {
-                println!(
+                human_println!(
                     "Fetched {} epochs (in epoch {} with {} blocks) from {} NewBlockEvents",
                     result.len(),
                     epoch,

--- a/crates/aptos/src/node/local_testnet/docker.rs
+++ b/crates/aptos/src/node/local_testnet/docker.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::traits::ShutdownStep;
+use crate::human_eprintln;
 use anyhow::{Context, Result};
 pub use aptos_localnet::docker::get_docker;
 use async_trait::async_trait;
@@ -95,7 +96,7 @@ pub async fn pull_docker_image(image_name: &str) -> Result<()> {
     }
 
     // The image is not present, let the user know we'll pull it.
-    eprintln!("Image {} not found, pulling it now...", image_name);
+    human_eprintln!("Image {} not found, pulling it now...", image_name);
 
     // The docker pull CLI command is just sugar around this API.
     docker

--- a/crates/aptos/src/node/local_testnet/health_checker.rs
+++ b/crates/aptos/src/node/local_testnet/health_checker.rs
@@ -138,17 +138,20 @@ impl HealthChecker {
         waiting_service: Option<&str>,
     ) -> Result<()> {
         let prefix = self.to_string();
-        wait_for_startup(|| self.check(), match waiting_service {
-            Some(waiting_service) => {
-                format!(
-                    "{} at {} did not start up before {}",
-                    prefix,
-                    self.address_str(),
-                    waiting_service,
-                )
+        wait_for_startup(
+            || self.check(),
+            match waiting_service {
+                Some(waiting_service) => {
+                    format!(
+                        "{} at {} did not start up before {}",
+                        prefix,
+                        self.address_str(),
+                        waiting_service,
+                    )
+                },
+                None => format!("{} at {} did not start up", prefix, self.address_str()),
             },
-            None => format!("{} at {} did not start up", prefix, self.address_str()),
-        })
+        )
         .await
     }
 

--- a/crates/aptos/src/node/local_testnet/indexer_api.rs
+++ b/crates/aptos/src/node/local_testnet/indexer_api.rs
@@ -10,6 +10,7 @@ use super::{
     traits::{PostHealthyStep, ServiceManager, ShutdownStep},
     RunLocalnet,
 };
+use crate::human_eprintln;
 use anyhow::{anyhow, Context, Result};
 pub use aptos_localnet::indexer_api::{
     make_hasura_metadata_request, post_metadata, HASURA_IMAGE, HASURA_METADATA,
@@ -119,7 +120,7 @@ impl ServiceManager for IndexerApiManager {
 
         // Warn the user about DOCKER_DEFAULT_PLATFORM.
         if let Ok(var) = std::env::var("DOCKER_DEFAULT_PLATFORM") {
-            eprintln!(
+            human_eprintln!(
                 "WARNING: DOCKER_DEFAULT_PLATFORM is set to {}. This may cause problems \
                 with running the indexer API. If it fails to start up, try unsetting \
                 this env var.\n",
@@ -157,9 +158,10 @@ impl ServiceManager for IndexerApiManager {
             let checker = HealthChecker::Http(url.clone(), "Indexer API".to_string());
             loop {
                 if let Err(e) = checker.wait(None).await {
-                    eprintln!(
+                    human_eprintln!(
                         "Existing Hasura instance at {} became unhealthy: {}",
-                        url, e
+                        url,
+                        e
                     );
                     break;
                 }

--- a/crates/aptos/src/node/local_testnet/mod.rs
+++ b/crates/aptos/src/node/local_testnet/mod.rs
@@ -31,6 +31,7 @@ use crate::{
         utils::prompt_yes_with_override,
     },
     config::GlobalConfig,
+    human_eprintln, human_println,
     node::local_testnet::{
         faucet::FaucetManager, indexer_api::IndexerApiManager, node::NodeManager,
         processors::ProcessorManager, ready_server::ReadyServerManager, traits::ShutdownStep,
@@ -53,6 +54,9 @@ use tracing::{info, warn};
 use tracing_subscriber::fmt::MakeWriter;
 
 const TESTNET_FOLDER: &str = "testnet";
+
+/// Use with `--destructive-confirm` and `--force-restart` (without `--assume-yes`) to wipe localnet data non-interactively.
+pub const CONFIRM_DELETE_LOCALNET_DATA: &str = "delete-localnet-data";
 
 /// Run a localnet
 ///
@@ -105,6 +109,10 @@ pub struct RunLocalnet {
     /// By default, tracing output goes to files. With this set, it goes to stdout.
     #[clap(long, hide = true)]
     log_to_stdout: bool,
+
+    /// With `--force-restart`, must be exactly `delete-localnet-data` to skip the confirmation prompt when not using `--assume-yes`.
+    #[clap(long)]
+    destructive_confirm: Option<String>,
 }
 
 impl RunLocalnet {
@@ -135,14 +143,14 @@ impl RunLocalnet {
                 HealthChecker::IndexerApiMetadata(_) => continue,
             };
             if !silent {
-                println!("{} is starting, please wait...", health_checker);
+                human_println!("{} is starting, please wait...", health_checker);
             } else {
                 info!("[silent] {} is starting, please wait...", health_checker);
             }
             let fut = async move {
                 health_checker.wait(None).await?;
                 if !silent {
-                    println!(
+                    human_println!(
                         "{} is ready. Endpoint: {}",
                         health_checker,
                         health_checker.address_str()
@@ -159,7 +167,7 @@ impl RunLocalnet {
             futures.push(Box::pin(fut));
         }
 
-        eprintln!();
+        human_eprintln!();
 
         // We use join_all because we expect all of these to return.
         for f in futures::future::join_all(futures).await {
@@ -197,10 +205,22 @@ impl CliCommand<()> for RunLocalnet {
 
         // If asked, remove the current test directory and start with a new node.
         if self.force_restart && test_dir.exists() {
-            prompt_yes_with_override(
-                "Are you sure you want to delete the existing localnet data?",
-                self.prompt_options,
-            )?;
+            if !self.prompt_options.assume_yes {
+                match self.destructive_confirm.as_deref() {
+                    Some(CONFIRM_DELETE_LOCALNET_DATA) => {},
+                    Some(_) => {
+                        return Err(CliError::CommandArgumentError(format!(
+                            "`--destructive-confirm` must be exactly `{CONFIRM_DELETE_LOCALNET_DATA}` when deleting existing localnet data"
+                        )));
+                    },
+                    None => {
+                        prompt_yes_with_override(
+                            "Are you sure you want to delete the existing localnet data?",
+                            self.prompt_options,
+                        )?;
+                    },
+                }
+            }
             remove_dir_all(test_dir.as_path()).map_err(|err| {
                 CliError::IO(format!("Failed to delete {}", test_dir.display()), err)
             })?;
@@ -337,9 +357,10 @@ impl CliCommand<()> for RunLocalnet {
             })?;
         }
 
-        println!(
+        human_println!(
             "\nReadiness endpoint: http://{}:{}/\n",
-            bind_to, self.ready_server_args.ready_server_listen_port,
+            bind_to,
+            self.ready_server_args.ready_server_listen_port,
         );
 
         // Collect post healthy steps to run after the services start.
@@ -365,9 +386,9 @@ impl CliCommand<()> for RunLocalnet {
                 res?
             },
             res = join_set.join_next() => {
-                eprintln!("\nOne of the services failed to start up, running shutdown steps...");
+                human_eprintln!("\nOne of the services failed to start up, running shutdown steps...");
                 run_shutdown_steps(shutdown_steps).await?;
-                eprintln!("Ran shutdown steps");
+                human_eprintln!("Ran shutdown steps");
                 return Err(CliError::UnexpectedError(format!(
                     "\nOne of the services crashed on startup:\n{:#?}\nPlease check the logs in {}",
                     // We can unwrap because we know for certain that the JoinSet is
@@ -378,7 +399,7 @@ impl CliCommand<()> for RunLocalnet {
             }
         }
 
-        eprintln!("\nApplying post startup steps...");
+        human_eprintln!("\nApplying post startup steps...");
 
         // Run any post healthy steps.
         for post_healthy_step in post_healthy_steps {
@@ -388,7 +409,7 @@ impl CliCommand<()> for RunLocalnet {
                 .context("Failed to run post startup step")?;
         }
 
-        eprintln!("\nSetup is complete, you can now use the localnet!");
+        human_eprintln!("\nSetup is complete, you can now use the localnet!");
 
         // Create a task that listens for ctrl-c. We want to intercept it so we can run
         // the shutdown steps before properly exiting. This is of course best effort,
@@ -419,9 +440,9 @@ impl CliCommand<()> for RunLocalnet {
 
         let was_ctrl_c = finished_task_id == ctrl_c_task_id;
         if was_ctrl_c {
-            eprintln!("\nReceived ctrl-c, running shutdown steps...");
+            human_eprintln!("\nReceived ctrl-c, running shutdown steps...");
         } else {
-            eprintln!("\nOne of the services exited unexpectedly, running shutdown steps...");
+            human_eprintln!("\nOne of the services exited unexpectedly, running shutdown steps...");
         }
 
         // At this point register another ctrl-c handler so the user can kill the CLI
@@ -431,14 +452,14 @@ impl CliCommand<()> for RunLocalnet {
                 .await
                 .expect("Failed to register ctrl-c hook");
             warn!("Received ctrl-c twice and exited immediately");
-            eprintln!();
+            human_eprintln!();
             std::process::exit(1);
         });
 
         // Run post shutdown steps, if any.
         run_shutdown_steps(shutdown_steps).await?;
 
-        eprintln!("Done, goodbye!");
+        human_eprintln!("Done, goodbye!");
 
         match was_ctrl_c {
             true => Ok(()),

--- a/crates/aptos/src/node/local_testnet/node.rs
+++ b/crates/aptos/src/node/local_testnet/node.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{health_checker::HealthChecker, traits::ServiceManager, RunLocalnet};
-use crate::node::local_testnet::utils::socket_addr_to_url;
+use crate::{human_eprintln, node::local_testnet::utils::socket_addr_to_url};
 use anyhow::{anyhow, Context, Result};
 use aptos_config::config::{NodeConfig, DEFAULT_GRPC_STREAM_PORT};
 use aptos_node::{load_node_config, start_test_environment_node};
@@ -146,7 +146,7 @@ impl NodeManager {
         txn_stream_port: u16,
         no_node: bool,
     ) -> Result<Self> {
-        eprintln!();
+        human_eprintln!();
 
         // Enable the grpc stream on the node if we will run a txn stream service.
         node_config.indexer_grpc.enabled = run_txn_stream;
@@ -220,7 +220,7 @@ impl ServiceManager for NodeManager {
 
         let node_thread_handle = thread::spawn(move || {
             let result = start_test_environment_node(self.config, self.test_dir, false);
-            eprintln!("Node stopped unexpectedly {:#?}", result);
+            human_eprintln!("Node stopped unexpectedly {:#?}", result);
         });
 
         // This just waits for the node thread forever.

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -7,6 +7,7 @@ pub mod local_testnet;
 use self::local_testnet::RunLocalnet;
 use crate::{
     common::{
+        cli_output::CliOutputMode,
         types::{
             CliCommand, CliError, CliResult, CliTypedResult, OptionalPoolAddressArgs,
             PoolAddressArgs, ProfileOptions, RestOptions, TransactionOptions, TransactionSummary,
@@ -14,6 +15,7 @@ use crate::{
         utils::read_from_file,
     },
     genesis::git::from_yaml,
+    human_println,
     node::analyze::{
         analyze_validators::{AnalyzeValidators, ValidatorStats},
         fetch_metadata::FetchMetadata,
@@ -101,10 +103,14 @@ impl NodeTool {
             ShowValidatorSet(tool) => tool.execute_serialized().await,
             ShowValidatorStake(tool) => tool.execute_serialized().await,
             ShowValidatorConfig(tool) => tool.execute_serialized().await,
-            RunLocalnet(tool) => tool
-                .execute_serialized_without_logger()
-                .await
-                .map(|_| "".to_string()),
+            RunLocalnet(tool) => {
+                let out = tool.execute_serialized_without_logger().await?;
+                if CliOutputMode::current().is_json_agent_mode() {
+                    Ok(out)
+                } else {
+                    Ok("".to_string())
+                }
+            },
             UpdateConsensusKey(tool) => tool.execute_serialized().await,
             UpdateValidatorNetworkAddresses(tool) => tool.execute_serialized().await,
         }
@@ -647,7 +653,7 @@ impl CliCommand<TransactionSummary> for InitializeValidator {
                 bcs::to_bytes(&full_node_network_addresses)?,
             ))
             .await
-            .map(|inner| inner.into())
+            .map(|t| self.txn_options.summarize_submitted_transaction(t))
     }
 }
 
@@ -708,7 +714,7 @@ impl CliCommand<TransactionSummary> for JoinValidatorSet {
         self.txn_options
             .submit_transaction(aptos_stdlib::stake_join_validator_set(address))
             .await
-            .map(|inner| inner.into())
+            .map(|t| self.txn_options.summarize_submitted_transaction(t))
     }
 }
 
@@ -738,7 +744,7 @@ impl CliCommand<TransactionSummary> for LeaveValidatorSet {
         self.txn_options
             .submit_transaction(aptos_stdlib::stake_leave_validator_set(address))
             .await
-            .map(|inner| inner.into())
+            .map(|t| self.txn_options.summarize_submitted_transaction(t))
     }
 }
 
@@ -1083,7 +1089,7 @@ impl CliCommand<TransactionSummary> for UpdateConsensusKey {
                 consensus_proof_of_possession.to_bytes().to_vec(),
             ))
             .await
-            .map(|inner| inner.into())
+            .map(|t| self.txn_options.summarize_submitted_transaction(t))
     }
 }
 
@@ -1144,7 +1150,7 @@ impl CliCommand<TransactionSummary> for UpdateValidatorNetworkAddresses {
                 bcs::to_bytes(&full_node_network_addresses)?,
             ))
             .await
-            .map(|inner| inner.into())
+            .map(|t| self.txn_options.summarize_submitted_transaction(t))
     }
 }
 
@@ -1229,7 +1235,7 @@ impl CliCommand<()> for AnalyzeValidatorPerformance {
                 epoch_stats.validator_stats = filtered_stats;
             }
             if print_detailed {
-                println!(
+                human_println!(
                     "Detailed table for {}epoch {}:",
                     if epoch_info.partial { "partial " } else { "" },
                     epoch_info.epoch
@@ -1249,7 +1255,7 @@ impl CliCommand<()> for AnalyzeValidatorPerformance {
             }
             if print_max_tps {
                 for (num_blocks_for_max_tps, max_tps) in &epoch_stats.max_tps_per_block_interval {
-                    println!(
+                    human_println!(
                         "In {}epoch {}: during consecutive {:?}, found peak of {} TPS, ending on version: {}, {} txns over {}s and {} blocks",
                         if epoch_info.partial { "partial " } else { "" },
                         epoch_info.epoch,
@@ -1268,12 +1274,12 @@ impl CliCommand<()> for AnalyzeValidatorPerformance {
         }
 
         if stats.is_empty() {
-            println!("No data found for given input");
+            human_println!("No data found for given input");
             return Ok(());
         }
         let total_stats = stats.values().cloned().reduce(|a, b| a + b).unwrap();
         if print_detailed {
-            println!(
+            human_println!(
                 "Detailed table for all epochs [{}, {}]:",
                 stats.keys().min().unwrap(),
                 stats.keys().max().unwrap()
@@ -1282,7 +1288,7 @@ impl CliCommand<()> for AnalyzeValidatorPerformance {
         }
         if print_max_tps {
             for (num_blocks_for_max_tps, max_tps) in &total_stats.max_tps_per_block_interval {
-                println!(
+                human_println!(
                     "Across all epochs: during consecutive {:?}, found peak of {} TPS, ending on version: {}, {} txns over {}s and {} blocks",
                     num_blocks_for_max_tps,
                     max_tps.tps,
@@ -1297,7 +1303,7 @@ impl CliCommand<()> for AnalyzeValidatorPerformance {
         if self.analyze_mode == AnalyzeMode::ValidatorHealthOverTime
             || self.analyze_mode == AnalyzeMode::All
         {
-            println!(
+            human_println!(
                 "Validator health over epochs [{}, {}]:",
                 stats.keys().min().unwrap(),
                 stats.keys().max().unwrap()
@@ -1307,7 +1313,7 @@ impl CliCommand<()> for AnalyzeValidatorPerformance {
         if self.analyze_mode == AnalyzeMode::NetworkHealthOverTime
             || self.analyze_mode == AnalyzeMode::All
         {
-            println!(
+            human_println!(
                 "Network health over epochs [{}, {}]:",
                 stats.keys().min().unwrap(),
                 stats.keys().max().unwrap()
@@ -1491,7 +1497,7 @@ impl Time {
 
 #[cfg(test)]
 mod tests {
-    use crate::{CliResult, Tool};
+    use crate::{CliResult, MovementCli};
     use clap::Parser;
 
     // TODO: there have to be cleaner ways to test things. Maybe a CLI test framework?
@@ -1525,8 +1531,9 @@ mod tests {
     }
 
     async fn run_tool_with_args(args: &[&str]) -> CliResult {
-        let tool: Tool = Tool::try_parse_from(args).map_err(|msg| msg.to_string())?;
-        tool.execute().await
+        let cli = MovementCli::try_parse_from(args).map_err(|msg| msg.to_string())?;
+        cli.install_output_mode();
+        cli.tool.execute().await
     }
 
     fn assert_contains(message: String, expected_string: &str) {

--- a/crates/aptos/src/stake/mod.rs
+++ b/crates/aptos/src/stake/mod.rs
@@ -92,7 +92,7 @@ impl CliCommand<Vec<TransactionSummary>> for AddStake {
                         self.txn_options
                             .submit_transaction(aptos_stdlib::stake_add_stake(amount))
                             .await
-                            .map(|inner| inner.into())?,
+                            .map(|t| self.txn_options.summarize_submitted_transaction(t))?,
                     );
                 },
                 StakePoolType::StakingContract => {
@@ -103,7 +103,7 @@ impl CliCommand<Vec<TransactionSummary>> for AddStake {
                                 amount,
                             ))
                             .await
-                            .map(|inner| inner.into())?,
+                            .map(|t| self.txn_options.summarize_submitted_transaction(t))?,
                     );
                 },
                 StakePoolType::Vesting => {
@@ -153,7 +153,7 @@ impl CliCommand<Vec<TransactionSummary>> for UnlockStake {
                         self.txn_options
                             .submit_transaction(aptos_stdlib::stake_unlock(amount))
                             .await
-                            .map(|inner| inner.into())?,
+                            .map(|t| self.txn_options.summarize_submitted_transaction(t))?,
                     );
                 },
                 StakePoolType::StakingContract => {
@@ -164,7 +164,7 @@ impl CliCommand<Vec<TransactionSummary>> for UnlockStake {
                                 amount,
                             ))
                             .await
-                            .map(|inner| inner.into())?,
+                            .map(|t| self.txn_options.summarize_submitted_transaction(t))?,
                     );
                 },
                 StakePoolType::Vesting => {
@@ -217,7 +217,7 @@ impl CliCommand<Vec<TransactionSummary>> for WithdrawStake {
                         self.node_op_options
                             .submit_transaction(aptos_stdlib::stake_withdraw(amount))
                             .await
-                            .map(|inner| inner.into())?,
+                            .map(|t| self.node_op_options.summarize_submitted_transaction(t))?,
                     );
                 },
                 StakePoolType::StakingContract => {
@@ -228,7 +228,7 @@ impl CliCommand<Vec<TransactionSummary>> for WithdrawStake {
                                 stake_pool.operator_address,
                             ))
                             .await
-                            .map(|inner| inner.into())?,
+                            .map(|t| self.node_op_options.summarize_submitted_transaction(t))?,
                     );
                 },
                 StakePoolType::Vesting => {
@@ -274,7 +274,7 @@ impl CliCommand<Vec<TransactionSummary>> for IncreaseLockup {
                         self.txn_options
                             .submit_transaction(aptos_stdlib::stake_increase_lockup())
                             .await
-                            .map(|inner| inner.into())?,
+                            .map(|t| self.txn_options.summarize_submitted_transaction(t))?,
                     );
                 },
                 StakePoolType::StakingContract => {
@@ -284,7 +284,7 @@ impl CliCommand<Vec<TransactionSummary>> for IncreaseLockup {
                                 stake_pool.operator_address,
                             ))
                             .await
-                            .map(|inner| inner.into())?,
+                            .map(|t| self.txn_options.summarize_submitted_transaction(t))?,
                     );
                 },
                 StakePoolType::Vesting => {
@@ -294,7 +294,7 @@ impl CliCommand<Vec<TransactionSummary>> for IncreaseLockup {
                                 stake_pool.vesting_contract.unwrap(),
                             ))
                             .await
-                            .map(|inner| inner.into())?,
+                            .map(|t| self.txn_options.summarize_submitted_transaction(t))?,
                     );
                 },
             }
@@ -340,7 +340,7 @@ impl CliCommand<TransactionSummary> for InitializeStakeOwner {
                 self.voter_address.unwrap_or(owner_address),
             ))
             .await
-            .map(|inner| inner.into())
+            .map(|t| self.txn_options.summarize_submitted_transaction(t))
     }
 }
 
@@ -385,7 +385,7 @@ impl CliCommand<Vec<TransactionSummary>> for SetOperator {
                                 new_operator_address,
                             ))
                             .await
-                            .map(|inner| inner.into())?,
+                            .map(|t| self.txn_options.summarize_submitted_transaction(t))?,
                     );
                 },
                 StakePoolType::StakingContract => {
@@ -398,7 +398,7 @@ impl CliCommand<Vec<TransactionSummary>> for SetOperator {
                                 ),
                             )
                             .await
-                            .map(|inner| inner.into())?,
+                            .map(|t| self.txn_options.summarize_submitted_transaction(t))?,
                     );
                 },
                 StakePoolType::Vesting => {
@@ -411,7 +411,7 @@ impl CliCommand<Vec<TransactionSummary>> for SetOperator {
                                 ),
                             )
                             .await
-                            .map(|inner| inner.into())?,
+                            .map(|t| self.txn_options.summarize_submitted_transaction(t))?,
                     );
                 },
             }
@@ -461,7 +461,7 @@ impl CliCommand<Vec<TransactionSummary>> for SetDelegatedVoter {
                                 new_voter_address,
                             ))
                             .await
-                            .map(|inner| inner.into())?,
+                            .map(|t| self.txn_options.summarize_submitted_transaction(t))?,
                     );
                 },
                 StakePoolType::StakingContract => {
@@ -472,7 +472,7 @@ impl CliCommand<Vec<TransactionSummary>> for SetDelegatedVoter {
                                 new_voter_address,
                             ))
                             .await
-                            .map(|inner| inner.into())?,
+                            .map(|t| self.txn_options.summarize_submitted_transaction(t))?,
                     );
                 },
                 StakePoolType::Vesting => {
@@ -483,7 +483,7 @@ impl CliCommand<Vec<TransactionSummary>> for SetDelegatedVoter {
                                 new_voter_address,
                             ))
                             .await
-                            .map(|inner| inner.into())?,
+                            .map(|t| self.txn_options.summarize_submitted_transaction(t))?,
                     );
                 },
             }
@@ -545,7 +545,7 @@ impl CliCommand<TransactionSummary> for CreateStakingContract {
                 vec![],
             ))
             .await
-            .map(|inner| inner.into())
+            .map(|t| self.txn_options.summarize_submitted_transaction(t))
     }
 }
 
@@ -574,7 +574,7 @@ impl CliCommand<TransactionSummary> for DistributeVestedCoins {
         self.txn_options
             .submit_transaction(aptos_stdlib::vesting_distribute(vesting_contract_address))
             .await
-            .map(|inner| inner.into())
+            .map(|t| self.txn_options.summarize_submitted_transaction(t))
     }
 }
 
@@ -607,7 +607,7 @@ impl CliCommand<TransactionSummary> for UnlockVestedCoins {
         self.txn_options
             .submit_transaction(aptos_stdlib::vesting_vest(vesting_contract_address))
             .await
-            .map(|inner| inner.into())
+            .map(|t| self.txn_options.summarize_submitted_transaction(t))
     }
 }
 
@@ -663,6 +663,6 @@ impl CliCommand<TransactionSummary> for RequestCommission {
                 self.operator_address,
             ))
             .await
-            .map(|inner| inner.into())
+            .map(|t| self.txn_options.summarize_submitted_transaction(t))
     }
 }

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -955,11 +955,15 @@ impl CliTestFramework {
         index: usize,
         script_contents: &str,
     ) -> CliTypedResult<TransactionSummary> {
-        self.run_script_with_framework_package(index, script_contents, FrameworkPackageArgs {
-            framework_git_rev: None,
-            framework_local_dir: Some(Self::aptos_framework_dir()),
-            skip_fetch_latest_git_deps: false,
-        })
+        self.run_script_with_framework_package(
+            index,
+            script_contents,
+            FrameworkPackageArgs {
+                framework_git_rev: None,
+                framework_local_dir: Some(Self::aptos_framework_dir()),
+                skip_fetch_latest_git_deps: false,
+            },
+        )
         .await
     }
 
@@ -988,11 +992,15 @@ impl CliTestFramework {
         index: usize,
         script_contents: &str,
     ) -> CliTypedResult<TransactionSummary> {
-        self.run_script_with_framework_package(index, script_contents, FrameworkPackageArgs {
-            framework_git_rev: None,
-            framework_local_dir: None,
-            skip_fetch_latest_git_deps: false,
-        })
+        self.run_script_with_framework_package(
+            index,
+            script_contents,
+            FrameworkPackageArgs {
+                framework_git_rev: None,
+                framework_local_dir: None,
+                skip_fetch_latest_git_deps: false,
+            },
+        )
         .await
     }
 

--- a/crates/aptos/src/test/tests.rs
+++ b/crates/aptos/src/test/tests.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     move_tool::{ArgWithType, FunctionArgType},
-    CliResult, Tool,
+    CliResult, MovementCli,
 };
 use clap::Parser;
 use std::str::FromStr;
@@ -55,6 +55,9 @@ async fn ensure_every_command_args_work() {
     .await;
 
     assert_cmd_not_panic(&["aptos", "info"]).await;
+
+    assert_cmd_not_panic(&["aptos", "meta"]).await;
+    assert_cmd_not_panic(&["aptos", "meta", "commands-schema", "--help"]).await;
 
     assert_cmd_not_panic(&["aptos", "init", "--help"]).await;
 
@@ -143,6 +146,7 @@ async fn assert_cmd_not_panic(args: &[&str]) {
 }
 
 async fn run_cmd(args: &[&str]) -> CliResult {
-    let tool: Tool = Tool::try_parse_from(args).map_err(|msg| msg.to_string())?;
-    tool.execute().await
+    let cli = MovementCli::try_parse_from(args).map_err(|msg| msg.to_string())?;
+    cli.install_output_mode();
+    cli.tool.execute().await
 }

--- a/crates/aptos/src/update/prover_dependencies.rs
+++ b/crates/aptos/src/update/prover_dependencies.rs
@@ -4,6 +4,7 @@
 use crate::{
     cli_build_information,
     common::types::{CliCommand, CliError, CliTypedResult, PromptOptions},
+    human_eprintln, human_println,
     update::{
         get_additional_binaries_dir, prover_dependency_installer::DependencyInstaller,
         update_binary,
@@ -81,13 +82,13 @@ impl ProverDependencyInstaller {
 
         set_env::set(env_var, install_path.to_string_lossy())
             .map_err(|e| CliError::UnexpectedError(format!("Failed to set {}: {}", env_var, e)))?;
-        println!(
+        human_println!(
             "Added {} to environment with value: {} to the profile.",
             env_var,
             install_path.to_string_lossy()
         );
         if env::var(env_var).is_err() {
-            eprintln!("Please use the `source` command or reboot the terminal to check whether {} is set with the correct value. \
+            human_eprintln!("Please use the `source` command or reboot the terminal to check whether {} is set with the correct value. \
             If not, please set it manually.", env_var);
         }
         Ok(())
@@ -130,7 +131,7 @@ impl ProverDependencyInstaller {
                 BOOGIE_EXE_ENV,
             )
             .await?;
-        println!("{}", res);
+        human_println!("{}", res);
 
         BoogieOptions::check_version_is_compatible(
             Z3_BINARY_NAME,
@@ -149,7 +150,7 @@ impl ProverDependencyInstaller {
                 Z3_EXE_ENV,
             )
             .await?;
-        println!("{}", res);
+        human_println!("{}", res);
 
         #[cfg(unix)]
         {
@@ -170,7 +171,7 @@ impl ProverDependencyInstaller {
                     CVC5_EXE_ENV,
                 )
                 .await?;
-            println!("{}", res);
+            human_println!("{}", res);
         }
 
         Ok("Succeeded".to_string())
@@ -201,7 +202,7 @@ impl ProverDependencyInstaller {
 
         let install_dir = install_dir.join(exe_name);
         if let Err(err) = self.add_env_var(env_name, &install_dir) {
-            eprintln!("{:#}. Please set it manually", err);
+            human_eprintln!("{:#}. Please set it manually", err);
         }
         Ok(result)
     }


### PR DESCRIPTION
## Title

Movement CLI: JSON output for AI agents (`--output json`, `MOVEMENT_OUTPUT` env var)

## Summary

Improves **AI agent and scripted** use of the Movement CLI (`crates/aptos`) by adding an explicit **human vs JSON** output mode, a **stable JSON envelope** (compact in JSON mode), **`--dry-run`** and **explorer URLs** where wired, **explicit confirms** for destructive operations, a **`movement meta commands-schema`** subcommand (with **`--path`** and **`--brief`** for scoped, token-efficient schema dumps), and a sweep that routes much incidental stdout/stderr through **`human_*`** macros so **JSON mode can treat stdout as the primary machine-readable result line**.

**Note:** There is no separate `--agent` flag. **JSON mode** (`--output json` or `MOVEMENT_OUTPUT=json`) is the supported machine-oriented interface for agents and tooling.

Human-facing defaults and existing workflows (including Python/e2e and `smoke-test`) are preserved.

## Output mode & envelope

- **Global** `--output human|json`, same setting also available via the **`MOVEMENT_OUTPUT`** environment variable (clap: **command-line `--output` takes precedence when both are set**; they do not error or apply two modes at once).
- **`main`** installs the resolved output mode, then runs **`execute()`**; success/error use the existing envelope, with **compact JSON** in JSON mode.
- **`TransactionSummary`** may include **`explorer_url`** via **`summarize_submitted_transaction` / `attach_explorer_url`** where integrated.

## Safety & scripted use

- **Transaction options:** **`--dry-run`** (simulate, no submit) where implemented.
- **Genesis:** **`--confirm-overwrite`** for overwriting genesis artifacts.
- **Localnet:** **`--destructive-confirm`** for destructive **`--force-restart`** / data-deletion paths when **`--assume-yes`** is not used (aligned with documented delete-localnet behavior).

## Meta / discovery

- **`movement meta commands-schema`:** emits a **JSON tree** of commands for tools and agents (names, args, subcommands, help text).
- **`--path PATH` (optional):** space-separated subcommand names from the CLI root (e.g. `move publish`) to emit **only that subtree** instead of the full tree. Unknown segments return **`CommandArgumentError`** with the list of valid child command names at that level.
- **`--brief`:** omit verbose fields (**`help`** on arguments, **`about`** on commands); keeps structural fields (**`name`**, **`long`**, **`required`**, **`num_args`**, aliases, nested **`subcommands`**). Omitted optional fields are left out of the JSON (not `null`) where applicable.

## Human-only I/O (`human_*` macros)

- **`human_println!` / `human_print!` / `human_eprintln!` / `human_eprint!`** in **`common/cli_output.rs`**: no-op in JSON mode for typical progress / UX text.
- Applied across many modules (e.g. **`move_tool`**, **`governance`**, **`node`**, **`local_testnet`**, **`common/types`**, **`common/transactions`**, **`init`** on non-prompt paths, **`key_rotation`** for non-Ledger summary noise, **`fmt`**, **`prover_dependencies`**, etc.).

**Intentional raw `println!` / `eprintln!` remain** where suppression would break behavior, including: interactive **`init`** prompts, **Ledger** prompts in **`key_rotation`**, bytecode **coverage** listing in JSON mode (**stderr**, by design), **genesis** diagnostics before **`Err`**, and **`main`** envelope printing.

## Docs

- **`crates/aptos/CONTRIBUTING.md`:** “Agent and automation output” (flags, env, JSON expectations, precedence).
- **`crates/aptos/README.md`:** short automation pointer (`--output json`, `MOVEMENT_OUTPUT`, `meta`, CONTRIBUTING).

## Tests / call sites

- Tests and completion generation updated for **`MovementCli`** as the root parser (e.g. **`try_parse_from`**, **`generate_cli_completions::<MovementCli>`**).

## How to test

```bash
cargo check -p movement
cargo test -p movement --lib
cargo check -p smoke-test