### PR TITLE
Revert voting power increase limit to 50

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
@@ -360,9 +360,8 @@ module aptos_framework::staking_config {
         new_voting_power_increase_limit: u64,
     ) acquires StakingConfig {
         system_addresses::assert_aptos_framework(aptos_framework);
-        //TODO(bowu): revert the limit back to 50
         assert!(
-            new_voting_power_increase_limit > 0 && new_voting_power_increase_limit <= 50*1_000_000_000,
+            new_voting_power_increase_limit > 0 && new_voting_power_increase_limit <= 50,
             error::invalid_argument(EINVALID_VOTING_POWER_INCREASE_LIMIT),
         );
 


### PR DESCRIPTION
## Summary
- revert the staking config voting power increase assertion to require values greater than 0 and less than or equal to 50
- remove the temporary TODO tied to the expanded limit