### PR TITLE
[ci] add aptos-debugger container and migrate to blacksmith runners

### DIFF
--- a/.github/workflows/build-versions.yaml
+++ b/.github/workflows/build-versions.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   setup:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     outputs:
       short_sha: ${{ steps.chop_sha.outputs.short_sha }}
       build_date: ${{ steps.build_date.outputs.build_date }}
@@ -74,7 +74,7 @@ jobs:
   binaries-aptos-node:
     needs: 
       - setup
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     name: "Build ${{ matrix.binary.package }} with Nix"
     strategy:
       matrix:
@@ -82,6 +82,7 @@ jobs:
           - package: "aptos-node"
           - package: "movement"
           - package: "l1-migration"
+          - package: "aptos-debugger"
     env:
       TARGET_FOLDER: target/${{ needs.setup.outputs.build_profile }}
     steps:
@@ -89,7 +90,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha}}
       - name: Build binary ${{ matrix.binary.package }}
-        uses: movementlabsxyz/aptos-core/.github/actions/build-binary@ci/version-builds
+        uses: movementlabsxyz/aptos-core/.github/actions/build-binary@m1
         with:
           binary_package: ${{ matrix.binary.package }}
           profile: ${{ needs.setup.outputs.build_profile }}
@@ -99,7 +100,7 @@ jobs:
     needs: 
       - setup
       - binaries-aptos-node
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     name: "build container: aptos-node"
     permissions:
       contents: read
@@ -131,7 +132,7 @@ jobs:
         run: ls -la ${{ env.TARGET_FOLDER }}
         
       - name: Build Container
-        uses: movementlabsxyz/aptos-core/.github/actions/build-container@ci/version-builds
+        uses: movementlabsxyz/aptos-core/.github/actions/build-container@m1
         with:
           image_name: ghcr.io/movementlabsxyz/aptos-node
           dockerfile_subdir: aptos-node
@@ -145,10 +146,48 @@ jobs:
           ghcr_password: ${{ secrets.INFRA_GH_PAT }}
           git_sha: ${{ needs.setup.outputs.git_sha }}
 
+  container-aptos-debugger:
+    needs:
+      - setup
+      - binaries-aptos-node
+    runs-on: blacksmith-16vcpu-ubuntu-2204
+    name: "build container: aptos-debugger"
+    permissions:
+      contents: read
+      packages: write
+    env:
+      TARGET_FOLDER: target/${{ needs.setup.outputs.build_profile }}
+      SHORT_SHA: ${{ needs.setup.outputs.short_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha}}
+      - name: Download aptos-debugger binary
+        uses: actions/download-artifact@v4
+        with:
+          name: aptos-debugger-${{ env.SHORT_SHA }}
+          path: ${{ env.TARGET_FOLDER }}
+      - name: List binaries
+        run: ls -la ${{ env.TARGET_FOLDER }}
+      - name: Build Container
+        uses: movementlabsxyz/aptos-core/.github/actions/build-container@m1
+        with:
+          image_name: ghcr.io/movementlabsxyz/aptos-debugger
+          dockerfile_subdir: aptos-debugger
+          build_args: |
+            BINARY_PATH=${{ env.TARGET_FOLDER }}
+            GIT_SHA=${{ env.SHORT_SHA }}
+            GIT_TAG=${{ needs.setup.outputs.git_tag }}
+            GIT_BRANCH=${{ needs.setup.outputs.git_branch }}
+            BUILD_DATE=${{ needs.setup.outputs.build_date }}
+          ghcr_username: ${{ vars.INFRA_GH_USER }}
+          ghcr_password: ${{ secrets.INFRA_GH_PAT }}
+          git_sha: ${{ needs.setup.outputs.git_sha }}
+
   binaries-aptos-faucet-service:
     needs: 
       - setup
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     name: "Build ${{ matrix.binary.package }} with Nix"
     strategy:
       matrix:
@@ -161,7 +200,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha}}
       - name: Build binary ${{ matrix.binary.package }}
-        uses: movementlabsxyz/aptos-core/.github/actions/build-binary@ci/version-builds
+        uses: movementlabsxyz/aptos-core/.github/actions/build-binary@m1
         with:
           binary_package: ${{ matrix.binary.package }}
           profile: ${{ needs.setup.outputs.build_profile }}
@@ -171,7 +210,7 @@ jobs:
     needs: 
       - setup
       - binaries-aptos-faucet-service
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     name: "build container: aptos-faucet-service"
     permissions:
       contents: read
@@ -193,7 +232,7 @@ jobs:
         run: ls -la ${{ env.TARGET_FOLDER }}
         
       - name: Build Container
-        uses: movementlabsxyz/aptos-core/.github/actions/build-container@ci/version-builds
+        uses: movementlabsxyz/aptos-core/.github/actions/build-container@m1
         with:
           image_name: ghcr.io/movementlabsxyz/aptos-faucet-service
           dockerfile_subdir: aptos-faucet-service
@@ -210,7 +249,7 @@ jobs:
   binaries-aptos-tools:
     needs: 
       - setup
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     name: "Build ${{ matrix.binary.package }} with Nix"
     strategy:
       matrix:
@@ -223,7 +262,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha}}
       - name: Build binary ${{ matrix.binary.package }}
-        uses: movementlabsxyz/aptos-core/.github/actions/build-binary@ci/version-builds
+        uses: movementlabsxyz/aptos-core/.github/actions/build-binary@m1
         with:
           binary_package: ${{ matrix.binary.package }}
           profile: ${{ needs.setup.outputs.build_profile }}

--- a/.github/workflows/pull-request-validation.yaml
+++ b/.github/workflows/pull-request-validation.yaml
@@ -80,7 +80,7 @@ jobs:
             package: "aptos-node"
             profile: "dev"
           - name: "aptos-cli"
-            package: "aptos"
+            package: "movement"
             profile: "dev"
           - name: "l1-migration"
             package: "l1-migration"
@@ -145,70 +145,6 @@ jobs:
           name: ${{ matrix.binary.package }}-${{ github.sha }}
           path: ${{ env.TARGET_FOLDER }}/${{ matrix.binary.package }}
           retention-days: 7
-
-  build-docker:
-    needs: build-binaries
-    runs-on: ubuntu-latest
-    name: "Build Docker Images"
-    permissions:
-      contents: read
-      packages: write
-    env:
-      TARGET_FOLDER: target/debug
-    steps:
-      - uses: actions/checkout@v4
-      
-      # Download artifacts
-      - name: Download aptos-node binary
-        uses: actions/download-artifact@v4
-        with:
-          name: aptos-node-${{ github.sha }}
-          path: ${{ env.TARGET_FOLDER }}
-      - name: Download aptos binary
-        uses: actions/download-artifact@v4
-        with:
-          name: aptos-${{ github.sha }}
-          path: ${{ env.TARGET_FOLDER }}
-      - name: Download l1-migration binary
-        uses: actions/download-artifact@v4
-        with:
-          name: l1-migration-${{ github.sha }}
-          path: ${{ env.TARGET_FOLDER }}
-      - name: List binaries
-        run: ls -la ${{ env.TARGET_FOLDER }}
-      # Setup Docker Buildx (replaces manual Docker checks)
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          version: latest
-
-      # Log in to GHCR (can also use docker/login-action)
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ vars.INFRA_GH_USER }}
-          password: ${{ secrets.INFRA_GH_PAT }}
-      
-      # Set build environment variables
-      - name: Set build environment
-        run: |
-          echo "GIT_SHA_SHORT=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
-          echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
-      
-      # Build and push Docker image
-      - name: Build and push aptos-node Docker image
-        run: |
-          docker build --build-arg BINARY_PATH=target/debug -f docker/aptos-node/Dockerfile -t ghcr.io/movementlabsxyz/aptos-node:${{ env.GIT_SHA_SHORT }} .
-          docker push ghcr.io/movementlabsxyz/aptos-node:${{ env.GIT_SHA_SHORT }}
-      
-      # Output image information
-      - name: Output image information
-        run: |
-          echo "✅ Docker image built and pushed successfully!"
-          echo "📦 Image: ghcr.io/movementlabsxyz/aptos-node:${{ env.GIT_SHA_SHORT }}"
-          echo "🏷️  Tag: ${{ env.GIT_SHA_SHORT }}"
-          echo "🌐 Registry: ghcr.io/movementlabsxyz/aptos-node"
 
   # Test CLI release build to verify the release workflow will work
   test-cli-release-build:

--- a/Justfile
+++ b/Justfile
@@ -85,6 +85,9 @@ container-build container="aptos-node" tag="latest" profile="release":
             just build aptos {{profile}}
             just build l1-migration {{profile}}
             ;;
+        "aptos-debugger")
+            just build aptos-debugger {{profile}}
+            ;;
         "aptos-faucet-service")
             just build aptos-faucet-service {{profile}}
             ;;
@@ -111,6 +114,27 @@ container-build container="aptos-node" tag="latest" profile="release":
     
     # Clean up the copied binary
     rm -f aptos-test
+
+# Push a container image to GHCR
+container-push container="aptos-node" tag="latest":
+    docker push ghcr.io/movementlabsxyz/{{container}}:{{tag}}
+
+# Build and push a container image
+container-release container="aptos-node" tag="latest" profile="release":
+    just container-build {{container}} {{tag}} {{profile}}
+    just container-push {{container}} {{tag}}
+
+# List available container targets
+list-containers:
+    @echo "Available container build targets:"
+    @echo "  aptos-node          - L1 blockchain node (aptos-node + movement + l1-migration)"
+    @echo "  aptos-debugger      - Database backup and restore tool"
+    @echo "  aptos-faucet-service - Token faucet for test networks"
+    @echo ""
+    @echo "Usage:"
+    @echo "  just container-build <container> [tag] [profile]"
+    @echo "  just container-push <container> [tag]"
+    @echo "  just container-release <container> [tag] [profile]  # build + push"
 
 # Build any binary by package name
 build-bin package:
@@ -143,3 +167,9 @@ help:
     @echo "  Use 'just build <binary-name>' for common binary builds"
     @echo "  Use 'just build' to build all packages"
     @echo "  Use 'just build-bin <package-name>' for custom package builds"
+    @echo ""
+    @echo "Container Build Options:"
+    @echo "  Use 'just list-containers' to see available container targets"
+    @echo "  Use 'just container-build <container>' to build a container image"
+    @echo "  Use 'just container-push <container>' to push to GHCR"
+    @echo "  Use 'just container-release <container>' to build + push"

--- a/docker/aptos-debugger/Dockerfile
+++ b/docker/aptos-debugger/Dockerfile
@@ -30,7 +30,7 @@ ARG GIT_SHA
 ENV GIT_SHA=${GIT_SHA}
 
 # Verify the binary can be executed
-RUN LD_LIBRARY_PATH=/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu /usr/local/bin/aptos-debugger --version
+RUN LD_LIBRARY_PATH=/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu /usr/local/bin/aptos-debugger --help
 
 ENTRYPOINT ["/usr/local/bin/aptos-debugger"]
-CMD ["--version"]
+CMD ["--help"]

--- a/docker/aptos-debugger/Dockerfile
+++ b/docker/aptos-debugger/Dockerfile
@@ -1,0 +1,36 @@
+FROM docker.io/library/ubuntu:24.04
+
+# Install necessary dependencies (same base as aptos-node)
+RUN apt-get update && apt-get install -y \
+libjemalloc2 \
+libdw1 \
+librocksdb-dev \
+libssl3 \
+libstdc++6 \
+zlib1g \
+ca-certificates \
+patchelf \
+&& rm -rf /var/lib/apt/lists/* \
+&& ln -sf /usr/lib/x86_64-linux-gnu/librocksdb.so /usr/lib/x86_64-linux-gnu/librocksdb.so.10
+
+WORKDIR /app
+
+ARG BINARY_PATH=target/release
+COPY --chmod=0755 ${BINARY_PATH}/aptos-debugger /usr/local/bin/aptos-debugger
+RUN patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 /usr/local/bin/aptos-debugger
+
+# Add build info
+ARG BUILD_DATE
+ENV BUILD_DATE=${BUILD_DATE}
+ARG GIT_TAG
+ENV GIT_TAG=${GIT_TAG}
+ARG GIT_BRANCH
+ENV GIT_BRANCH=${GIT_BRANCH}
+ARG GIT_SHA
+ENV GIT_SHA=${GIT_SHA}
+
+# Verify the binary can be executed
+RUN LD_LIBRARY_PATH=/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu /usr/local/bin/aptos-debugger --version
+
+ENTRYPOINT ["/usr/local/bin/aptos-debugger"]
+CMD ["--version"]

--- a/docker/aptos-debugger/README.md
+++ b/docker/aptos-debugger/README.md
@@ -1,0 +1,54 @@
+# Aptos Debugger Docker Image
+
+Lightweight container image containing the `aptos-debugger` binary for database
+backup and restore operations.
+
+## What's Included
+
+- `aptos-debugger` — Aptos database debugging and backup tool
+
+## Use Cases
+
+- **Continuous backup**: Runs `aptos-debugger aptos-db backup continuously` as a
+  sidecar alongside an archival node, streaming epoch endings, state snapshots, and
+  transactions to S3.
+- **Native restore**: Runs `aptos-debugger aptos-db restore bootstrap-db` to restore
+  a node's database from continuous backup data in S3.
+
+## Building Locally
+
+From the repository root:
+
+```bash
+# Build the binary + container image
+just container-build aptos-debugger latest release
+
+# Verify
+docker run --rm ghcr.io/movementlabsxyz/aptos-debugger:latest --version
+```
+
+## Pushing to GHCR
+
+```bash
+# Authenticate (one-time)
+docker login ghcr.io -u <username>
+
+# Push
+docker push ghcr.io/movementlabsxyz/aptos-debugger:latest
+```
+
+## CI
+
+The `build-versions.yaml` workflow automatically builds and pushes this image on
+every push to the default branch. The image is tagged with the short git SHA
+(e.g., `ghcr.io/movementlabsxyz/aptos-debugger:f24a5bc`).
+
+## Runtime Dependencies
+
+Same shared libraries as the `aptos-node` image:
+
+- libjemalloc.so.2
+- libdw.so.1
+- librocksdb.so.10
+- libssl.so.3
+- Standard glibc libraries


### PR DESCRIPTION
Currently there is no container image for the aptos-debugger tool, requiring
manual setup to run it in containerized environments. Additionally, the CI
build infrastructure uses buildjet runners which have [been shutdown](https://buildjet.com/for-github-actions/blog/we-are-shutting-down).

This change adds a Dockerfile and README for the aptos-debugger container,
integrates it into the binary build matrix with a new container build job,
and migrates all runners from buildjet to blacksmith. It also adds Justfile
targets for container-push, container-release, and list-containers to
streamline container operations, and updates action refs to target m1.