### PR TITLE
[dashboards] fix panel queries to match Movement deployment labels

### DIFF
--- a/dashboards/ddos.json
+++ b/dashboards/ddos.json
@@ -692,7 +692,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${Datasource}" },
-          "expr": "sum by (container) (rate(container_cpu_usage_seconds_total{environment=~\"$environment\", container=~\"$container\"}[$AggInterval]))",
+          "expr": "sum by (container) (rate(container_cpu_usage_seconds_total{container=~\"$container\"}[$AggInterval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{container}}",
@@ -700,7 +700,7 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "${Datasource}" },
-          "expr": "sum by (container_name) (rate(container_cpu_usage_seconds_total{environment=~\"$environment\", container_name=~\"$container\"}[$AggInterval]))",
+          "expr": "sum by (container_name) (rate(container_cpu_usage_seconds_total{container_name=~\"$container\"}[$AggInterval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{container_name}}",
@@ -873,7 +873,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${Datasource}" },
-          "expr": "container_memory_working_set_bytes{environment=~\"$environment\", container=~\"$container\"} / container_spec_memory_limit_bytes{container=~\"$container\"}",
+          "expr": "container_memory_working_set_bytes{container=~\"$container\"} / container_spec_memory_limit_bytes{container=~\"$container\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{container}}",
@@ -881,7 +881,7 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "${Datasource}" },
-          "expr": "container_memory_working_set_bytes{environment=~\"$environment\", container_name=~\"$container\"} / container_spec_memory_limit_bytes{container_name=~\"$container\"}",
+          "expr": "container_memory_working_set_bytes{container_name=~\"$container\"} / container_spec_memory_limit_bytes{container_name=~\"$container\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{container_name}}",
@@ -962,7 +962,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${Datasource}" },
-          "expr": "kubelet_volume_stats_used_bytes{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*-($container)-e.*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*-($container)-e.*\"}",
+          "expr": "kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*-($container)-e.*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*-($container)-e.*\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{persistentvolumeclaim}}",

--- a/dashboards/end-to-end-txn-latency.json
+++ b/dashboards/end-to-end-txn-latency.json
@@ -115,7 +115,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${Datasource}" },
           "editorMode": "code",
-          "expr": "(sum (rate(aptos_core_mempool_txn_commit_latency_sum{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\",stage=\"commit_accepted_block\", pod=~\"^(pfn|public-fullnode-).*\" }[$interval])) / sum (rate(aptos_core_mempool_txn_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\", stage=\"commit_accepted_block\", pod=~\"^(pfn|public-fullnode-).*\"}[$interval])))\n-\n(sum (rate(aptos_core_mempool_txn_commit_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",stage=\"commit_accepted_block\", pod=~\".*aptos-node-.*-fullnode-.*\" }[$interval])) / sum (rate(aptos_core_mempool_txn_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\", stage=\"commit_accepted_block\", pod=~\".*aptos-node-.*-fullnode-.*\"}[$interval])))\n> 0",
+          "expr": "(sum (rate(aptos_core_mempool_txn_commit_latency_sum{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\",stage=\"commit_accepted_block\", pod=~\"^(pfn|public-fullnode-).*\" }[$interval])) / sum (rate(aptos_core_mempool_txn_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\", stage=\"commit_accepted_block\", pod=~\"^(pfn|public-fullnode-).*\"}[$interval])))\n-\n(sum (rate(aptos_core_mempool_txn_commit_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",stage=\"commit_accepted_block\", pod=~\"^(pfn|public-fullnode-).*\" }[$interval])) / sum (rate(aptos_core_mempool_txn_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\", stage=\"commit_accepted_block\", pod=~\"^(pfn|public-fullnode-).*\"}[$interval])))\n> 0",
           "instant": false,
           "legendFormat": "PFN -> VFN txn",
           "range": true,
@@ -124,7 +124,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${Datasource}" },
           "editorMode": "code",
-          "expr": "(sum (rate(aptos_core_mempool_txn_commit_latency_sum{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\",stage=\"commit_accepted_block\", pod=~\".*aptos-node-.*-fullnode-.*\" }[$interval])) / sum (rate(aptos_core_mempool_txn_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\", stage=\"commit_accepted_block\", pod=~\".*aptos-node-.*-fullnode-.*\"}[$interval])))\n-\n(sum (rate(aptos_core_mempool_txn_commit_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", stage=\"commit_accepted_block\"}[$interval])) / sum (rate(aptos_core_mempool_txn_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", stage=\"commit_accepted_block\"}[$interval]))) \n> 0",
+          "expr": "(sum (rate(aptos_core_mempool_txn_commit_latency_sum{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\",stage=\"commit_accepted_block\", pod=~\"^(pfn|public-fullnode-).*\" }[$interval])) / sum (rate(aptos_core_mempool_txn_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\", stage=\"commit_accepted_block\", pod=~\"^(pfn|public-fullnode-).*\"}[$interval])))\n-\n(sum (rate(aptos_core_mempool_txn_commit_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", stage=\"commit_accepted_block\"}[$interval])) / sum (rate(aptos_core_mempool_txn_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", stage=\"commit_accepted_block\"}[$interval]))) \n> 0",
           "hide": false,
           "instant": false,
           "legendFormat": "VFN -> Validator txn",
@@ -204,7 +204,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${Datasource}" },
           "editorMode": "code",
-          "expr": "(sum (rate(aptos_data_client_sync_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\", pod=~\".*aptos-node-.*-fullnode-.*\",label=\"propose_to_sync_latency\"}[$__rate_interval])) / sum (rate(aptos_data_client_sync_latencies_count{namespace=~\"$namespace\", pod=~\".*aptos-node-.*-fullnode-.*\",label=\"propose_to_sync_latency\"}[$__rate_interval])))\n-\n(quantile(0.67, rate(aptos_consensus_block_tracing_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", stage=\"committed\"}[$interval]) / rate(aptos_consensus_block_tracing_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", stage=\"committed\"}[$interval])) < 1000000)",
+          "expr": "(sum (rate(aptos_data_client_sync_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\", pod=~\"^(pfn|public-fullnode-).*\",label=\"propose_to_sync_latency\"}[$__rate_interval])) / sum (rate(aptos_data_client_sync_latencies_count{namespace=~\"$namespace\", pod=~\"^(pfn|public-fullnode-).*\",label=\"propose_to_sync_latency\"}[$__rate_interval])))\n-\n(quantile(0.67, rate(aptos_consensus_block_tracing_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", stage=\"committed\"}[$interval]) / rate(aptos_consensus_block_tracing_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", stage=\"committed\"}[$interval])) < 1000000)",
           "hide": false,
           "instant": false,
           "legendFormat": "Committed block -> VFN sync",
@@ -215,7 +215,7 @@
           "datasource": { "type": "prometheus", "uid": "${Datasource}" },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "(sum (rate(aptos_data_client_sync_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\", pod=~\"^(pfn|public-fullnode-).*\",label=\"propose_to_sync_latency\"}[$__rate_interval])) / sum (rate(aptos_data_client_sync_latencies_count{namespace=~\"$namespace\", pod=~\"^(pfn|public-fullnode-).*\",label=\"propose_to_sync_latency\"}[$__rate_interval])))\n-\n(sum (rate(aptos_data_client_sync_latencies_sum{namespace=~\"$namespace\", pod=~\".*aptos-node-.*-fullnode-.*\",label=\"propose_to_sync_latency\"}[$__rate_interval])) / sum (rate(aptos_data_client_sync_latencies_count{namespace=~\"$namespace\", pod=~\".*aptos-node-.*-fullnode-.*\",label=\"propose_to_sync_latency\"}[$__rate_interval])))\n",
+          "expr": "(sum (rate(aptos_data_client_sync_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\", pod=~\"^(pfn|public-fullnode-).*\",label=\"propose_to_sync_latency\"}[$__rate_interval])) / sum (rate(aptos_data_client_sync_latencies_count{namespace=~\"$namespace\", pod=~\"^(pfn|public-fullnode-).*\",label=\"propose_to_sync_latency\"}[$__rate_interval])))\n-\n(sum (rate(aptos_data_client_sync_latencies_sum{namespace=~\"$namespace\", pod=~\"^(pfn|public-fullnode-).*\",label=\"propose_to_sync_latency\"}[$__rate_interval])) / sum (rate(aptos_data_client_sync_latencies_count{namespace=~\"$namespace\", pod=~\"^(pfn|public-fullnode-).*\",label=\"propose_to_sync_latency\"}[$__rate_interval])))\n",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1020,7 +1020,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${Datasource}" },
           "editorMode": "code",
-          "expr": "sum(rate(aptos_data_client_sync_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\".*aptos-node-.*-fullnode-.*\"}[$__rate_interval])) / sum(rate(aptos_data_client_sync_latencies_count{namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\".*aptos-node-.*-fullnode-.*\"}[$__rate_interval]))",
+          "expr": "sum(rate(aptos_data_client_sync_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\"^(pfn|public-fullnode-).*\"}[$__rate_interval])) / sum(rate(aptos_data_client_sync_latencies_count{namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\"^(pfn|public-fullnode-).*\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1031,7 +1031,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${Datasource}" },
           "editorMode": "code",
-          "expr": "sum(rate(aptos_data_client_sync_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\"^(pfn|public-fullnode-).*\"}[$__rate_interval])) / sum(rate(aptos_data_client_sync_latencies_count{namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\"^^(pfn|public-fullnode-).*\"}[$__rate_interval]))",
+          "expr": "sum(rate(aptos_data_client_sync_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\"^(pfn|public-fullnode-).*\"}[$__rate_interval])) / sum(rate(aptos_data_client_sync_latencies_count{namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\"^(pfn|public-fullnode-).*\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1094,7 +1094,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${Datasource}" },
           "editorMode": "code",
-          "expr": "(sum(rate(aptos_data_client_sync_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\".*aptos-node-.*-fullnode-.*\"}[$__rate_interval])) / sum(rate(aptos_data_client_sync_latencies_count{namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\".*aptos-node-.*-fullnode-.*\"}[$__rate_interval])))\n-\nquantile(0.67, rate(aptos_consensus_block_tracing_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", stage=\"committed\"}[$__rate_interval]) / rate(aptos_consensus_block_tracing_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", stage=\"committed\"}[$__rate_interval]))",
+          "expr": "(sum(rate(aptos_data_client_sync_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\"^(pfn|public-fullnode-).*\"}[$__rate_interval])) / sum(rate(aptos_data_client_sync_latencies_count{namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\"^(pfn|public-fullnode-).*\"}[$__rate_interval])))\n-\nquantile(0.67, rate(aptos_consensus_block_tracing_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", stage=\"committed\"}[$__rate_interval]) / rate(aptos_consensus_block_tracing_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", stage=\"committed\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1168,7 +1168,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${Datasource}" },
           "editorMode": "code",
-          "expr": "(sum(rate(aptos_data_client_sync_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\".*aptos-node-.*-fullnode-.*\"}[$__rate_interval])) / sum(rate(aptos_data_client_sync_latencies_count{namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\".*aptos-node-.*-fullnode-.*\"}[$__rate_interval])))\n-\nquantile(0.67, rate(aptos_consensus_block_tracing_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", stage=\"committed\"}[$__rate_interval]) / rate(aptos_consensus_block_tracing_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", stage=\"committed\"}[$__rate_interval]))",
+          "expr": "(sum(rate(aptos_data_client_sync_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\"^(pfn|public-fullnode-).*\"}[$__rate_interval])) / sum(rate(aptos_data_client_sync_latencies_count{namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\"^(pfn|public-fullnode-).*\"}[$__rate_interval])))\n-\nquantile(0.67, rate(aptos_consensus_block_tracing_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", stage=\"committed\"}[$__rate_interval]) / rate(aptos_consensus_block_tracing_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", stage=\"committed\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1231,7 +1231,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${Datasource}" },
           "editorMode": "code",
-          "expr": "(sum(rate(aptos_data_client_sync_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\"^(pfn|public-fullnode-).*\"}[$__rate_interval])) / sum(rate(aptos_data_client_sync_latencies_count{namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\"^(pfn|public-fullnode-).*\"}[$__rate_interval])))\n-\n(sum by() (rate(aptos_data_client_sync_latencies_sum{namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\".*aptos-node-.*-fullnode-.*\"}[$__rate_interval])) / sum by() (rate(aptos_data_client_sync_latencies_count{namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\".*aptos-node-.*-fullnode-.*\"}[$__rate_interval])))",
+          "expr": "(sum(rate(aptos_data_client_sync_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\"^(pfn|public-fullnode-).*\"}[$__rate_interval])) / sum(rate(aptos_data_client_sync_latencies_count{namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\"^(pfn|public-fullnode-).*\"}[$__rate_interval])))\n-\n(sum by() (rate(aptos_data_client_sync_latencies_sum{namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\"^(pfn|public-fullnode-).*\"}[$__rate_interval])) / sum by() (rate(aptos_data_client_sync_latencies_count{namespace=~\"$namespace\",label=\"propose_to_sync_latency\",pod=~\"^(pfn|public-fullnode-).*\"}[$__rate_interval])))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1292,7 +1292,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "fHo-R604z" },
           "editorMode": "code",
-          "expr": "(sum(rate(aptos_data_client_request_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\", pod=~\".*aptos-node-.*-fullnode-.*\",request_type=~\"get_new_transactions_or_outputs_with_proof_compressed|get_transactions_or_outputs_with_proof_compressed\"}[$__rate_interval])))\n/\n(sum(rate(aptos_data_client_request_latencies_count{namespace=~\"$namespace\", pod=~\".*aptos-node-.*-fullnode-.*\",request_type=~\"get_new_transactions_or_outputs_with_proof_compressed|get_transactions_or_outputs_with_proof_compressed\"}[$__rate_interval])))",
+          "expr": "(sum(rate(aptos_data_client_request_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\", pod=~\"^(pfn|public-fullnode-).*\",request_type=~\"get_new_transactions_or_outputs_with_proof_compressed|get_transactions_or_outputs_with_proof_compressed\"}[$__rate_interval])))\n/\n(sum(rate(aptos_data_client_request_latencies_count{namespace=~\"$namespace\", pod=~\"^(pfn|public-fullnode-).*\",request_type=~\"get_new_transactions_or_outputs_with_proof_compressed|get_transactions_or_outputs_with_proof_compressed\"}[$__rate_interval])))",
           "hide": false,
           "instant": false,
           "legendFormat": "Fetch Chunk",
@@ -1302,7 +1302,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "fHo-R604z" },
           "editorMode": "code",
-          "expr": "(sum(rate(aptos_state_sync_storage_synchronizer_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\", pod=~\".*aptos-node-.*-fullnode-.*\",label!=\"commit_chunk\"}[$__rate_interval])))\n/\n(sum(rate(aptos_state_sync_storage_synchronizer_latencies_count{namespace=~\"$namespace\", pod=~\".*aptos-node-.*-fullnode-.*\",label!=\"commit_chunk\"}[$__rate_interval])))",
+          "expr": "(sum(rate(aptos_state_sync_storage_synchronizer_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\", pod=~\"^(pfn|public-fullnode-).*\",label!=\"commit_chunk\"}[$__rate_interval])))\n/\n(sum(rate(aptos_state_sync_storage_synchronizer_latencies_count{namespace=~\"$namespace\", pod=~\"^(pfn|public-fullnode-).*\",label!=\"commit_chunk\"}[$__rate_interval])))",
           "hide": false,
           "instant": false,
           "legendFormat": "Execute/Apply Chunk",
@@ -1312,7 +1312,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "fHo-R604z" },
           "editorMode": "code",
-          "expr": "(sum(rate(aptos_state_sync_storage_synchronizer_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\", pod=~\".*aptos-node-.*-fullnode-.*\",label=\"commit_chunk\"}[$__rate_interval])))\n/\n(sum(rate(aptos_state_sync_storage_synchronizer_latencies_count{namespace=~\"$namespace\", pod=~\".*aptos-node-.*-fullnode-.*\",label=\"commit_chunk\"}[$__rate_interval])))",
+          "expr": "(sum(rate(aptos_state_sync_storage_synchronizer_latencies_sum{environment=~\"$environment\", namespace=~\"$namespace\", pod=~\"^(pfn|public-fullnode-).*\",label=\"commit_chunk\"}[$__rate_interval])))\n/\n(sum(rate(aptos_state_sync_storage_synchronizer_latencies_count{namespace=~\"$namespace\", pod=~\"^(pfn|public-fullnode-).*\",label=\"commit_chunk\"}[$__rate_interval])))",
           "hide": false,
           "instant": false,
           "legendFormat": "Commit Chunk",

--- a/dashboards/fullnodes.json
+++ b/dashboards/fullnodes.json
@@ -109,7 +109,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "fHo-R604z" },
           "editorMode": "code",
-          "expr": "aptos_state_sync_version{environment=~\"$environment\", type=\"synced\", pod=~\"$pod\", pod=~\".*fullnode.*\", cluster=~\"$cluster\", namespace=~\"$namespace\"}",
+          "expr": "aptos_state_sync_version{environment=~\"$environment\", type=\"synced\", pod=~\"$pod\", cluster=~\"$cluster\", namespace=~\"$namespace\"}",
           "legendFormat": "{{pod}}-{{pod}}",
           "range": true,
           "refId": "A"
@@ -224,12 +224,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(aptos_state_sync_version{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", type=\"synced\", pod=~\".*fullnode.*\", pod=~\"$pod\"}[$interval])",
+          "expr": "rate(aptos_state_sync_version{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", type=\"synced\", pod=~\"$pod\"}[$interval])",
           "legendFormat": "{{pod}}-{{pod}}",
           "refId": "A"
         },
         {
-          "expr": "rate(aptos_state_sync_version{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", type=\"synced\", job=~\".*fullnode.*\", pod=~\"$pod\"}[$interval])",
+          "expr": "rate(aptos_state_sync_version{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", type=\"synced\", pod=~\"$pod\"}[$interval])",
           "legendFormat": "{{pod}}-{{job}}",
           "refId": "B"
         }
@@ -291,7 +291,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "fHo-R604z" },
           "editorMode": "code",
-          "expr": "sum by (pod, network_id)(aptos_connections{environment=~\"$environment\", pod=~\"$pod\", pod=~\".*fullnode.*\", cluster=~\"$cluster\", namespace=~\"$namespace\"})",
+          "expr": "sum by (pod, network_id)(aptos_connections{environment=~\"$environment\", pod=~\"$pod\", cluster=~\"$cluster\", namespace=~\"$namespace\"})",
           "legendFormat": "{{pod}}-{{pod}}",
           "range": true,
           "refId": "A"
@@ -364,12 +364,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aptos_core_mempool_index_size{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", index=\"system_ttl\", pod=~\".*fullnode.*\", pod=~\"$pod\"}",
+          "expr": "aptos_core_mempool_index_size{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", index=\"system_ttl\", pod=~\"$pod\"}",
           "legendFormat": "{{pod}}-{{pod}}",
           "refId": "A"
         },
         {
-          "expr": "aptos_core_mempool_index_size{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", index=\"system_ttl\", job=~\".*fullnode.*\", pod=~\"$pod\"}",
+          "expr": "aptos_core_mempool_index_size{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", index=\"system_ttl\", pod=~\"$pod\"}",
           "legendFormat": "{{pod}}-{{job}}",
           "refId": "B"
         }
@@ -429,12 +429,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aptos_core_mempool_txn_commit_latency_sum{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\".*fullnode.*\", pod=~\"$pod\"} / aptos_core_mempool_txn_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\".*fullnode.*\", pod=~\"$pod\"}",
+          "expr": "aptos_core_mempool_txn_commit_latency_sum{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"} / aptos_core_mempool_txn_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}",
           "legendFormat": "{{pod}}-{{pod}}",
           "refId": "A"
         },
         {
-          "expr": "aptos_core_mempool_txn_commit_latency_sum{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\".*fullnode.*\", pod=~\"$pod\"} / aptos_core_mempool_txn_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\".*fullnode.*\", pod=~\"$pod\"}",
+          "expr": "aptos_core_mempool_txn_commit_latency_sum{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"} / aptos_core_mempool_txn_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}",
           "legendFormat": "{{pod}}-{{job}}",
           "refId": "B"
         }
@@ -695,12 +695,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(container_network_receive_bytes_total{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod.*fullnode.*\"}[$interval])) by (pod)",
+          "expr": "sum(irate(container_network_receive_bytes_total{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$interval])) by (pod)",
           "legendFormat": "{{pod}}",
           "refId": "A"
         },
         {
-          "expr": "sum(irate(container_network_receive_bytes_total{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod.*fullnode.*\"}[$interval]))",
+          "expr": "sum(irate(container_network_receive_bytes_total{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$interval]))",
           "legendFormat": "total",
           "refId": "B"
         }
@@ -772,20 +772,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "fHo-R604z" },
           "editorMode": "code",
-          "expr": "1 - kubelet_volume_stats_available_bytes{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"fn.$pod.*\", pod=~\"$pod\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"fn.$pod.*\", pod=~\"$pod\"}",
+          "expr": "1 - kubelet_volume_stats_available_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*-node-storage\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*-node-storage\"}",
           "legendFormat": "{{persistentvolumeclaim}}:{{namespace}}",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "fHo-R604z" },
-          "editorMode": "code",
-          "expr": "1 - kubelet_volume_stats_available_bytes{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pod.*fullnode.*\", pod!~\"val.*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pod.*fullnode.*\", pod!~\"val.*\"}",
-          "legendFormat": "{{persistentvolumeclaim}}:{{namespace}}",
-          "range": true,
-          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -842,9 +833,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "fHo-R604z" },
           "editorMode": "code",
-          "expr": "container_memory_working_set_bytes{environment=~\"$environment\", container=\"fullnode\", pod=~\"$pod.*\", job=\"kubernetes-cadvisor\", cluster=\"$cluster\"}",
+          "expr": "container_memory_working_set_bytes{container=\"fn\", pod=~\"$pod.*\", job=\"kubelet\", cluster=~\"$cluster\"}",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"

--- a/dashboards/public-fullnodes.json
+++ b/dashboards/public-fullnodes.json
@@ -332,12 +332,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aptos_core_mempool_index_size{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", index=\"system_ttl\", pod=~\".*fullnode.*\", pod=~\"$pod\"}",
+          "expr": "aptos_core_mempool_index_size{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", index=\"system_ttl\", pod=~\"$pod\"}",
           "legendFormat": "{{pod}}-{{pod}}",
           "refId": "A"
         },
         {
-          "expr": "aptos_core_mempool_index_size{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", index=\"system_ttl\", job=~\".*fullnode.*\", pod=~\"$pod\"}",
+          "expr": "aptos_core_mempool_index_size{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", index=\"system_ttl\", pod=~\"$pod\"}",
           "legendFormat": "{{pod}}-{{job}}",
           "refId": "B"
         }
@@ -397,12 +397,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "aptos_core_mempool_txn_commit_latency_sum{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\".*fullnode.*\", pod=~\"$pod\"} / aptos_core_mempool_txn_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\".*fullnode.*\", pod=~\"$pod\"}",
+          "expr": "aptos_core_mempool_txn_commit_latency_sum{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"} / aptos_core_mempool_txn_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}",
           "legendFormat": "{{pod}}-{{pod}}",
           "refId": "A"
         },
         {
-          "expr": "aptos_core_mempool_txn_commit_latency_sum{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\".*fullnode.*\", pod=~\"$pod\"} / aptos_core_mempool_txn_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\".*fullnode.*\", pod=~\"$pod\"}",
+          "expr": "aptos_core_mempool_txn_commit_latency_sum{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"} / aptos_core_mempool_txn_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}",
           "legendFormat": "{{pod}}-{{job}}",
           "refId": "B"
         }
@@ -593,12 +593,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(container_network_transmit_bytes_total{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod.*fullnode.*\"}[$interval])) by (pod)",
+          "expr": "sum(irate(container_network_transmit_bytes_total{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$interval])) by (pod)",
           "legendFormat": "{{pod}}",
           "refId": "A"
         },
         {
-          "expr": "sum(irate(container_network_transmit_bytes_total{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod.*fullnode.*\"}[$interval]))",
+          "expr": "sum(irate(container_network_transmit_bytes_total{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$interval]))",
           "legendFormat": "total",
           "refId": "B"
         }
@@ -657,12 +657,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(container_network_receive_bytes_total{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod.*fullnode.*\"}[$interval])) by (pod)",
+          "expr": "sum(irate(container_network_receive_bytes_total{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$interval])) by (pod)",
           "legendFormat": "{{pod}}",
           "refId": "A"
         },
         {
-          "expr": "sum(irate(container_network_receive_bytes_total{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod.*fullnode.*\"}[$interval]))",
+          "expr": "sum(irate(container_network_receive_bytes_total{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$interval]))",
           "legendFormat": "total",
           "refId": "B"
         }
@@ -733,12 +733,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1 - kubelet_volume_stats_available_bytes{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"fn.$pod.*\", pod=~\"$pod\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"fn.$pod.*\", pod=~\"$pod\"}",
+          "expr": "1 - kubelet_volume_stats_available_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*-fn-.*-node-storage\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*-fn-.*-node-storage\"}",
           "legendFormat": "{{persistentvolumeclaim}}",
           "refId": "A"
         },
         {
-          "expr": "1 - kubelet_volume_stats_available_bytes{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pod.*fullnode.*\", pod!~\"val.*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pod.*fullnode.*\", pod!~\"val.*\"}",
+          "expr": "1 - kubelet_volume_stats_available_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*-fn-.*-node-storage\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*-fn-.*-node-storage\"}",
           "legendFormat": "{{persistentvolumeclaim}}",
           "refId": "B"
         }
@@ -797,9 +797,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "fHo-R604z" },
           "editorMode": "code",
-          "expr": "container_memory_working_set_bytes{environment=~\"$environment\", container=\"fullnode\", pod=~\"$pod.*\", job=\"kubernetes-cadvisor\", cluster=~\"$cluster\", namespace=~\"$namespace\"}",
+          "expr": "container_memory_working_set_bytes{container=\"fn\", pod=~\"$pod.*\", job=\"kubelet\", cluster=~\"$cluster\", namespace=~\"$namespace\"}",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"

--- a/dashboards/storage-overview.json
+++ b/dashboards/storage-overview.json
@@ -1136,7 +1136,7 @@
             {
               "datasource": { "type": "prometheus", "uid": "${Datasource}" },
               "editorMode": "code",
-              "expr": "kubelet_volume_stats_capacity_bytes{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", persistentvolumeclaim!~\".*prometheus.*\"} - kubelet_volume_stats_used_bytes",
+              "expr": "kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", persistentvolumeclaim!~\".*prometheus.*\"} - kubelet_volume_stats_used_bytes",
               "hide": true,
               "interval": "",
               "legendFormat": "{{pod}} {{persistentvolumeclaim}}",

--- a/dashboards/system.json
+++ b/dashboards/system.json
@@ -95,7 +95,7 @@
       "pluginVersion": "10.0.1-cloud.2.a7a20fbf",
       "targets": [
         {
-          "expr": "rate(container_cpu_usage_seconds_total{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[$interval])",
+          "expr": "rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}[$interval])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}}-{{container}}",
@@ -148,7 +148,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "container_memory_working_set_bytes{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}",
+          "expr": "container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}}-{{container}}",
@@ -277,7 +277,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${Datasource}" },
           "editorMode": "code",
-          "expr": "kubelet_volume_stats_used_bytes{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*-($container)-e.*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*-($container)-e.*\"}",
+          "expr": "kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*-($container)-e.*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*-($container)-e.*\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}}-{{persistentvolumeclaim}}",
@@ -342,7 +342,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${Datasource}" },
           "editorMode": "code",
-          "expr": "kubelet_volume_stats_used_bytes{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*-($container)-e.*\"}",
+          "expr": "kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*-($container)-e.*\"}",
           "hide": false,
           "legendFormat": "{{cluster}} {{pod}}",
           "range": true,
@@ -404,7 +404,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "container_memory_working_set_bytes{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"} / container_spec_memory_limit_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}",
+          "expr": "container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"} / container_spec_memory_limit_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"$container\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}}-{{container}}",
@@ -530,7 +530,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "P968F4F8972F6D74D" },
           "editorMode": "code",
-          "expr": "rate(container_network_receive_bytes_total{environment=~\"$environment\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$interval]) + rate(container_network_transmit_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$interval])",
+          "expr": "rate(container_network_receive_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$interval]) + rate(container_network_transmit_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$interval])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}}-{{pod}}",


### PR DESCRIPTION

## Description

Fixes Grafana dashboard queries that had been silently returning "No data" on the Movement deployments because they used label filters inherited from upstream aptos-core that never matched Movement's pod/container/job naming. Dashboard JSON only — no code changes.

Panels affected span Mempool, State Sync, Connections, Memory, Disk, and End-to-End Latency across `public-fullnodes`, `fullnodes`, `end-to-end-txn-latency`, `system`, `ddos`, and `storage-overview`.

## How Has This Been Tested?

Each fixed query was verified against the live mainnet Prometheus before upload. After uploading, the previously-empty panels render real data (Memory, Disk, Mempool, State Sync all confirmed).

## Type of Change

- [x] Bug fix

## Which Components or Systems Does This Change Impact?

- [x] Developer Infrastructure

## Checklist

- [x] I have performed a self-review of my own code
- [x] I tested both happy and unhappy path of the functionality