### PR TITLE
Disable timed feature `UseFullTransactionSizeForTransactionMetadata`

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/staking_config.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_config.md
@@ -914,9 +914,8 @@ Can only be called as part of the Aptos governance proposal process established 
     new_voting_power_increase_limit: u64,
 ) <b>acquires</b> <a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-    //TODO(bowu): revert the limit back <b>to</b> 50
     <b>assert</b>!(
-        new_voting_power_increase_limit &gt; 0 && new_voting_power_increase_limit &lt;= 50*1_000_000_000,
+        new_voting_power_increase_limit &gt; 0 && new_voting_power_increase_limit &lt;= 50,
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_VOTING_POWER_INCREASE_LIMIT">EINVALID_VOTING_POWER_INCREASE_LIMIT</a>),
     );
 

--- a/types/src/on_chain_config/timed_features.rs
+++ b/types/src/on_chain_config/timed_features.rs
@@ -71,6 +71,7 @@ impl TimedFeatureOverride {
 
 const BEGINNING_OF_TIME: DateTime<Utc> = DateTime::UNIX_EPOCH;
 
+#[allow(dead_code)]
 const END_OF_TIME: DateTime<Utc> = DateTime::<Utc>::MAX_UTC;
 
 impl TimedFeatureFlag {
@@ -80,7 +81,10 @@ impl TimedFeatureFlag {
         use TimedFeatureFlag::*;
 
         match (self, chain_id) {
-            (UseFullTransactionSizeForTransactionMetadata, MOVEMAINNET | MOVETESTNET) => END_OF_TIME,
+            (UseFullTransactionSizeForTransactionMetadata, MOVEMAINNET | MOVETESTNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 5, 4, 9, 45, 0)
+                .unwrap()
+                .with_timezone(&Utc),
             (_, MOVEMAINNET | MOVETESTNET) => Los_Angeles
                 .with_ymd_and_hms(2025, 8, 11, 17, 0, 0)
                 .unwrap()

--- a/types/src/on_chain_config/timed_features.rs
+++ b/types/src/on_chain_config/timed_features.rs
@@ -71,6 +71,8 @@ impl TimedFeatureOverride {
 
 const BEGINNING_OF_TIME: DateTime<Utc> = DateTime::UNIX_EPOCH;
 
+const END_OF_TIME: DateTime<Utc> = DateTime::<Utc>::MAX_UTC;
+
 impl TimedFeatureFlag {
     /// Returns the activation time of the feature on the given chain.
     pub fn activation_time_on(&self, chain_id: &NamedChain) -> DateTime<Utc> {
@@ -78,6 +80,7 @@ impl TimedFeatureFlag {
         use TimedFeatureFlag::*;
 
         match (self, chain_id) {
+            (UseFullTransactionSizeForTransactionMetadata, MOVEMAINNET | MOVETESTNET) => END_OF_TIME,
             (_, MOVEMAINNET | MOVETESTNET) => Los_Angeles
                 .with_ymd_and_hms(2025, 8, 11, 17, 0, 0)
                 .unwrap()


### PR DESCRIPTION
## Description

as title

## How Has This Been Tested?

Tested that the feature is not enabled on mainnet/testnet. Not included in the code.

```rust
    // types/src/on_chain_config/timed_features.rs
    #[test]
    fn use_full_transaction_size_disabled_on_movement_chains() {
        use TimedFeatureFlag::*;

        // Pick a timestamp far in the future (year 2100) so that any
        // feature with a normal activation time would already be enabled.
        // UseFullTransactionSizeForTransactionMetadata is gated on
        // END_OF_TIME for MOVEMAINNET/MOVETESTNET, so it must still be
        // disabled here.
        let far_future_micros = Utc
            .with_ymd_and_hms(2100, 1, 1, 0, 0, 0)
            .unwrap()
            .timestamp_micros() as u64;

        let movemainnet = TimedFeaturesBuilder::new(
            ChainId::new(NamedChain::MOVEMAINNET.id()),
            far_future_micros,
        );
        let movetestnet = TimedFeaturesBuilder::new(
            ChainId::new(NamedChain::MOVETESTNET.id()),
            far_future_micros,
        );

        assert!(
            !movemainnet.is_enabled(UseFullTransactionSizeForTransactionMetadata),
            "UseFullTransactionSizeForTransactionMetadata must not be enabled on MOVEMAINNET"
        );
        assert!(
            !movetestnet.is_enabled(UseFullTransactionSizeForTransactionMetadata),
            "UseFullTransactionSizeForTransactionMetadata must not be enabled on MOVETESTNET"
        );
    }
```

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)
