### PR TITLE
[verifier] fix mod_bounds.max to use per-module limit

### DIFF
--- a/third_party/move/move-bytecode-verifier/src/meter.rs
+++ b/third_party/move/move-bytecode-verifier/src/meter.rs
@@ -112,7 +112,7 @@ impl BoundMeter {
             mod_bounds: Bounds {
                 name: "<unknown>".to_string(),
                 units: 0,
-                max: config.max_per_fun_meter_units,
+                max: config.max_per_mod_meter_units,
             },
             fun_bounds: Bounds {
                 name: "<unknown>".to_string(),


### PR DESCRIPTION
## Description

The moudule bound in `BoundMeter` was incorrectly inherited from `max_per_fun_meter_units` which is for functions. We fixed this.

## How Has This Been Tested?

- `cargo check -p move-bytecode-verifier` — clean
- `cargo test -p move-bytecode-verifier` — 5 unit tests + 2 doc tests pass
- `cargo test -p bytecode-verifier-tests` — all tests pass except `unit_tests::bounds_tests::garbage_inputs`, which stack-overflows on `origin/m1` baseline as well (pre-existing flake unrelated to this change)

No new tests added — every existing `VerifierConfig` sets both meter limits to the same value, so the behavior is observably identical regardless of the fix. A test would only be meaningful with a config where the two diverge, which we don't currently have.

## Key Areas to Review

`third_party/move/move-bytecode-verifier/src/meter.rs:115` — the one-line change. Confirm `mod_bounds` should use the per-module limit (it should: `mod_bounds` is selected via `Scope::Module` in `get_bounds`).

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have performed a self-review of my own code
- [x] I tested both happy and unhappy path of the functionality