### PR TITLE
fix: enforce batch metadata size limits on proposal verification

### DIFF
--- a/aptos-move/framework/aptos-experimental/doc/large_packages.md
+++ b/aptos-move/framework/aptos-experimental/doc/large_packages.md
@@ -51,19 +51,20 @@ gaps.
 ## Notes
 
 
-* Make sure LargePackages is deployed to your network of choice, you can currently find it both on
-mainnet and testnet at <code>0xa29df848eebfe5d981f708c2a5b06d31af2be53bbd8ddc94c8523f4b903f7adb</code>, and
-in 0x7 (aptos-experimental) on devnet/localnet.
+* Make sure LargePackages is deployed to your network of choice.
 * Ensure that <code>code_indices</code> have no gaps. For example, if code_indices are
-provided as [0, 1, 3] (skipping index 2), the inline function <code>assemble_module_code</code> will abort
-since <code><a href="large_packages.md#0x7_large_packages_StagingArea">StagingArea</a>.last_module_idx</code> is set as the max value of the provided index
-from <code>code_indices</code>, and <code>assemble_module_code</code> will lookup the <code><a href="large_packages.md#0x7_large_packages_StagingArea">StagingArea</a>.<a href="../../aptos-framework/doc/code.md#0x1_code">code</a></code> SmartTable from
-0 to <code><a href="large_packages.md#0x7_large_packages_StagingArea">StagingArea</a>.last_module_idx</code> in turn.
+provided as [0, 1, 3] (skipping index 2), <code>assemble_module_code</code> aborts with
+<code><a href="large_packages.md#0x7_large_packages_EINDEX_GAP">EINDEX_GAP</a></code> (invalid state) once it reaches the missing index, instead of an opaque table error.
+* Staging, publish, upgrade, and cleanup emit module events for indexers and monitoring.
 
 
 -  [Aptos Large Packages Framework](#@Aptos_Large_Packages_Framework_0)
 -  [Usage](#@Usage_1)
 -  [Notes](#@Notes_2)
+-  [Struct `ChunkStaged`](#0x7_large_packages_ChunkStaged)
+-  [Struct `PackagePublished`](#0x7_large_packages_PackagePublished)
+-  [Struct `PackageUpgraded`](#0x7_large_packages_PackageUpgraded)
+-  [Struct `StagingCleanedUp`](#0x7_large_packages_StagingCleanedUp)
 -  [Resource `StagingArea`](#0x7_large_packages_StagingArea)
 -  [Constants](#@Constants_3)
 -  [Function `stage_code_chunk`](#0x7_large_packages_stage_code_chunk)
@@ -80,6 +81,7 @@ from <code>code_indices</code>, and <code>assemble_module_code</code> will looku
 
 <pre><code><b>use</b> <a href="../../aptos-framework/doc/code.md#0x1_code">0x1::code</a>;
 <b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<b>use</b> <a href="../../aptos-framework/doc/event.md#0x1_event">0x1::event</a>;
 <b>use</b> <a href="../../aptos-framework/doc/object.md#0x1_object">0x1::object</a>;
 <b>use</b> <a href="../../aptos-framework/doc/object_code_deployment.md#0x1_object_code_deployment">0x1::object_code_deployment</a>;
 <b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
@@ -88,6 +90,164 @@ from <code>code_indices</code>, and <code>assemble_module_code</code> will looku
 </code></pre>
 
 
+
+<a id="0x7_large_packages_ChunkStaged"></a>
+
+## Struct `ChunkStaged`
+
+Emitted after each successful staging call (including the final chunk before publish/upgrade).
+
+
+<pre><code>#[<a href="../../aptos-framework/doc/event.md#0x1_event">event</a>]
+<b>struct</b> <a href="large_packages.md#0x7_large_packages_ChunkStaged">ChunkStaged</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>owner: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>module_indices: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u16&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>current_last_idx: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x7_large_packages_PackagePublished"></a>
+
+## Struct `PackagePublished`
+
+Emitted after a chunked package is published to an account or to a new object.
+
+
+<pre><code>#[<a href="../../aptos-framework/doc/event.md#0x1_event">event</a>]
+<b>struct</b> <a href="large_packages.md#0x7_large_packages_PackagePublished">PackagePublished</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>publisher: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>target: <b>address</b></code>
+</dt>
+<dd>
+ For account publish, the package address. For object publish, same as publisher (see <code><a href="../../aptos-framework/doc/object_code_deployment.md#0x1_object_code_deployment_Publish">object_code_deployment::Publish</a></code> for the new object address).
+</dd>
+<dt>
+<code>is_object: bool</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>module_count: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x7_large_packages_PackageUpgraded"></a>
+
+## Struct `PackageUpgraded`
+
+Emitted after a chunked upgrade of object-hosted package code.
+
+
+<pre><code>#[<a href="../../aptos-framework/doc/event.md#0x1_event">event</a>]
+<b>struct</b> <a href="large_packages.md#0x7_large_packages_PackageUpgraded">PackageUpgraded</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>publisher: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>code_object_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>module_count: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x7_large_packages_StagingCleanedUp"></a>
+
+## Struct `StagingCleanedUp`
+
+Emitted when a staging area is removed via <code>cleanup_staging_area</code>.
+
+
+<pre><code>#[<a href="../../aptos-framework/doc/event.md#0x1_event">event</a>]
+<b>struct</b> <a href="large_packages.md#0x7_large_packages_StagingCleanedUp">StagingCleanedUp</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>owner: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
 
 <a id="0x7_large_packages_StagingArea"></a>
 
@@ -139,6 +299,26 @@ code_indices and code_chunks should be the same length.
 
 
 <pre><code><b>const</b> <a href="large_packages.md#0x7_large_packages_ECODE_MISMATCH">ECODE_MISMATCH</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x7_large_packages_EEMPTY_CODE"></a>
+
+Code chunk must be non-empty.
+
+
+<pre><code><b>const</b> <a href="large_packages.md#0x7_large_packages_EEMPTY_CODE">EEMPTY_CODE</a>: u64 = 4;
+</code></pre>
+
+
+
+<a id="0x7_large_packages_EINDEX_GAP"></a>
+
+Assembly expected module index <code>i</code> in <code>0..=last_module_idx</code> but chunk <code>i</code> was never staged (gap in indices).
+
+
+<pre><code><b>const</b> <a href="large_packages.md#0x7_large_packages_EINDEX_GAP">EINDEX_GAP</a>: u64 = 3;
 </code></pre>
 
 
@@ -203,8 +383,16 @@ Object reference should be provided when upgrading object code.
     code_indices: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u16&gt;,
     code_chunks: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
 ) <b>acquires</b> <a href="large_packages.md#0x7_large_packages_StagingArea">StagingArea</a> {
+    <b>let</b> owner_address = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
     <b>let</b> staging_area = <a href="large_packages.md#0x7_large_packages_stage_code_chunk_internal">stage_code_chunk_internal</a>(owner, metadata_chunk, code_indices, code_chunks);
+    <b>let</b> module_count = staging_area.last_module_idx + 1;
     <a href="large_packages.md#0x7_large_packages_publish_to_account">publish_to_account</a>(owner, staging_area);
+    <a href="../../aptos-framework/doc/event.md#0x1_event_emit">event::emit</a>(<a href="large_packages.md#0x7_large_packages_PackagePublished">PackagePublished</a> {
+        publisher: owner_address,
+        target: owner_address,
+        is_object: <b>false</b>,
+        module_count,
+    });
     <a href="large_packages.md#0x7_large_packages_cleanup_staging_area">cleanup_staging_area</a>(owner);
 }
 </code></pre>
@@ -234,8 +422,16 @@ Object reference should be provided when upgrading object code.
     code_indices: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u16&gt;,
     code_chunks: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
 ) <b>acquires</b> <a href="large_packages.md#0x7_large_packages_StagingArea">StagingArea</a> {
+    <b>let</b> owner_address = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
     <b>let</b> staging_area = <a href="large_packages.md#0x7_large_packages_stage_code_chunk_internal">stage_code_chunk_internal</a>(owner, metadata_chunk, code_indices, code_chunks);
+    <b>let</b> module_count = staging_area.last_module_idx + 1;
     <a href="large_packages.md#0x7_large_packages_publish_to_object">publish_to_object</a>(owner, staging_area);
+    <a href="../../aptos-framework/doc/event.md#0x1_event_emit">event::emit</a>(<a href="large_packages.md#0x7_large_packages_PackagePublished">PackagePublished</a> {
+        publisher: owner_address,
+        target: owner_address,
+        is_object: <b>true</b>,
+        module_count,
+    });
     <a href="large_packages.md#0x7_large_packages_cleanup_staging_area">cleanup_staging_area</a>(owner);
 }
 </code></pre>
@@ -266,8 +462,16 @@ Object reference should be provided when upgrading object code.
     code_chunks: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
     code_object: Object&lt;PackageRegistry&gt;,
 ) <b>acquires</b> <a href="large_packages.md#0x7_large_packages_StagingArea">StagingArea</a> {
+    <b>let</b> owner_address = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> code_object_address = <a href="../../aptos-framework/doc/object.md#0x1_object_object_address">object::object_address</a>(&code_object);
     <b>let</b> staging_area = <a href="large_packages.md#0x7_large_packages_stage_code_chunk_internal">stage_code_chunk_internal</a>(owner, metadata_chunk, code_indices, code_chunks);
+    <b>let</b> module_count = staging_area.last_module_idx + 1;
     <a href="large_packages.md#0x7_large_packages_upgrade_object_code">upgrade_object_code</a>(owner, staging_area, code_object);
+    <a href="../../aptos-framework/doc/event.md#0x1_event_emit">event::emit</a>(<a href="large_packages.md#0x7_large_packages_PackageUpgraded">PackageUpgraded</a> {
+        publisher: owner_address,
+        code_object_address,
+        module_count,
+    });
     <a href="large_packages.md#0x7_large_packages_cleanup_staging_area">cleanup_staging_area</a>(owner);
 }
 </code></pre>
@@ -321,6 +525,10 @@ Object reference should be provided when upgrading object code.
     <b>let</b> i = 0;
     <b>while</b> (i &lt; <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&code_chunks)) {
         <b>let</b> inner_code = *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&code_chunks, i);
+        <b>assert</b>!(
+            <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&inner_code) &gt; 0,
+            <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="large_packages.md#0x7_large_packages_EEMPTY_CODE">EEMPTY_CODE</a>),
+        );
         <b>let</b> idx = (*<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&code_indices, i) <b>as</b> u64);
 
         <b>if</b> (<a href="../../aptos-framework/../aptos-stdlib/doc/smart_table.md#0x1_smart_table_contains">smart_table::contains</a>(&staging_area.<a href="../../aptos-framework/doc/code.md#0x1_code">code</a>, idx)) {
@@ -333,6 +541,12 @@ Object reference should be provided when upgrading object code.
         };
         i = i + 1;
     };
+
+    <a href="../../aptos-framework/doc/event.md#0x1_event_emit">event::emit</a>(<a href="large_packages.md#0x7_large_packages_ChunkStaged">ChunkStaged</a> {
+        owner: owner_address,
+        module_indices: code_indices,
+        current_last_idx: staging_area.last_module_idx,
+    });
 
     staging_area
 }
@@ -449,6 +663,10 @@ Object reference should be provided when upgrading object code.
     <b>let</b> <a href="../../aptos-framework/doc/code.md#0x1_code">code</a> = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
     <b>let</b> i = 0;
     <b>while</b> (i &lt;= last_module_idx) {
+        <b>assert</b>!(
+            <a href="../../aptos-framework/../aptos-stdlib/doc/smart_table.md#0x1_smart_table_contains">smart_table::contains</a>(&staging_area.<a href="../../aptos-framework/doc/code.md#0x1_code">code</a>, i),
+            <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="large_packages.md#0x7_large_packages_EINDEX_GAP">EINDEX_GAP</a>),
+        );
         <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(
             &<b>mut</b> <a href="../../aptos-framework/doc/code.md#0x1_code">code</a>,
             *<a href="../../aptos-framework/../aptos-stdlib/doc/smart_table.md#0x1_smart_table_borrow">smart_table::borrow</a>(&staging_area.<a href="../../aptos-framework/doc/code.md#0x1_code">code</a>, i)
@@ -479,12 +697,16 @@ Object reference should be provided when upgrading object code.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="large_packages.md#0x7_large_packages_cleanup_staging_area">cleanup_staging_area</a>(owner: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="large_packages.md#0x7_large_packages_StagingArea">StagingArea</a> {
-    <b>let</b> <a href="large_packages.md#0x7_large_packages_StagingArea">StagingArea</a> {
-        metadata_serialized: _,
-        <a href="../../aptos-framework/doc/code.md#0x1_code">code</a>,
-        last_module_idx: _,
-    } = <b>move_from</b>&lt;<a href="large_packages.md#0x7_large_packages_StagingArea">StagingArea</a>&gt;(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner));
-    <a href="../../aptos-framework/../aptos-stdlib/doc/smart_table.md#0x1_smart_table_destroy">smart_table::destroy</a>(<a href="../../aptos-framework/doc/code.md#0x1_code">code</a>);
+    <b>let</b> owner_address = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>if</b> (<b>exists</b>&lt;<a href="large_packages.md#0x7_large_packages_StagingArea">StagingArea</a>&gt;(owner_address)) {
+        <b>let</b> <a href="large_packages.md#0x7_large_packages_StagingArea">StagingArea</a> {
+            metadata_serialized: _,
+            <a href="../../aptos-framework/doc/code.md#0x1_code">code</a>,
+            last_module_idx: _,
+        } = <b>move_from</b>&lt;<a href="large_packages.md#0x7_large_packages_StagingArea">StagingArea</a>&gt;(owner_address);
+        <a href="../../aptos-framework/../aptos-stdlib/doc/smart_table.md#0x1_smart_table_destroy">smart_table::destroy</a>(<a href="../../aptos-framework/doc/code.md#0x1_code">code</a>);
+        <a href="../../aptos-framework/doc/event.md#0x1_event_emit">event::emit</a>(<a href="large_packages.md#0x7_large_packages_StagingCleanedUp">StagingCleanedUp</a> { owner: owner_address });
+    };
 }
 </code></pre>
 

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -943,4 +943,16 @@ mod tests {
         assert!(limits.check(&make_batch(u64::MAX, 500)).is_err());
         assert!(limits.check(&make_batch(50, u64::MAX)).is_err());
     }
+
+    #[test]
+    fn verify_inline_batches_rejects_oversized_batch() {
+        let limits = BatchSizeLimits::new(100, 1000);
+        let oversized = make_batch(101, 500);
+        let txns = vec![];
+        let batches = vec![(&oversized, &txns)];
+
+        let err = Payload::verify_inline_batches(batches.into_iter(), limits)
+            .expect_err("should reject oversized inline batch during verification");
+        assert!(err.to_string().contains("txns"), "{err}");
+    }
 }

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -125,6 +125,27 @@ pub struct RejectedTransactionSummary {
     pub reason: DiscardedVMStatus,
 }
 
+/// Validates that a single batch's num_txns and num_bytes are within receiver-side limits.
+pub fn verify_batch_info_limits(
+    batch: &BatchInfo,
+    max_batch_txns: u64,
+    max_batch_bytes: u64,
+) -> anyhow::Result<()> {
+    ensure!(
+        batch.num_txns() <= max_batch_txns,
+        "Batch txn count {} exceeds limit {}",
+        batch.num_txns(),
+        max_batch_txns,
+    );
+    ensure!(
+        batch.num_bytes() <= max_batch_bytes,
+        "Batch byte count {} exceeds limit {}",
+        batch.num_bytes(),
+        max_batch_bytes,
+    );
+    Ok(())
+}
+
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct ProofWithData {
     pub proofs: Vec<ProofOfStore>,
@@ -533,8 +554,11 @@ impl Payload {
 
     pub fn verify_inline_batches<'a>(
         inline_batches: impl Iterator<Item = (&'a BatchInfo, &'a Vec<SignedTransaction>)>,
+        max_batch_txns: u64,
+        max_batch_bytes: u64,
     ) -> anyhow::Result<()> {
         for (batch, payload) in inline_batches {
+            verify_batch_info_limits(batch, max_batch_txns, max_batch_bytes)?;
             // TODO: Can cloning be avoided here?
             let computed_digest = BatchPayload::new(batch.author(), payload.clone()).hash();
             ensure!(
@@ -551,9 +575,12 @@ impl Payload {
     pub fn verify_opt_batches(
         verifier: &ValidatorVerifier,
         opt_batches: &OptBatches,
+        max_batch_txns: u64,
+        max_batch_bytes: u64,
     ) -> anyhow::Result<()> {
         let authors = verifier.address_to_validator_index();
         for batch in &opt_batches.batch_summary {
+            verify_batch_info_limits(batch, max_batch_txns, max_batch_bytes)?;
             ensure!(
                 authors.contains_key(&batch.author()),
                 "Invalid author {} for batch {}",
@@ -569,35 +596,62 @@ impl Payload {
         verifier: &ValidatorVerifier,
         proof_cache: &ProofCache,
         quorum_store_enabled: bool,
+        max_batch_txns: u64,
+        max_batch_bytes: u64,
     ) -> anyhow::Result<()> {
         match (quorum_store_enabled, self) {
             (false, Payload::DirectMempool(_)) => Ok(()),
             (true, Payload::InQuorumStore(proof_with_status)) => {
-                Self::verify_with_cache(&proof_with_status.proofs, verifier, proof_cache)
+                Self::verify_with_cache(&proof_with_status.proofs, verifier, proof_cache)?;
+                for proof in &proof_with_status.proofs {
+                    verify_batch_info_limits(proof.info(), max_batch_txns, max_batch_bytes)?;
+                }
+                Ok(())
             },
-            (true, Payload::InQuorumStoreWithLimit(proof_with_status)) => Self::verify_with_cache(
-                &proof_with_status.proof_with_data.proofs,
-                verifier,
-                proof_cache,
-            ),
+            (true, Payload::InQuorumStoreWithLimit(proof_with_status)) => {
+                Self::verify_with_cache(
+                    &proof_with_status.proof_with_data.proofs,
+                    verifier,
+                    proof_cache,
+                )?;
+                for proof in &proof_with_status.proof_with_data.proofs {
+                    verify_batch_info_limits(proof.info(), max_batch_txns, max_batch_bytes)?;
+                }
+                Ok(())
+            },
             (true, Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _))
             | (true, Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _)) => {
                 Self::verify_with_cache(&proof_with_data.proofs, verifier, proof_cache)?;
+                for proof in &proof_with_data.proofs {
+                    verify_batch_info_limits(proof.info(), max_batch_txns, max_batch_bytes)?;
+                }
                 Self::verify_inline_batches(
                     inline_batches.iter().map(|(info, txns)| (info, txns)),
+                    max_batch_txns,
+                    max_batch_bytes,
                 )?;
                 Ok(())
             },
             (true, Payload::OptQuorumStore(opt_quorum_store)) => {
                 let proof_with_data = opt_quorum_store.proof_with_data();
                 Self::verify_with_cache(&proof_with_data.batch_summary, verifier, proof_cache)?;
+                for proof in &proof_with_data.batch_summary {
+                    verify_batch_info_limits(proof.info(), max_batch_txns, max_batch_bytes)?;
+                }
                 Self::verify_inline_batches(
                     opt_quorum_store
                         .inline_batches()
                         .iter()
                         .map(|batch| (batch.info(), batch.transactions())),
+                    max_batch_txns,
+                    max_batch_bytes,
                 )?;
-                Self::verify_opt_batches(verifier, opt_quorum_store.opt_batches())?;
+                Self::verify_opt_batches(
+                    verifier,
+                    opt_quorum_store.opt_batches(),
+                    max_batch_txns,
+                    max_batch_bytes,
+                )?;
                 Ok(())
             },
             (_, _) => Err(anyhow::anyhow!(

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -889,3 +889,58 @@ impl fmt::Display for PayloadFilter {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proof_of_store::{BatchId, BatchInfo};
+    use aptos_crypto::HashValue;
+    use aptos_types::PeerId;
+
+    fn make_batch(num_txns: u64, num_bytes: u64) -> BatchInfo {
+        BatchInfo::new(
+            PeerId::random(),
+            BatchId::new_for_test(1),
+            0,
+            100,
+            HashValue::random(),
+            num_txns,
+            num_bytes,
+            0,
+        )
+    }
+
+    #[test]
+    fn batch_size_limits_accepts_within_bounds() {
+        let limits = BatchSizeLimits::new(100, 1000);
+        assert!(limits.check(&make_batch(100, 1000)).is_ok());
+        assert!(limits.check(&make_batch(1, 1)).is_ok());
+        assert!(limits.check(&make_batch(0, 0)).is_ok());
+    }
+
+    #[test]
+    fn batch_size_limits_rejects_excess_txns() {
+        let limits = BatchSizeLimits::new(100, 1000);
+        let err = limits
+            .check(&make_batch(101, 500))
+            .expect_err("should reject batch exceeding txn cap");
+        assert!(err.to_string().contains("txns"), "{err}");
+    }
+
+    #[test]
+    fn batch_size_limits_rejects_excess_bytes() {
+        let limits = BatchSizeLimits::new(100, 1000);
+        let err = limits
+            .check(&make_batch(50, 1001))
+            .expect_err("should reject batch exceeding byte cap");
+        assert!(err.to_string().contains("bytes"), "{err}");
+    }
+
+    #[test]
+    fn batch_size_limits_rejects_overflow_values() {
+        let limits = BatchSizeLimits::new(100, 1000);
+        // Attacker claims u64::MAX txns / bytes — must be rejected.
+        assert!(limits.check(&make_batch(u64::MAX, 500)).is_err());
+        assert!(limits.check(&make_batch(50, u64::MAX)).is_err());
+    }
+}

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -125,25 +125,37 @@ pub struct RejectedTransactionSummary {
     pub reason: DiscardedVMStatus,
 }
 
-/// Validates that a single batch's num_txns and num_bytes are within receiver-side limits.
-pub fn verify_batch_info_limits(
-    batch: &BatchInfo,
-    max_batch_txns: u64,
-    max_batch_bytes: u64,
-) -> anyhow::Result<()> {
-    ensure!(
-        batch.num_txns() <= max_batch_txns,
-        "Batch txn count {} exceeds limit {}",
-        batch.num_txns(),
-        max_batch_txns,
-    );
-    ensure!(
-        batch.num_bytes() <= max_batch_bytes,
-        "Batch byte count {} exceeds limit {}",
-        batch.num_bytes(),
-        max_batch_bytes,
-    );
-    Ok(())
+/// Upper bounds on the number of transactions and bytes a single batch may declare.
+/// Checked on the receiver side to reject proposals or batches with inflated metadata.
+#[derive(Clone, Copy, Debug)]
+pub struct BatchSizeLimits {
+    pub max_txns: u64,
+    pub max_bytes: u64,
+}
+
+impl BatchSizeLimits {
+    pub fn new(max_txns: u64, max_bytes: u64) -> Self {
+        Self { max_txns, max_bytes }
+    }
+
+    /// Returns an error if `batch` exceeds either the transaction or byte cap.
+    pub fn check(&self, batch: &BatchInfo) -> anyhow::Result<()> {
+        ensure!(
+            batch.num_txns() <= self.max_txns,
+            "batch {} has {} txns, cap is {}",
+            batch.digest(),
+            batch.num_txns(),
+            self.max_txns,
+        );
+        ensure!(
+            batch.num_bytes() <= self.max_bytes,
+            "batch {} has {} bytes, cap is {}",
+            batch.digest(),
+            batch.num_bytes(),
+            self.max_bytes,
+        );
+        Ok(())
+    }
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
@@ -554,11 +566,10 @@ impl Payload {
 
     pub fn verify_inline_batches<'a>(
         inline_batches: impl Iterator<Item = (&'a BatchInfo, &'a Vec<SignedTransaction>)>,
-        max_batch_txns: u64,
-        max_batch_bytes: u64,
+        size_limits: BatchSizeLimits,
     ) -> anyhow::Result<()> {
         for (batch, payload) in inline_batches {
-            verify_batch_info_limits(batch, max_batch_txns, max_batch_bytes)?;
+            size_limits.check(batch)?;
             // TODO: Can cloning be avoided here?
             let computed_digest = BatchPayload::new(batch.author(), payload.clone()).hash();
             ensure!(
@@ -575,12 +586,11 @@ impl Payload {
     pub fn verify_opt_batches(
         verifier: &ValidatorVerifier,
         opt_batches: &OptBatches,
-        max_batch_txns: u64,
-        max_batch_bytes: u64,
+        size_limits: BatchSizeLimits,
     ) -> anyhow::Result<()> {
         let authors = verifier.address_to_validator_index();
         for batch in &opt_batches.batch_summary {
-            verify_batch_info_limits(batch, max_batch_txns, max_batch_bytes)?;
+            size_limits.check(batch)?;
             ensure!(
                 authors.contains_key(&batch.author()),
                 "Invalid author {} for batch {}",
@@ -596,15 +606,14 @@ impl Payload {
         verifier: &ValidatorVerifier,
         proof_cache: &ProofCache,
         quorum_store_enabled: bool,
-        max_batch_txns: u64,
-        max_batch_bytes: u64,
+        size_limits: BatchSizeLimits,
     ) -> anyhow::Result<()> {
         match (quorum_store_enabled, self) {
             (false, Payload::DirectMempool(_)) => Ok(()),
             (true, Payload::InQuorumStore(proof_with_status)) => {
                 Self::verify_with_cache(&proof_with_status.proofs, verifier, proof_cache)?;
                 for proof in &proof_with_status.proofs {
-                    verify_batch_info_limits(proof.info(), max_batch_txns, max_batch_bytes)?;
+                    size_limits.check(proof.info())?;
                 }
                 Ok(())
             },
@@ -615,7 +624,7 @@ impl Payload {
                     proof_cache,
                 )?;
                 for proof in &proof_with_status.proof_with_data.proofs {
-                    verify_batch_info_limits(proof.info(), max_batch_txns, max_batch_bytes)?;
+                    size_limits.check(proof.info())?;
                 }
                 Ok(())
             },
@@ -623,12 +632,11 @@ impl Payload {
             | (true, Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _)) => {
                 Self::verify_with_cache(&proof_with_data.proofs, verifier, proof_cache)?;
                 for proof in &proof_with_data.proofs {
-                    verify_batch_info_limits(proof.info(), max_batch_txns, max_batch_bytes)?;
+                    size_limits.check(proof.info())?;
                 }
                 Self::verify_inline_batches(
                     inline_batches.iter().map(|(info, txns)| (info, txns)),
-                    max_batch_txns,
-                    max_batch_bytes,
+                    size_limits,
                 )?;
                 Ok(())
             },
@@ -636,21 +644,19 @@ impl Payload {
                 let proof_with_data = opt_quorum_store.proof_with_data();
                 Self::verify_with_cache(&proof_with_data.batch_summary, verifier, proof_cache)?;
                 for proof in &proof_with_data.batch_summary {
-                    verify_batch_info_limits(proof.info(), max_batch_txns, max_batch_bytes)?;
+                    size_limits.check(proof.info())?;
                 }
                 Self::verify_inline_batches(
                     opt_quorum_store
                         .inline_batches()
                         .iter()
                         .map(|batch| (batch.info(), batch.transactions())),
-                    max_batch_txns,
-                    max_batch_bytes,
+                    size_limits,
                 )?;
                 Self::verify_opt_batches(
                     verifier,
                     opt_quorum_store.opt_batches(),
-                    max_batch_txns,
-                    max_batch_bytes,
+                    size_limits,
                 )?;
                 Ok(())
             },

--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -86,6 +86,8 @@ impl ProposalMsg {
         validator: &ValidatorVerifier,
         proof_cache: &ProofCache,
         quorum_store_enabled: bool,
+        max_batch_txns: u64,
+        max_batch_bytes: u64,
     ) -> Result<()> {
         if let Some(proposal_author) = self.proposal.author() {
             ensure!(
@@ -96,7 +98,13 @@ impl ProposalMsg {
             );
         }
         self.proposal().payload().map_or(Ok(()), |p| {
-            p.verify(validator, proof_cache, quorum_store_enabled)
+            p.verify(
+                validator,
+                proof_cache,
+                quorum_store_enabled,
+                max_batch_txns,
+                max_batch_bytes,
+            )
         })?;
 
         self.proposal()

--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -2,7 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{block::Block, common::Author, proof_of_store::ProofCache, sync_info::SyncInfo};
+use crate::{block::Block, common::{Author, BatchSizeLimits}, proof_of_store::ProofCache, sync_info::SyncInfo};
 use anyhow::{anyhow, ensure, format_err, Context, Result};
 use aptos_short_hex_str::AsShortHexStr;
 use aptos_types::validator_verifier::ValidatorVerifier;
@@ -86,8 +86,7 @@ impl ProposalMsg {
         validator: &ValidatorVerifier,
         proof_cache: &ProofCache,
         quorum_store_enabled: bool,
-        max_batch_txns: u64,
-        max_batch_bytes: u64,
+        size_limits: BatchSizeLimits,
     ) -> Result<()> {
         if let Some(proposal_author) = self.proposal.author() {
             ensure!(
@@ -102,8 +101,7 @@ impl ProposalMsg {
                 validator,
                 proof_cache,
                 quorum_store_enabled,
-                max_batch_txns,
-                max_batch_bytes,
+                size_limits,
             )
         })?;
 

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1530,6 +1530,8 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             let max_num_batches = self.config.quorum_store.receiver_max_num_batches;
             let max_batch_expiry_gap_usecs =
                 self.config.quorum_store.batch_expiry_gap_when_init_usecs;
+            let max_batch_txns = self.config.quorum_store.receiver_max_batch_txns as u64;
+            let max_batch_bytes = self.config.quorum_store.receiver_max_batch_bytes as u64;
             let payload_manager = self.payload_manager.clone();
             let pending_blocks = self.pending_blocks.clone();
             self.bounded_executor
@@ -1544,6 +1546,8 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                             peer_id == my_peer_id,
                             max_num_batches,
                             max_batch_expiry_gap_usecs,
+                            max_batch_txns,
+                            max_batch_bytes,
                         )
                     ) {
                         Ok(verified_event) => {

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1530,8 +1530,10 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             let max_num_batches = self.config.quorum_store.receiver_max_num_batches;
             let max_batch_expiry_gap_usecs =
                 self.config.quorum_store.batch_expiry_gap_when_init_usecs;
-            let max_batch_txns = self.config.quorum_store.receiver_max_batch_txns as u64;
-            let max_batch_bytes = self.config.quorum_store.receiver_max_batch_bytes as u64;
+            let size_limits = aptos_consensus_types::common::BatchSizeLimits::new(
+                self.config.quorum_store.receiver_max_batch_txns as u64,
+                self.config.quorum_store.receiver_max_batch_bytes as u64,
+            );
             let payload_manager = self.payload_manager.clone();
             let pending_blocks = self.pending_blocks.clone();
             self.bounded_executor
@@ -1546,8 +1548,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                             peer_id == my_peer_id,
                             max_num_batches,
                             max_batch_expiry_gap_usecs,
-                            max_batch_txns,
-                            max_batch_bytes,
+                            size_limits,
                         )
                     ) {
                         Ok(verified_event) => {

--- a/consensus/src/quorum_store/batch_coordinator.rs
+++ b/consensus/src/quorum_store/batch_coordinator.rs
@@ -14,7 +14,7 @@ use crate::{
     },
 };
 use anyhow::ensure;
-use aptos_consensus_types::payload::TDataInfo;
+use aptos_consensus_types::{common::verify_batch_info_limits, payload::TDataInfo};
 use aptos_logger::prelude::*;
 use aptos_short_hex_str::AsShortHexStr;
 use aptos_types::PeerId;
@@ -113,18 +113,11 @@ impl BatchCoordinator {
         let mut total_txns = 0;
         let mut total_bytes = 0;
         for batch in batches.iter() {
-            ensure!(
-                batch.num_txns() <= self.max_batch_txns,
-                "Exceeds batch txn limit {} > {}",
-                batch.num_txns(),
+            verify_batch_info_limits(
+                batch.batch_info(),
                 self.max_batch_txns,
-            );
-            ensure!(
-                batch.num_bytes() <= self.max_batch_bytes,
-                "Exceeds batch bytes limit {} > {}",
-                batch.num_bytes(),
                 self.max_batch_bytes,
-            );
+            )?;
 
             total_txns += batch.num_txns();
             total_bytes += batch.num_bytes();

--- a/consensus/src/quorum_store/batch_coordinator.rs
+++ b/consensus/src/quorum_store/batch_coordinator.rs
@@ -14,7 +14,7 @@ use crate::{
     },
 };
 use anyhow::ensure;
-use aptos_consensus_types::{common::verify_batch_info_limits, payload::TDataInfo};
+use aptos_consensus_types::{common::BatchSizeLimits, payload::TDataInfo};
 use aptos_logger::prelude::*;
 use aptos_short_hex_str::AsShortHexStr;
 use aptos_types::PeerId;
@@ -113,11 +113,8 @@ impl BatchCoordinator {
         let mut total_txns = 0;
         let mut total_bytes = 0;
         for batch in batches.iter() {
-            verify_batch_info_limits(
-                batch.batch_info(),
-                self.max_batch_txns,
-                self.max_batch_bytes,
-            )?;
+            BatchSizeLimits::new(self.max_batch_txns, self.max_batch_bytes)
+                .check(batch.batch_info())?;
 
             total_txns += batch.num_txns();
             total_bytes += batch.num_bytes();

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -106,13 +106,15 @@ impl UnverifiedEvent {
         self_message: bool,
         max_num_batches: usize,
         max_batch_expiry_gap_usecs: u64,
+        max_batch_txns: u64,
+        max_batch_bytes: u64,
     ) -> Result<VerifiedEvent, VerifyError> {
         let start_time = Instant::now();
         Ok(match self {
             //TODO: no need to sign and verify the proposal
             UnverifiedEvent::ProposalMsg(p) => {
                 if !self_message {
-                    p.verify(peer_id, validator, proof_cache, quorum_store_enabled)?;
+                    p.verify(peer_id, validator, proof_cache, quorum_store_enabled, max_batch_txns, max_batch_bytes)?;
                     counters::VERIFY_MSG
                         .with_label_values(&["proposal"])
                         .observe(start_time.elapsed().as_secs_f64());

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -39,7 +39,7 @@ use aptos_config::config::ConsensusConfig;
 use aptos_consensus_types::{
     block::Block,
     block_data::BlockType,
-    common::{Author, Round},
+    common::{Author, BatchSizeLimits, Round},
     order_vote::OrderVote,
     order_vote_msg::OrderVoteMsg,
     pipelined_block::PipelinedBlock,
@@ -106,15 +106,14 @@ impl UnverifiedEvent {
         self_message: bool,
         max_num_batches: usize,
         max_batch_expiry_gap_usecs: u64,
-        max_batch_txns: u64,
-        max_batch_bytes: u64,
+        size_limits: BatchSizeLimits,
     ) -> Result<VerifiedEvent, VerifyError> {
         let start_time = Instant::now();
         Ok(match self {
             //TODO: no need to sign and verify the proposal
             UnverifiedEvent::ProposalMsg(p) => {
                 if !self_message {
-                    p.verify(peer_id, validator, proof_cache, quorum_store_enabled, max_batch_txns, max_batch_bytes)?;
+                    p.verify(peer_id, validator, proof_cache, quorum_store_enabled, size_limits)?;
                     counters::VERIFY_MSG
                         .with_label_values(&["proposal"])
                         .observe(start_time.elapsed().as_secs_f64());


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Enforces batch metadata size limits (max_batch_txns, max_batch_bytes) during proposal verification in the consensus layer.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
