### PR TITLE
feat: disable DFA support

### DIFF
--- a/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
+++ b/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
@@ -13,7 +13,7 @@ module aptos_experimental::confidential_asset {
     use aptos_framework::coin;
     use aptos_framework::event;
     use aptos_framework::dispatchable_fungible_asset;
-    use aptos_framework::fungible_asset::{Metadata};
+    use aptos_framework::fungible_asset::{Self, Metadata};
     use aptos_framework::object::{Self, ExtendRef, Object};
     use aptos_framework::primary_fungible_store;
     use aptos_framework::system_addresses;
@@ -84,6 +84,10 @@ module aptos_experimental::confidential_asset {
 
     /// `sender_auditor_hint` exceeds [`MAX_SENDER_AUDITOR_HINT_BYTES`].
     const EAUDITOR_HINT_TOO_LONG: u64 = 18;
+
+    /// Dispatchable fungible asset types (those with custom withdraw, deposit, balance, or
+    /// supply hooks) are not yet supported in confidential transfers.
+    const EUNSAFE_DISPATCHABLE_FA: u64 = 19;
 
     //
     // Constants
@@ -767,6 +771,7 @@ module aptos_experimental::confidential_asset {
         token: Object<Metadata>,
         ek: twisted_elgamal::CompressedPubkey) acquires FAController, FAConfig
     {
+        assert!(is_safe_for_confidentiality(&token), error::invalid_argument(EUNSAFE_DISPATCHABLE_FA));
         assert!(is_token_allowed(token), error::invalid_argument(ETOKEN_DISABLED));
 
         let user = signer::address_of(sender);
@@ -798,6 +803,7 @@ module aptos_experimental::confidential_asset {
         to: address,
         amount: u64) acquires ConfidentialAssetStore, FAController, FAConfig
     {
+        assert!(is_safe_for_confidentiality(&token), error::invalid_argument(EUNSAFE_DISPATCHABLE_FA));
         assert!(is_token_allowed(token), error::invalid_argument(ETOKEN_DISABLED));
         assert!(!is_frozen(to, token), error::invalid_state(EALREADY_FROZEN));
 
@@ -806,7 +812,12 @@ module aptos_experimental::confidential_asset {
         let sender_fa_store = primary_fungible_store::ensure_primary_store_exists(from, token);
         let ca_fa_store = primary_fungible_store::ensure_primary_store_exists(get_fa_store_address(), token);
 
+        let pool_before = fungible_asset::balance(ca_fa_store);
         dispatchable_fungible_asset::transfer(sender, sender_fa_store, ca_fa_store, amount);
+        assert!(
+            fungible_asset::balance(ca_fa_store) - pool_before == amount,
+            error::invalid_argument(EUNSAFE_DISPATCHABLE_FA)
+        );
 
         let ca_store = borrow_global_mut<ConfidentialAssetStore>(get_user_address(to, token));
         let pending_balance = confidential_balance::decompress_balance(&ca_store.pending_balance);
@@ -844,6 +855,8 @@ module aptos_experimental::confidential_asset {
         new_balance: confidential_balance::ConfidentialBalance,
         proof: WithdrawalProof) acquires ConfidentialAssetStore, FAController
     {
+        assert!(is_safe_for_confidentiality(&token), error::invalid_argument(EUNSAFE_DISPATCHABLE_FA));
+
         let from = signer::address_of(sender);
 
         let sender_ek = encryption_key(from, token);
@@ -866,7 +879,12 @@ module aptos_experimental::confidential_asset {
         ca_store.normalized = true;
         ca_store.actual_balance = confidential_balance::compress_balance(&new_balance);
 
+        let pool_before = primary_fungible_store::balance(get_fa_store_address(), token);
         primary_fungible_store::transfer(&get_fa_store_signer(), token, to, amount);
+        assert!(
+            pool_before - primary_fungible_store::balance(get_fa_store_address(), token) == amount,
+            error::invalid_argument(EUNSAFE_DISPATCHABLE_FA)
+        );
 
         event::emit(Withdrawn {
             from,
@@ -890,6 +908,7 @@ module aptos_experimental::confidential_asset {
         proof: TransferProof,
         sender_auditor_hint: vector<u8>) acquires ConfidentialAssetStore, FAConfig, FAController
     {
+        assert!(is_safe_for_confidentiality(&token), error::invalid_argument(EUNSAFE_DISPATCHABLE_FA));
         assert!(is_token_allowed(token), error::invalid_argument(ETOKEN_DISABLED));
         assert!(!is_frozen(to, token), error::invalid_state(EALREADY_FROZEN));
         assert!(
@@ -1131,6 +1150,16 @@ module aptos_experimental::confidential_asset {
     //
     // Private functions.
     //
+
+    /// Returns whether the given asset type is safe for use in confidential transfers.
+    ///
+    /// Dispatchable fungible assets can override withdraw, deposit, balance, or supply
+    /// behaviour in ways that are incompatible with encrypted on-chain balances (e.g.,
+    /// fee-on-transfer tokens, rebasing balances, custom supply hooks). Until a safe
+    /// integration path exists, only vanilla (non-dispatchable) FA types are accepted.
+    fun is_safe_for_confidentiality(token: &Object<Metadata>): bool {
+        !fungible_asset::is_asset_type_dispatchable(token)
+    }
 
     /// Ensures that the `FAConfig` object exists for the specified token.
     /// If the object does not exist, creates it.

--- a/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
+++ b/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
@@ -1156,7 +1156,7 @@ module aptos_experimental::confidential_asset {
     /// Dispatchable fungible assets can override withdraw, deposit, balance, or supply
     /// behaviour in ways that are incompatible with encrypted on-chain balances (e.g.,
     /// fee-on-transfer tokens, rebasing balances, custom supply hooks). Until a safe
-    /// integration path exists, only vanilla (non-dispatchable) FA types are accepted.
+    /// integration path exists, only standard (non-dispatchable) FA types are accepted.
     fun is_safe_for_confidentiality(token: &Object<Metadata>): bool {
         !fungible_asset::is_asset_type_dispatchable(token)
     }

--- a/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
+++ b/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
@@ -13,7 +13,7 @@ module aptos_experimental::confidential_asset {
     use aptos_framework::coin;
     use aptos_framework::event;
     use aptos_framework::dispatchable_fungible_asset;
-    use aptos_framework::fungible_asset::{Self, Metadata};
+    use aptos_framework::fungible_asset::{Self, FungibleStore, Metadata};
     use aptos_framework::object::{Self, ExtendRef, Object};
     use aptos_framework::primary_fungible_store;
     use aptos_framework::system_addresses;
@@ -754,10 +754,7 @@ module aptos_experimental::confidential_asset {
     #[view]
     /// Returns the circulating supply of the confidential asset.
     public fun confidential_asset_balance(token: Object<Metadata>): u64 acquires FAController {
-        let fa_store_address = get_fa_store_address();
-        assert!(primary_fungible_store::primary_store_exists(fa_store_address, token), EINTERNAL_ERROR);
-
-        primary_fungible_store::balance(fa_store_address, token)
+        fungible_asset::balance(get_pool_fa_store(token))
     }
 
     //
@@ -809,15 +806,11 @@ module aptos_experimental::confidential_asset {
 
         let from = signer::address_of(sender);
 
-        let sender_fa_store = primary_fungible_store::ensure_primary_store_exists(from, token);
-        let ca_fa_store = primary_fungible_store::ensure_primary_store_exists(get_fa_store_address(), token);
+        let pool_fa_store = ensure_pool_fa_store(token);
 
-        let pool_before = fungible_asset::balance(ca_fa_store);
-        dispatchable_fungible_asset::transfer(sender, sender_fa_store, ca_fa_store, amount);
-        assert!(
-            fungible_asset::balance(ca_fa_store) - pool_before == amount,
-            error::invalid_argument(EUNSAFE_DISPATCHABLE_FA)
-        );
+        let pool_before = fungible_asset::balance(pool_fa_store);
+        let sender_fa_store = primary_fungible_store::primary_store(from, token);
+        dispatchable_fungible_asset::transfer(sender, sender_fa_store, pool_fa_store, amount);
 
         let ca_store = borrow_global_mut<ConfidentialAssetStore>(get_user_address(to, token));
         let pending_balance = confidential_balance::decompress_balance(&ca_store.pending_balance);
@@ -843,6 +836,11 @@ module aptos_experimental::confidential_asset {
             amount,
             new_pending_balance: ca_store.pending_balance,
         });
+
+        assert!(
+            amount == fungible_asset::balance(pool_fa_store) - pool_before,
+            error::invalid_argument(EUNSAFE_DISPATCHABLE_FA)
+        );
     }
 
     /// Implementation of the `withdraw_to` entry function.
@@ -879,12 +877,10 @@ module aptos_experimental::confidential_asset {
         ca_store.normalized = true;
         ca_store.actual_balance = confidential_balance::compress_balance(&new_balance);
 
-        let pool_before = primary_fungible_store::balance(get_fa_store_address(), token);
-        primary_fungible_store::transfer(&get_fa_store_signer(), token, to, amount);
-        assert!(
-            pool_before - primary_fungible_store::balance(get_fa_store_address(), token) == amount,
-            error::invalid_argument(EUNSAFE_DISPATCHABLE_FA)
-        );
+        let pool_fa_store = get_pool_fa_store(token);
+        let pool_before = fungible_asset::balance(pool_fa_store);
+        let recipient_fa_store = primary_fungible_store::ensure_primary_store_exists(to, token);
+        dispatchable_fungible_asset::transfer(&get_fa_store_signer(), pool_fa_store, recipient_fa_store, amount);
 
         event::emit(Withdrawn {
             from,
@@ -893,6 +889,11 @@ module aptos_experimental::confidential_asset {
             amount,
             new_available_balance: ca_store.actual_balance,
         });
+
+        assert!(
+            amount == pool_before - fungible_asset::balance(pool_fa_store),
+            error::invalid_argument(EUNSAFE_DISPATCHABLE_FA)
+        );
     }
 
     /// Implementation of the `confidential_transfer` entry function.
@@ -1187,6 +1188,16 @@ module aptos_experimental::confidential_asset {
     /// Returns the address that handles all the FA primary stores.
     fun get_fa_store_address(): address acquires FAController {
         object::address_from_extend_ref(&borrow_global<FAController>(@aptos_experimental).extend_ref)
+    }
+
+    /// Returns the pool's primary fungible store for the given token, aborting if it does not exist.
+    fun get_pool_fa_store(token: Object<Metadata>): Object<FungibleStore> acquires FAController {
+        primary_fungible_store::primary_store(get_fa_store_address(), token)
+    }
+
+    /// Returns the pool's primary fungible store for the given token, creating it if necessary.
+    fun ensure_pool_fa_store(token: Object<Metadata>): Object<FungibleStore> acquires FAController {
+        primary_fungible_store::ensure_primary_store_exists(get_fa_store_address(), token)
     }
 
     /// Returns an object for handling the `ConfidentialAssetStore` and returns a signer for it.

--- a/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
+++ b/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
@@ -89,6 +89,9 @@ module aptos_experimental::confidential_asset {
     /// supply hooks) are not yet supported in confidential transfers.
     const EUNSAFE_DISPATCHABLE_FA: u64 = 19;
 
+    /// No confidential asset pool exists for the given asset type.
+    const ENO_CONFIDENTIAL_ASSET_POOL: u64 = 20;
+
     //
     // Constants
     //
@@ -1192,7 +1195,9 @@ module aptos_experimental::confidential_asset {
 
     /// Returns the pool's primary fungible store for the given token, aborting if it does not exist.
     fun get_pool_fa_store(token: Object<Metadata>): Object<FungibleStore> acquires FAController {
-        primary_fungible_store::primary_store(get_fa_store_address(), token)
+        let pool_addr = get_fa_store_address();
+        assert!(primary_fungible_store::primary_store_exists(pool_addr, token), error::not_found(ENO_CONFIDENTIAL_ASSET_POOL));
+        primary_fungible_store::primary_store(pool_addr, token)
     }
 
     /// Returns the pool's primary fungible store for the given token, creating it if necessary.

--- a/aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_asset_tests.move
+++ b/aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_asset_tests.move
@@ -1027,7 +1027,7 @@ module aptos_experimental::confidential_asset_tests {
         fa = @0xfa,
         alice = @0xa1
     )]
-    fun success_vanilla_fa_not_blocked(
+    fun success_standard_fa_not_blocked(
         confidential_asset: signer,
         aptos_fx: signer,
         fa: signer,

--- a/aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_asset_tests.move
+++ b/aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_asset_tests.move
@@ -8,6 +8,7 @@ module aptos_experimental::confidential_asset_tests {
     use aptos_framework::account;
     use aptos_framework::chain_id;
     use aptos_framework::coin;
+    use aptos_framework::dispatchable_fungible_asset;
     use aptos_framework::fungible_asset::{Self, Metadata};
     use aptos_framework::object::{Self, Object};
     use aptos_framework::primary_fungible_store;
@@ -956,5 +957,89 @@ module aptos_experimental::confidential_asset_tests {
         assert!(coin::balance<MockCoin>(alice_addr) == 50, 1);
         assert!(primary_fungible_store::balance(alice_addr, token) == 50, 1);
         assert!(confidential_asset::verify_pending_balance(alice_addr, token, &alice_dk, 50), 1);
+    }
+
+    fun set_up_dispatchable_fa_test(
+        confidential_asset_signer: &signer,
+        aptos_fx: &signer,
+        fa: &signer,
+        sender: &signer,
+        sender_amount: u64): Object<Metadata>
+    {
+        chain_id::initialize_for_test(aptos_fx, 4);
+
+        let ctor_ref = &object::create_sticky_object(signer::address_of(fa));
+
+        primary_fungible_store::create_primary_store_enabled_fungible_asset(
+            ctor_ref,
+            option::none(),
+            utf8(b"DispatchToken"),
+            utf8(b"DT"),
+            18,
+            utf8(b"https://"),
+            utf8(b"https://"),
+        );
+
+        dispatchable_fungible_asset::register_dispatch_functions(
+            ctor_ref,
+            option::none(),
+            option::none(),
+            option::none(),
+        );
+
+        let mint_ref = fungible_asset::generate_mint_ref(ctor_ref);
+
+        confidential_asset::init_module_for_testing(confidential_asset_signer);
+        features::change_feature_flags_for_testing(aptos_fx, vector[features::get_bulletproofs_feature()], vector[]);
+
+        let token = object::object_from_constructor_ref<Metadata>(ctor_ref);
+
+        let sender_store = primary_fungible_store::ensure_primary_store_exists(signer::address_of(sender), token);
+        fungible_asset::mint_to(&mint_ref, sender_store, sender_amount);
+
+        token
+    }
+
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        fa = @0xfa,
+        alice = @0xa1
+    )]
+    #[expected_failure(abort_code = 0x010013, location = confidential_asset)]
+    fun fail_register_with_dispatchable_fa(
+        confidential_asset: signer,
+        aptos_fx: signer,
+        fa: signer,
+        alice: signer)
+    {
+        let token = set_up_dispatchable_fa_test(&confidential_asset, &aptos_fx, &fa, &alice, 500);
+
+        assert!(fungible_asset::is_asset_type_dispatchable(&token), 1);
+
+        let (_, alice_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::register_for_testing(&alice, token, twisted_elgamal::pubkey_to_bytes(&alice_ek));
+    }
+
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        fa = @0xfa,
+        alice = @0xa1
+    )]
+    fun success_vanilla_fa_not_blocked(
+        confidential_asset: signer,
+        aptos_fx: signer,
+        fa: signer,
+        alice: signer)
+    {
+        let token = set_up_for_confidential_asset_test(
+            &confidential_asset, &aptos_fx, &fa, &alice, &alice, 500, 0);
+
+        assert!(!fungible_asset::is_asset_type_dispatchable(&token), 1);
+
+        let (_, alice_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::register_for_testing(&alice, token, twisted_elgamal::pubkey_to_bytes(&alice_ek));
+        confidential_asset::deposit(&alice, token, 100);
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.move
@@ -700,6 +700,13 @@ module aptos_framework::fungible_asset {
         exists<DispatchFunctionStore>(metadata_addr)
     }
 
+    #[view]
+    /// Return whether a fungible asset type has any dispatch or derived-supply hooks registered.
+    public fun is_asset_type_dispatchable(metadata: &Object<Metadata>): bool {
+        let metadata_addr = object::object_address(metadata);
+        exists<DispatchFunctionStore>(metadata_addr) || exists<DeriveSupply>(metadata_addr)
+    }
+
     public fun deposit_dispatch_function<T: key>(store: Object<T>): Option<FunctionInfo> acquires FungibleStore, DispatchFunctionStore {
         let fa_store = borrow_store_resource(&store);
         let metadata_addr = object::object_address(&fa_store.metadata);


### PR DESCRIPTION
## Disable Dispatchable Fungible Asset (DFA) Support in Confidential Transfers

### Summary

- Add `is_asset_type_dispatchable` view function to `fungible_asset.move` that checks for both `DispatchFunctionStore` and `DeriveSupply` hooks.
- Add `is_safe_for_confidentiality` guard to `confidential_asset.move` that rejects dispatchable FA types at `register`, `deposit_to`, `withdraw_to`, and `confidential_transfer` entry points.
- Introduce `get_pool_fa_store` / `ensure_pool_fa_store` helpers returning typed `Object<FungibleStore>`, and use `dispatchable_fungible_asset::transfer` for both deposit and withdraw paths with post-event balance re-assertions to catch fee-on-transfer or rebasing behavior.
- Simplify `confidential_asset_balance` view to use the new pool store helper.
- Add Move unit tests: `fail_register_with_dispatchable_fa` (verifies DFA rejection) and `success_standard_fa_not_blocked` (verifies standard FA still works through register + deposit).

### Motivation

Dispatchable fungible assets can override withdraw, deposit, balance, or supply behavior in ways that are incompatible with encrypted on-chain balances (e.g., fee-on-transfer tokens, rebasing balances, custom supply hooks). Until a safe integration path exists, only standard (non-dispatchable) FA types are accepted.

Even for DFAs that only have custom withdraw/deposit dispatch functions, it is unclear how to generically support them. For example, sender blocklists implemented via withdraw dispatching would only be enforced when users deposit/withdraw tokens into/from the confidential asset pool, since a `confidential_transfer` cannot by definition interact with any FA functions without leaking amounts or balances.

### Testing

- `fail_register_with_dispatchable_fa` — confirms `register` aborts with `EUNSAFE_DISPATCHABLE_FA` (0x010013) when the asset type has dispatch hooks
- `success_standard_fa_not_blocked` — confirms a standard FA can still register and deposit without error
- Verify existing e2e tests pass (they use non-dispatchable `MOVE_METADATA` and are unaffected)