### PR TITLE
feat(confidential assets): add chain auditor and auditor epochs

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/confidential_asset_e2e.rs
+++ b/aptos-move/e2e-move-tests/src/tests/confidential_asset_e2e.rs
@@ -480,6 +480,28 @@ fn run_normalize(
     h.run(txn)
 }
 
+fn run_normalize_and_rollover(
+    h: &mut MoveHarness,
+    account: &Account,
+    new_bal: &[u8],
+    zkrp: &[u8],
+    sigma: &[u8],
+) -> TransactionStatus {
+    let payload = TransactionPayload::EntryFunction(EntryFunction::new(
+        ca_module_id(),
+        Identifier::new("normalize_and_rollover_pending_balance").unwrap(),
+        vec![],
+        vec![
+            bcs::to_bytes(&MOVE_METADATA).unwrap(),
+            new_bal.to_vec(),
+            zkrp.to_vec(),
+            sigma.to_vec(),
+        ],
+    ));
+    let txn = h.create_transaction_payload(account, payload);
+    h.run(txn)
+}
+
 fn set_asset_auditor(h: &mut MoveHarness, auditor_pubkey_32: &[u8]) {
     let args = vec![
         MoveValue::Signer(AccountAddress::ONE)
@@ -1224,6 +1246,46 @@ fn confidential_transfer_rejects_after_chain_auditor_rotation() {
     assert_kept_failure(&st, "post-rotation old-key proof must be rejected");
 }
 
+/// `normalize_and_rollover_pending_balance` does both steps in one tx. The proof is
+/// generated against the *current* (unnormalized) actual balance; success implies both
+/// `normalize_internal` and `rollover_pending_balance_internal` ran (their state asserts
+/// are mutually exclusive — `normalize` requires `!normalized`, `rollover` requires
+/// `normalized`, so a wrong composition would abort one of them).
+#[test]
+fn normalize_and_rollover_combined_entry_succeeds() {
+    let mut h = fresh_harness();
+    let chain = h.executor.get_chain_id().id();
+    let alice_addr = confidential_e2e_addr(0xEC, 1);
+    let bob_addr = confidential_e2e_addr(0xEC, 2);
+    let alice = h.new_account_with_balance_at(alice_addr, 50_000_000_000_000);
+    let bob = h.new_account_with_balance_at(bob_addr, 50_000_000_000_000);
+
+    let (alice_dk, alice_ek) = generate_elgamal_keypair(&mut h);
+    let (bob_dk, bob_ek) = generate_elgamal_keypair(&mut h);
+    for (acct, addr, dk, ek) in [(&alice, alice_addr, &alice_dk, &alice_ek), (&bob, bob_addr, &bob_dk, &bob_ek)] {
+        let pk = twisted_pubkey_bytes(&mut h, ek);
+        let (c, r) = prove_registration_parts(&mut h, chain, addr, dk, ek, MOVE_METADATA);
+        assert_kept_success(&run_register(&mut h, acct, &pk, &c, &r), "register");
+    }
+
+    // Stack two max-chunk deposits into the available balance to leave it unnormalized.
+    let max_chunk: u64 = (1u64 << 16) - 1;
+    assert_kept_success(&run_deposit(&mut h, &alice, max_chunk), "alice deposit 1");
+    assert_kept_success(&run_deposit_to(&mut h, &bob, alice_addr, max_chunk), "bob → alice deposit");
+    assert_kept_success(&run_rollover(&mut h, &alice), "rollover (now unnormalized)");
+
+    // A fresh deposit lands in pending; the combined entry must roll it in.
+    assert_kept_success(&run_deposit(&mut h, &alice, 50), "alice deposit 2");
+
+    // Proof normalizes against the *current* (unnormalized, pre-rollover) actual balance.
+    let cur: u128 = 2u128 * max_chunk as u128;
+    let (new_bal, zkrp, sigma) = pack_normalize(&mut h, chain, alice_addr, &alice_dk, cur);
+    assert_kept_success(
+        &run_normalize_and_rollover(&mut h, &alice, &new_bal, &zkrp, &sigma),
+        "normalize_and_rollover_pending_balance",
+    );
+}
+
 fn view_chain_auditor_pubkey(h: &mut MoveHarness) -> Vec<u8> {
     let ret = bypass_at(h, "confidential_asset", "get_chain_auditor", vec![], vec![]);
     assert_eq!(ret.return_values.len(), 1);
@@ -1232,4 +1294,229 @@ fn view_chain_auditor_pubkey(h: &mut MoveHarness) -> Vec<u8> {
     assert!(!opt_struct.is_empty() && opt_struct[0] == 1, "chain auditor must be Some");
     let inner = opt_struct[1..].to_vec();
     twisted_pubkey_bytes(h, &inner)
+}
+
+// ---- Combined "lands spendable" entrypoints (single-tx make-private flows) ----
+//
+// These three Move entrypoints collapse a deposit into a spendable confidential balance in one
+// transaction. All three end with `rollover_pending_balance_internal`, which writes the new
+// actual balance and zeros pending. The wallet picks based on on-chain state:
+//
+//   - unregistered                                  → register_and_deposit_and_rollover_pending_balance
+//   - registered, normalized=true                   → deposit_and_rollover_pending_balance
+//   - registered, normalized=false (post-rollover)  → deposit_and_normalize_and_rollover_pending_balance
+
+fn run_register_and_deposit_and_rollover(
+    h: &mut MoveHarness,
+    sender: &Account,
+    amount: u64,
+    ek_pubkey_32: &[u8],
+    comm: &[u8],
+    resp: &[u8],
+) -> TransactionStatus {
+    let payload = TransactionPayload::EntryFunction(EntryFunction::new(
+        ca_module_id(),
+        Identifier::new("register_and_deposit_and_rollover_pending_balance").unwrap(),
+        vec![],
+        vec![
+            bcs::to_bytes(&MOVE_METADATA).unwrap(),
+            bcs::to_bytes(&amount).unwrap(),
+            ek_pubkey_32.to_vec(),
+            comm.to_vec(),
+            resp.to_vec(),
+        ],
+    ));
+    let txn = h.create_transaction_payload(sender, payload);
+    h.run(txn)
+}
+
+fn run_deposit_and_rollover(h: &mut MoveHarness, sender: &Account, amount: u64) -> TransactionStatus {
+    let payload = TransactionPayload::EntryFunction(EntryFunction::new(
+        ca_module_id(),
+        Identifier::new("deposit_and_rollover_pending_balance").unwrap(),
+        vec![],
+        vec![bcs::to_bytes(&MOVE_METADATA).unwrap(), bcs::to_bytes(&amount).unwrap()],
+    ));
+    let txn = h.create_transaction_payload(sender, payload);
+    h.run(txn)
+}
+
+fn run_deposit_normalize_and_rollover(
+    h: &mut MoveHarness,
+    sender: &Account,
+    amount: u64,
+    new_balance: &[u8],
+    zkrp: &[u8],
+    sigma: &[u8],
+) -> TransactionStatus {
+    let payload = TransactionPayload::EntryFunction(EntryFunction::new(
+        ca_module_id(),
+        Identifier::new("deposit_and_normalize_and_rollover_pending_balance").unwrap(),
+        vec![],
+        vec![
+            bcs::to_bytes(&MOVE_METADATA).unwrap(),
+            bcs::to_bytes(&amount).unwrap(),
+            new_balance.to_vec(),
+            zkrp.to_vec(),
+            sigma.to_vec(),
+        ],
+    ));
+    let txn = h.create_transaction_payload(sender, payload);
+    h.run(txn)
+}
+
+/// First-time atomic register + deposit + rollover. Verifies (a) the entry succeeds, (b) the
+/// store is genuinely registered (a follow-up plain deposit works), and (c) the funds landed in
+/// actual (spendable), since the test exercises the same path the wallet's "Make private" UX
+/// uses for unregistered users.
+#[test]
+fn register_and_deposit_and_rollover_succeeds() {
+    let mut h = fresh_harness();
+    let chain = h.executor.get_chain_id().id();
+    let alice_addr = confidential_e2e_addr(0xCD, 3);
+    let alice = h.new_account_with_balance_at(alice_addr, 50_000_000_000_000);
+
+    let (alice_dk, alice_ek) = generate_elgamal_keypair(&mut h);
+    let alice_pk = twisted_pubkey_bytes(&mut h, &alice_ek);
+    let (c, r) = prove_registration_parts(&mut h, chain, alice_addr, &alice_dk, &alice_ek, MOVE_METADATA);
+
+    assert_kept_success(
+        &run_register_and_deposit_and_rollover(&mut h, &alice, 100, &alice_pk, &c, &r),
+        "register_and_deposit_and_rollover",
+    );
+    // Registration genuinely persisted: subsequent plain deposit (which requires an existing
+    // store) must succeed.
+    assert_kept_success(&run_deposit(&mut h, &alice, 25), "post-deposit");
+}
+
+/// Bad registration proof must reject before any state mutates.
+#[test]
+fn register_and_deposit_and_rollover_rejects_bad_proof() {
+    let mut h = fresh_harness();
+    let chain = h.executor.get_chain_id().id();
+    let alice_addr = confidential_e2e_addr(0xCD, 4);
+    let alice = h.new_account_with_balance_at(alice_addr, 50_000_000_000_000);
+
+    let (alice_dk, alice_ek) = generate_elgamal_keypair(&mut h);
+    let (_other_dk, other_ek) = generate_elgamal_keypair(&mut h);
+    let other_pk = twisted_pubkey_bytes(&mut h, &other_ek);
+    let (c, r) = prove_registration_parts(&mut h, chain, alice_addr, &alice_dk, &alice_ek, MOVE_METADATA);
+
+    assert_kept_failure(
+        &run_register_and_deposit_and_rollover(&mut h, &alice, 50, &other_pk, &c, &r),
+        "bad registration proof must reject combined call",
+    );
+}
+
+/// Combined entry aborts when the sender is already registered.
+#[test]
+fn register_and_deposit_and_rollover_aborts_when_already_registered() {
+    let mut h = fresh_harness();
+    let chain = h.executor.get_chain_id().id();
+    let alice_addr = confidential_e2e_addr(0xCD, 8);
+    let alice = h.new_account_with_balance_at(alice_addr, 50_000_000_000_000);
+
+    let (alice_dk, alice_ek) = generate_elgamal_keypair(&mut h);
+    let alice_pk = twisted_pubkey_bytes(&mut h, &alice_ek);
+    let (c, r) = prove_registration_parts(&mut h, chain, alice_addr, &alice_dk, &alice_ek, MOVE_METADATA);
+
+    assert_kept_success(
+        &run_register(&mut h, &alice, &alice_pk, &c, &r),
+        "alice plain register",
+    );
+    assert_kept_failure(
+        &run_register_and_deposit_and_rollover(&mut h, &alice, 5, &alice_pk, &c, &r),
+        "register_and_deposit_and_rollover on already-registered must abort",
+    );
+}
+
+/// Subsequent combined entry on a normalized state: deposit + rollover, no normalize required.
+/// Pre-state (normalized=true) is established by registering, depositing, rolling over, then
+/// withdrawing — the withdraw path sets normalized=true.
+#[test]
+fn deposit_and_rollover_succeeds_when_normalized() {
+    let mut h = fresh_harness();
+    let chain = h.executor.get_chain_id().id();
+    let alice_addr = confidential_e2e_addr(0xCD, 10);
+    let alice = h.new_account_with_balance_at(alice_addr, 50_000_000_000_000);
+
+    let (alice_dk, alice_ek) = generate_elgamal_keypair(&mut h);
+    let alice_pk = twisted_pubkey_bytes(&mut h, &alice_ek);
+    let (c, r) = prove_registration_parts(&mut h, chain, alice_addr, &alice_dk, &alice_ek, MOVE_METADATA);
+
+    // First-time path leaves normalized=false (rollover side effect).
+    assert_kept_success(
+        &run_register_and_deposit_and_rollover(&mut h, &alice, 100, &alice_pk, &c, &r),
+        "register_and_deposit_and_rollover",
+    );
+
+    // Withdraw any amount: normalized is set true on the sender's store.
+    let (new_bal, zkrp, sigma) = pack_withdraw(&mut h, chain, alice_addr, &alice_dk, &alice_ek, 1, 99);
+    assert_kept_success(
+        &run_withdraw(&mut h, &alice, 1, &new_bal, &zkrp, &sigma),
+        "withdraw to set normalized=true",
+    );
+
+    // Now the deposit_and_rollover path must succeed.
+    assert_kept_success(
+        &run_deposit_and_rollover(&mut h, &alice, 50),
+        "deposit_and_rollover when normalized",
+    );
+}
+
+/// Subsequent combined entry on a NOT-normalized state must abort with ENORMALIZATION_REQUIRED
+/// (3 << 16 | 10 = 196618). The wallet detects this state via `is_normalized` view and routes
+/// to `deposit_and_normalize_and_rollover_pending_balance` instead.
+#[test]
+fn deposit_and_rollover_aborts_when_not_normalized() {
+    let mut h = fresh_harness();
+    let chain = h.executor.get_chain_id().id();
+    let alice_addr = confidential_e2e_addr(0xCD, 11);
+    let alice = h.new_account_with_balance_at(alice_addr, 50_000_000_000_000);
+
+    let (alice_dk, alice_ek) = generate_elgamal_keypair(&mut h);
+    let alice_pk = twisted_pubkey_bytes(&mut h, &alice_ek);
+    let (c, r) = prove_registration_parts(&mut h, chain, alice_addr, &alice_dk, &alice_ek, MOVE_METADATA);
+
+    // After register_and_deposit_and_rollover, normalized=false.
+    assert_kept_success(
+        &run_register_and_deposit_and_rollover(&mut h, &alice, 100, &alice_pk, &c, &r),
+        "register_and_deposit_and_rollover",
+    );
+
+    // No withdraw / transfer / normalize in between → normalized still false.
+    assert_kept_failure(
+        &run_deposit_and_rollover(&mut h, &alice, 50),
+        "deposit_and_rollover when not normalized must abort",
+    );
+}
+
+/// Subsequent combined entry on a NOT-normalized state, with normalize proof. Lands funds
+/// spendable in one tx.
+#[test]
+fn deposit_normalize_and_rollover_succeeds_when_not_normalized() {
+    let mut h = fresh_harness();
+    let chain = h.executor.get_chain_id().id();
+    let alice_addr = confidential_e2e_addr(0xCD, 12);
+    let alice = h.new_account_with_balance_at(alice_addr, 50_000_000_000_000);
+
+    let (alice_dk, alice_ek) = generate_elgamal_keypair(&mut h);
+    let alice_pk = twisted_pubkey_bytes(&mut h, &alice_ek);
+    let (c, r) = prove_registration_parts(&mut h, chain, alice_addr, &alice_dk, &alice_ek, MOVE_METADATA);
+
+    // First-time → normalized=false, actual=100.
+    assert_kept_success(
+        &run_register_and_deposit_and_rollover(&mut h, &alice, 100, &alice_pk, &c, &r),
+        "register_and_deposit_and_rollover",
+    );
+
+    // Build the normalize proof against the *current* (pre-second-deposit) actual balance =
+    // 100. `deposit_to_internal` only mutates pending, so the actual the proof binds to matches
+    // the on-chain actual at normalize_internal time.
+    let (new_bal, zkrp, sigma) = pack_normalize(&mut h, chain, alice_addr, &alice_dk, 100u128);
+
+    assert_kept_success(
+        &run_deposit_normalize_and_rollover(&mut h, &alice, 50, &new_bal, &zkrp, &sigma),
+        "deposit_normalize_and_rollover when not normalized",
+    );
 }

--- a/aptos-move/e2e-move-tests/src/tests/confidential_asset_e2e.rs
+++ b/aptos-move/e2e-move-tests/src/tests/confidential_asset_e2e.rs
@@ -491,10 +491,36 @@ fn set_asset_auditor(h: &mut MoveHarness, auditor_pubkey_32: &[u8]) {
     bypass_at(
         h,
         "confidential_asset",
-        "set_auditor",
+        "set_asset_auditor",
         vec![],
         args,
     );
+}
+
+fn set_chain_auditor(h: &mut MoveHarness, auditor_pubkey_32: &[u8]) {
+    let args = vec![
+        MoveValue::Signer(AccountAddress::ONE)
+            .simple_serialize()
+            .unwrap(),
+        auditor_pubkey_32.to_vec(),
+    ];
+    bypass_at(
+        h,
+        "confidential_asset",
+        "set_chain_auditor",
+        vec![],
+        args,
+    );
+}
+
+/// Generates a fresh chain auditor keypair and installs it via `set_chain_auditor`.
+/// Used by `fresh_harness` so every confidential transfer in the test suite has a
+/// valid `auditor_eks[0]` available; tests that need to exercise rotation can call
+/// this again to install a successor.
+fn install_default_chain_auditor(h: &mut MoveHarness) {
+    let (_chain_dk, chain_ek) = generate_elgamal_keypair(h);
+    let chain_pk = twisted_pubkey_bytes(h, &chain_ek);
+    set_chain_auditor(h, &chain_pk);
 }
 
 fn pack_transfer_simple(
@@ -521,6 +547,43 @@ fn pack_transfer_simple(
         h,
         "confidential_gas_e2e_helpers",
         "pack_confidential_transfer_proof_simple",
+        vec![],
+        args,
+    );
+    assert_eq!(ret.return_values.len(), 8);
+    std::array::from_fn(|i| ret.return_values[i].0.clone())
+}
+
+fn pack_transfer_audited_verbatim(
+    h: &mut MoveHarness,
+    chain_byte: u8,
+    sender: AccountAddress,
+    recipient: AccountAddress,
+    dk: &[u8],
+    amount: u64,
+    new_balance: u128,
+    auditor_eks: Vec<Vec<u8>>,
+    sender_auditor_hint: Vec<u8>,
+) -> [Vec<u8>; 8] {
+    let auditor_inner: Vec<Vec<u8>> = auditor_eks
+        .iter()
+        .map(|b| raw_bytes_from_move_vector_u8(b))
+        .collect();
+    let args = vec![
+        bcs::to_bytes(&chain_byte).unwrap(),
+        bcs::to_bytes(&sender).unwrap(),
+        bcs::to_bytes(&recipient).unwrap(),
+        dk.to_vec(),
+        bcs::to_bytes(&amount).unwrap(),
+        bcs::to_bytes(&new_balance).unwrap(),
+        bcs::to_bytes(&MOVE_METADATA).unwrap(),
+        bcs::to_bytes(&auditor_inner).unwrap(),
+        bcs::to_bytes(&sender_auditor_hint).unwrap(),
+    ];
+    let ret = bypass_at(
+        h,
+        "confidential_gas_e2e_helpers",
+        "pack_confidential_transfer_proof_verbatim",
         vec![],
         args,
     );
@@ -828,6 +891,11 @@ fn fresh_harness() -> MoveHarness {
     delete_genesis_fa_controller_if_present(&mut h);
     inject_confidential_e2e_modules(&mut h);
     reinit_confidential_asset_module(&mut h);
+    // Every confidential transfer requires a chain-level auditor; install a deterministic
+    // throwaway one here so individual tests don't need to know about it. Tests that
+    // exercise the unset state should call `delete_genesis_fa_controller_if_present` +
+    // `reinit_confidential_asset_module` themselves to get a clean slate.
+    install_default_chain_auditor(&mut h);
     h
 }
 
@@ -1032,4 +1100,114 @@ fn confidential_transfer_rejects_non_matching_asset_auditor_pubkey() {
     );
     let st = run_confidential_transfer(&mut h, &alice, bob_addr, &parts, vec![]);
     assert_kept_failure(&st, "first auditor EK must match asset auditor");
+}
+
+// --- Chain-level auditor scenarios ---
+
+/// Harness variant that *omits* the default chain-auditor install. Tests use this when they
+/// need to exercise either the unset state or installation timing.
+fn fresh_harness_no_chain_auditor() -> MoveHarness {
+    let mut h = MoveHarness::new();
+    enable_confidential_features(&mut h);
+    delete_genesis_fa_controller_if_present(&mut h);
+    inject_confidential_e2e_modules(&mut h);
+    reinit_confidential_asset_module(&mut h);
+    h
+}
+
+#[test]
+fn confidential_transfer_rejects_when_chain_auditor_unset() {
+    let mut h = fresh_harness_no_chain_auditor();
+    let chain = h.executor.get_chain_id().id();
+    let alice_addr = confidential_e2e_addr(0xE9, 1);
+    let bob_addr = confidential_e2e_addr(0xE9, 2);
+    let alice = h.new_account_with_balance_at(alice_addr, 50_000_000_000_000);
+    let bob = h.new_account_with_balance_at(bob_addr, 1_000_000_000);
+
+    let (alice_dk, alice_ek) = generate_elgamal_keypair(&mut h);
+    let (bob_dk, bob_ek) = generate_elgamal_keypair(&mut h);
+    for (acct, addr, dk, ek) in [(&alice, alice_addr, &alice_dk, &alice_ek), (&bob, bob_addr, &bob_dk, &bob_ek)] {
+        let pk = twisted_pubkey_bytes(&mut h, ek);
+        let (c, r) = prove_registration_parts(&mut h, chain, addr, dk, ek, MOVE_METADATA);
+        assert_kept_success(&run_register(&mut h, acct, &pk, &c, &r), "register");
+    }
+    assert_kept_success(&run_deposit(&mut h, &alice, 2_000), "deposit");
+    assert_kept_success(&run_rollover(&mut h, &alice), "rollover");
+
+    // Empty auditor list — chain auditor isn't set on-chain, so any transfer must abort
+    // at the `ECHAIN_AUDITOR_NOT_SET` precondition before slot-matching even runs.
+    let parts = pack_transfer_audited_verbatim(
+        &mut h, chain, alice_addr, bob_addr, &alice_dk, 100, 1900, vec![], vec![]);
+    let st = run_confidential_transfer(&mut h, &alice, bob_addr, &parts, vec![]);
+    assert_kept_failure(&st, "transfer must abort when chain auditor is unset");
+}
+
+#[test]
+fn confidential_transfer_rejects_when_slot0_not_chain_auditor() {
+    let mut h = fresh_harness();
+    let chain = h.executor.get_chain_id().id();
+    let alice_addr = confidential_e2e_addr(0xEA, 1);
+    let bob_addr = confidential_e2e_addr(0xEA, 2);
+    let alice = h.new_account_with_balance_at(alice_addr, 50_000_000_000_000);
+    let bob = h.new_account_with_balance_at(bob_addr, 1_000_000_000);
+
+    let (alice_dk, alice_ek) = generate_elgamal_keypair(&mut h);
+    let (bob_dk, bob_ek) = generate_elgamal_keypair(&mut h);
+    for (acct, addr, dk, ek) in [(&alice, alice_addr, &alice_dk, &alice_ek), (&bob, bob_addr, &bob_dk, &bob_ek)] {
+        let pk = twisted_pubkey_bytes(&mut h, ek);
+        let (c, r) = prove_registration_parts(&mut h, chain, addr, dk, ek, MOVE_METADATA);
+        assert_kept_success(&run_register(&mut h, acct, &pk, &c, &r), "register");
+    }
+    assert_kept_success(&run_deposit(&mut h, &alice, 2_000), "deposit");
+    assert_kept_success(&run_rollover(&mut h, &alice), "rollover");
+
+    // Use a fresh keypair as slot 0 — proof is internally consistent (FS transcript binds
+    // this key) but `validate_auditors` rejects because slot 0 ≠ on-chain chain auditor.
+    let (_dk, wrong_ek) = generate_elgamal_keypair(&mut h);
+    let wrong_pk = twisted_pubkey_bytes(&mut h, &wrong_ek);
+    let parts = pack_transfer_audited_verbatim(
+        &mut h, chain, alice_addr, bob_addr, &alice_dk, 100, 1900, vec![wrong_pk], vec![]);
+    let st = run_confidential_transfer(&mut h, &alice, bob_addr, &parts, vec![]);
+    assert_kept_failure(&st, "slot 0 must equal active chain auditor");
+}
+
+#[test]
+fn confidential_transfer_rejects_after_chain_auditor_rotation() {
+    let mut h = fresh_harness();
+    let chain = h.executor.get_chain_id().id();
+    let alice_addr = confidential_e2e_addr(0xEB, 1);
+    let bob_addr = confidential_e2e_addr(0xEB, 2);
+    let alice = h.new_account_with_balance_at(alice_addr, 50_000_000_000_000);
+    let bob = h.new_account_with_balance_at(bob_addr, 1_000_000_000);
+
+    let (alice_dk, alice_ek) = generate_elgamal_keypair(&mut h);
+    let (bob_dk, bob_ek) = generate_elgamal_keypair(&mut h);
+    for (acct, addr, dk, ek) in [(&alice, alice_addr, &alice_dk, &alice_ek), (&bob, bob_addr, &bob_dk, &bob_ek)] {
+        let pk = twisted_pubkey_bytes(&mut h, ek);
+        let (c, r) = prove_registration_parts(&mut h, chain, addr, dk, ek, MOVE_METADATA);
+        assert_kept_success(&run_register(&mut h, acct, &pk, &c, &r), "register");
+    }
+    assert_kept_success(&run_deposit(&mut h, &alice, 2_000), "deposit");
+    assert_kept_success(&run_rollover(&mut h, &alice), "rollover");
+
+    // Snapshot the chain auditor key in force at proof-generation time, then rotate.
+    // The pre-rotation proof (slot 0 = old chain key) becomes unsubmittable.
+    let old_chain_pk = view_chain_auditor_pubkey(&mut h);
+    let parts = pack_transfer_audited_verbatim(
+        &mut h, chain, alice_addr, bob_addr, &alice_dk, 100, 1900, vec![old_chain_pk], vec![]);
+
+    install_default_chain_auditor(&mut h); // bumps to a new chain auditor key
+
+    let st = run_confidential_transfer(&mut h, &alice, bob_addr, &parts, vec![]);
+    assert_kept_failure(&st, "post-rotation old-key proof must be rejected");
+}
+
+fn view_chain_auditor_pubkey(h: &mut MoveHarness) -> Vec<u8> {
+    let ret = bypass_at(h, "confidential_asset", "get_chain_auditor", vec![], vec![]);
+    assert_eq!(ret.return_values.len(), 1);
+    let opt_struct = ret.return_values[0].0.clone();
+    // `Option<CompressedPubkey>` is BCS `0x01 || pubkey_bytes` when Some.
+    assert!(!opt_struct.is_empty() && opt_struct[0] == 1, "chain auditor must be Some");
+    let inner = opt_struct[1..].to_vec();
+    twisted_pubkey_bytes(h, &inner)
 }

--- a/aptos-move/e2e-move-tests/src/tests/confidential_asset_e2e.rs
+++ b/aptos-move/e2e-move-tests/src/tests/confidential_asset_e2e.rs
@@ -13,7 +13,7 @@
 // `0x1::event` from the same compile graph as `aptos-experimental` so `event::emitted_events` matches
 // `confidential_asset` (genesis `event` bytecode can lag). It also injects every `0x7` module from that
 // experimental build. Genesis already publishes
-// `FAController` for an older bytecode revision; we delete that resource and re-run
+// `GlobalConfig` for an older bytecode revision; we delete that resource and re-run
 // `init_module_for_testing` so on-disk layout matches the injected `confidential_asset` module.
 
 use crate::{tests::common::framework_dir_path, MoveHarness};
@@ -279,13 +279,13 @@ fn bypass_at(
         .unwrap_or_else(|e| panic!("bypass {module}::{fun}: {e:?}"))
 }
 
-/// Genesis `head` publishes `FAController` for bytecode that may differ from the injected module;
+/// Genesis `head` publishes `GlobalConfig` for bytecode that may differ from the injected module;
 /// remove it so `init_module` can republish with a matching layout.
-fn delete_genesis_fa_controller_if_present(h: &mut MoveHarness) {
+fn delete_genesis_global_config_if_present(h: &mut MoveHarness) {
     let tag = StructTag {
         address: APTOS_EXPERIMENTAL,
         module: Identifier::new("confidential_asset").unwrap(),
-        name: Identifier::new("FAController").unwrap(),
+        name: Identifier::new("GlobalConfig").unwrap(),
         type_args: vec![],
     };
     let key = StateKey::resource(&APTOS_EXPERIMENTAL, &tag).unwrap();
@@ -513,11 +513,33 @@ fn set_chain_auditor(h: &mut MoveHarness, auditor_pubkey_32: &[u8]) {
     );
 }
 
+/// Designates `admin_addr` as the chain-auditor admin (governance-only path). Required
+/// before `set_chain_auditor` will accept the corresponding signer; governance no longer
+/// holds chain-auditor authority directly.
+fn set_chain_auditor_admin(h: &mut MoveHarness, admin_addr: AccountAddress) {
+    let args = vec![
+        MoveValue::Signer(AccountAddress::ONE)
+            .simple_serialize()
+            .unwrap(),
+        bcs::to_bytes(&admin_addr).unwrap(),
+    ];
+    bypass_at(
+        h,
+        "confidential_asset",
+        "set_chain_auditor_admin",
+        vec![],
+        args,
+    );
+}
+
 /// Generates a fresh chain auditor keypair and installs it via `set_chain_auditor`.
 /// Used by `fresh_harness` so every confidential transfer in the test suite has a
 /// valid `auditor_eks[0]` available; tests that need to exercise rotation can call
-/// this again to install a successor.
+/// this again to install a successor. Designates `@0x1` as the chain-auditor admin so
+/// the bypass path can subsequently invoke `set_chain_auditor` with the framework
+/// signer; production deployments would point this at a dedicated admin account.
 fn install_default_chain_auditor(h: &mut MoveHarness) {
+    set_chain_auditor_admin(h, AccountAddress::ONE);
     let (_chain_dk, chain_ek) = generate_elgamal_keypair(h);
     let chain_pk = twisted_pubkey_bytes(h, &chain_ek);
     set_chain_auditor(h, &chain_pk);
@@ -888,12 +910,12 @@ fn profile_gas(
 fn fresh_harness() -> MoveHarness {
     let mut h = MoveHarness::new();
     enable_confidential_features(&mut h);
-    delete_genesis_fa_controller_if_present(&mut h);
+    delete_genesis_global_config_if_present(&mut h);
     inject_confidential_e2e_modules(&mut h);
     reinit_confidential_asset_module(&mut h);
     // Every confidential transfer requires a chain-level auditor; install a deterministic
     // throwaway one here so individual tests don't need to know about it. Tests that
-    // exercise the unset state should call `delete_genesis_fa_controller_if_present` +
+    // exercise the unset state should call `delete_genesis_global_config_if_present` +
     // `reinit_confidential_asset_module` themselves to get a clean slate.
     install_default_chain_auditor(&mut h);
     h
@@ -1109,7 +1131,7 @@ fn confidential_transfer_rejects_non_matching_asset_auditor_pubkey() {
 fn fresh_harness_no_chain_auditor() -> MoveHarness {
     let mut h = MoveHarness::new();
     enable_confidential_features(&mut h);
-    delete_genesis_fa_controller_if_present(&mut h);
+    delete_genesis_global_config_if_present(&mut h);
     inject_confidential_e2e_modules(&mut h);
     reinit_confidential_asset_module(&mut h);
     h

--- a/aptos-move/framework/aptos-experimental/doc/confidential_asset.md
+++ b/aptos-move/framework/aptos-experimental/doc/confidential_asset.md
@@ -8,7 +8,8 @@ It enables private transfers by obfuscating token amounts while keeping sender a
 
 
 -  [Resource `ConfidentialAssetStore`](#0x7_confidential_asset_ConfidentialAssetStore)
--  [Resource `FAController`](#0x7_confidential_asset_FAController)
+-  [Struct `AuditorEntry`](#0x7_confidential_asset_AuditorEntry)
+-  [Resource `GlobalConfig`](#0x7_confidential_asset_GlobalConfig)
 -  [Resource `FAConfig`](#0x7_confidential_asset_FAConfig)
 -  [Struct `Registered`](#0x7_confidential_asset_Registered)
 -  [Struct `Deposited`](#0x7_confidential_asset_Deposited)
@@ -20,7 +21,9 @@ It enables private transfers by obfuscating token amounts while keeping sender a
 -  [Struct `FreezeChanged`](#0x7_confidential_asset_FreezeChanged)
 -  [Struct `AllowListChanged`](#0x7_confidential_asset_AllowListChanged)
 -  [Struct `TokenAllowChanged`](#0x7_confidential_asset_TokenAllowChanged)
--  [Struct `AuditorChanged`](#0x7_confidential_asset_AuditorChanged)
+-  [Struct `AssetAuditorChanged`](#0x7_confidential_asset_AssetAuditorChanged)
+-  [Struct `ChainAuditorChanged`](#0x7_confidential_asset_ChainAuditorChanged)
+-  [Struct `ChainAuditorAdminChanged`](#0x7_confidential_asset_ChainAuditorAdminChanged)
 -  [Constants](#@Constants_0)
 -  [Function `init_module`](#0x7_confidential_asset_init_module)
 -  [Function `register`](#0x7_confidential_asset_register)
@@ -43,7 +46,9 @@ It enables private transfers by obfuscating token amounts while keeping sender a
 -  [Function `disable_allow_list`](#0x7_confidential_asset_disable_allow_list)
 -  [Function `enable_token`](#0x7_confidential_asset_enable_token)
 -  [Function `disable_token`](#0x7_confidential_asset_disable_token)
--  [Function `set_auditor`](#0x7_confidential_asset_set_auditor)
+-  [Function `set_asset_auditor`](#0x7_confidential_asset_set_asset_auditor)
+-  [Function `set_chain_auditor_admin`](#0x7_confidential_asset_set_chain_auditor_admin)
+-  [Function `set_chain_auditor`](#0x7_confidential_asset_set_chain_auditor)
 -  [Function `has_confidential_asset_store`](#0x7_confidential_asset_has_confidential_asset_store)
 -  [Function `is_token_allowed`](#0x7_confidential_asset_is_token_allowed)
 -  [Function `is_allow_list_enabled`](#0x7_confidential_asset_is_allow_list_enabled)
@@ -52,7 +57,13 @@ It enables private transfers by obfuscating token amounts while keeping sender a
 -  [Function `encryption_key`](#0x7_confidential_asset_encryption_key)
 -  [Function `is_normalized`](#0x7_confidential_asset_is_normalized)
 -  [Function `is_frozen`](#0x7_confidential_asset_is_frozen)
--  [Function `get_auditor`](#0x7_confidential_asset_get_auditor)
+-  [Function `get_asset_auditor`](#0x7_confidential_asset_get_asset_auditor)
+-  [Function `get_asset_auditor_epoch`](#0x7_confidential_asset_get_asset_auditor_epoch)
+-  [Function `get_asset_auditor_history`](#0x7_confidential_asset_get_asset_auditor_history)
+-  [Function `get_chain_auditor`](#0x7_confidential_asset_get_chain_auditor)
+-  [Function `get_chain_auditor_epoch`](#0x7_confidential_asset_get_chain_auditor_epoch)
+-  [Function `get_chain_auditor_history`](#0x7_confidential_asset_get_chain_auditor_history)
+-  [Function `get_chain_auditor_admin`](#0x7_confidential_asset_get_chain_auditor_admin)
 -  [Function `confidential_asset_balance`](#0x7_confidential_asset_confidential_asset_balance)
 -  [Function `register_internal`](#0x7_confidential_asset_register_internal)
 -  [Function `deposit_to_internal`](#0x7_confidential_asset_deposit_to_internal)
@@ -181,14 +192,58 @@ The <code><a href="confidential_asset.md#0x7_confidential_asset">confidential_as
 
 </details>
 
-<a id="0x7_confidential_asset_FAController"></a>
+<a id="0x7_confidential_asset_AuditorEntry"></a>
 
-## Resource `FAController`
+## Struct `AuditorEntry`
 
-Represents the controller for the primary FA stores and <code><a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a></code> objects.
+One entry in an auditor key history vector — used for both the chain-level auditor
+(on [<code><a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a></code>]) and the per-asset auditor (on [<code><a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a></code>]). Rotated keys are
+retained so transfers stamped with a prior epoch can still be decrypted.
 
 
-<pre><code><b>struct</b> <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a> <b>has</b> key
+<pre><code><b>struct</b> <a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">AuditorEntry</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>ek: <a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>activated_at_epoch: u64</code>
+</dt>
+<dd>
+ First epoch in which <code>ek</code> was the active auditor key. Monotonically increasing
+ per layer (chain or asset).
+</dd>
+<dt>
+<code>deactivated_at_epoch: u64</code>
+</dt>
+<dd>
+ Epoch at which this entry was deactivated (i.e. the <code>activated_at_epoch</code> of its
+ successor). <code>0</code> means the entry is still the active key.
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x7_confidential_asset_GlobalConfig"></a>
+
+## Resource `GlobalConfig`
+
+Global configuration for confidential assets: primary FA stores, <code><a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a></code> derivation, and chain-level auditor state.
+
+
+<pre><code><b>struct</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> <b>has</b> key
 </code></pre>
 
 
@@ -210,6 +265,37 @@ Represents the controller for the primary FA stores and <code><a href="confident
 </dt>
 <dd>
  Used to derive a signer that owns all the FAs' primary stores and <code><a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a></code> objects.
+</dd>
+<dt>
+<code>chain_auditor_ek: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>&gt;</code>
+</dt>
+<dd>
+ Chain-level auditor encryption key. Required at <code>auditor_eks[0]</code> on every
+ confidential transfer. <code>None</code> until set via [<code>set_chain_auditor</code>]; transfers
+ abort with [<code><a href="confidential_asset.md#0x7_confidential_asset_ECHAIN_AUDITOR_NOT_SET">ECHAIN_AUDITOR_NOT_SET</a></code>] in that state.
+</dd>
+<dt>
+<code>chain_auditor_admin: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;</code>
+</dt>
+<dd>
+ Account authorized to call [<code>set_chain_auditor</code>]. Set by governance via
+ [<code>set_chain_auditor_admin</code>]. <code>None</code> until governance assigns one, during which
+ window <code>set_chain_auditor</code> aborts with [<code><a href="confidential_asset.md#0x7_confidential_asset_ECHAIN_AUDITOR_ADMIN_NOT_SET">ECHAIN_AUDITOR_ADMIN_NOT_SET</a></code>].
+</dd>
+<dt>
+<code>chain_auditor_epoch: u64</code>
+</dt>
+<dd>
+ Bumped on every [<code>set_chain_auditor</code>] call (including clears). Stamped on each
+ [<code><a href="confidential_asset.md#0x7_confidential_asset_Transferred">Transferred</a></code>] event.
+</dd>
+<dt>
+<code>chain_auditor_history: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">confidential_asset::AuditorEntry</a>&gt;</code>
+</dt>
+<dd>
+ Append-only history of chain auditor keys. Each entry's
+ <code>[activated_at_epoch, deactivated_at_epoch)</code> half-open interval is the range
+ of <code>chain_auditor_epoch</code> values during which it was active.
 </dd>
 </dl>
 
@@ -242,12 +328,25 @@ Represents the configuration of a token.
  Can be toggled by the governance module. The withdrawals are always allowed.
 </dd>
 <dt>
-<code>auditor_ek: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>&gt;</code>
+<code>asset_auditor_ek: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>&gt;</code>
 </dt>
 <dd>
- The auditor's public key for the token. If the auditor is not set, this field is <code>None</code>.
- Otherwise, each confidential transfer must include the auditor as an additional party,
- alongside the recipient, who has access to the decrypted transferred amount.
+ Per-asset auditor encryption key. When set, required at <code>auditor_eks[1]</code> on
+ every transfer of this asset (additive to the chain auditor at <code>[0]</code>). Set via
+ [<code>set_asset_auditor</code>] by the FA metadata object's root owner.
+</dd>
+<dt>
+<code>asset_auditor_epoch: u64</code>
+</dt>
+<dd>
+ Bumped on every [<code>set_asset_auditor</code>] call. Stamped on each [<code><a href="confidential_asset.md#0x7_confidential_asset_Transferred">Transferred</a></code>]
+ event for this asset.
+</dd>
+<dt>
+<code>asset_auditor_history: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">confidential_asset::AuditorEntry</a>&gt;</code>
+</dt>
+<dd>
+ Append-only history of asset auditor keys. See [<code><a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">AuditorEntry</a></code>].
 </dd>
 </dl>
 
@@ -481,6 +580,22 @@ from the verified proof. See the technical whitepaper (<code>whitepaper.md</code
 </dt>
 <dd>
  Reserved memo payload for future or off-chain conventions; currently emitted as an empty <code><a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a></code>.
+</dd>
+<dt>
+<code>chain_auditor_epoch: u64</code>
+</dt>
+<dd>
+ Value of [<code><a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>.chain_auditor_epoch</code>] at the time of the transfer.
+ Required for compliance: lets future audits identify which historical
+ chain-level auditor key was in force, so that the transcript can still be
+ decrypted years after a key rotation.
+</dd>
+<dt>
+<code>asset_auditor_epoch: u64</code>
+</dt>
+<dd>
+ Value of [<code><a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>.asset_auditor_epoch</code>] for this asset at the time of the
+ transfer. <code>0</code> when this asset has no asset-level auditor configured.
 </dd>
 </dl>
 
@@ -721,15 +836,15 @@ Emitted when a token's confidential-transfer permission is toggled.
 
 </details>
 
-<a id="0x7_confidential_asset_AuditorChanged"></a>
+<a id="0x7_confidential_asset_AssetAuditorChanged"></a>
 
-## Struct `AuditorChanged`
+## Struct `AssetAuditorChanged`
 
-Emitted when the asset-specific auditor is set or removed.
+Asset auditor set, rotated, or cleared.
 
 
 <pre><code>#[<a href="../../aptos-framework/doc/event.md#0x1_event">event</a>]
-<b>struct</b> <a href="confidential_asset.md#0x7_confidential_asset_AuditorChanged">AuditorChanged</a> <b>has</b> drop, store
+<b>struct</b> <a href="confidential_asset.md#0x7_confidential_asset_AssetAuditorChanged">AssetAuditorChanged</a> <b>has</b> drop, store
 </code></pre>
 
 
@@ -746,7 +861,77 @@ Emitted when the asset-specific auditor is set or removed.
 
 </dd>
 <dt>
-<code>new_auditor_ek: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>&gt;</code>
+<code>new_asset_auditor_ek: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>new_epoch: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x7_confidential_asset_ChainAuditorChanged"></a>
+
+## Struct `ChainAuditorChanged`
+
+Chain auditor set, rotated, or cleared.
+
+
+<pre><code>#[<a href="../../aptos-framework/doc/event.md#0x1_event">event</a>]
+<b>struct</b> <a href="confidential_asset.md#0x7_confidential_asset_ChainAuditorChanged">ChainAuditorChanged</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>new_chain_auditor_ek: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>new_epoch: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x7_confidential_asset_ChainAuditorAdminChanged"></a>
+
+## Struct `ChainAuditorAdminChanged`
+
+Chain-auditor admin assigned or rotated by governance.
+
+
+<pre><code>#[<a href="../../aptos-framework/doc/event.md#0x1_event">event</a>]
+<b>struct</b> <a href="confidential_asset.md#0x7_confidential_asset_ChainAuditorAdminChanged">ChainAuditorAdminChanged</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>new_admin: <b>address</b></code>
 </dt>
 <dd>
 
@@ -851,6 +1036,26 @@ The confidential asset store has not been published for the given user-token pai
 
 
 
+<a id="0x7_confidential_asset_ECHAIN_AUDITOR_ADMIN_NOT_SET"></a>
+
+Chain-auditor admin not assigned by governance.
+
+
+<pre><code><b>const</b> <a href="confidential_asset.md#0x7_confidential_asset_ECHAIN_AUDITOR_ADMIN_NOT_SET">ECHAIN_AUDITOR_ADMIN_NOT_SET</a>: u64 = 23;
+</code></pre>
+
+
+
+<a id="0x7_confidential_asset_ECHAIN_AUDITOR_NOT_SET"></a>
+
+Chain auditor not configured; confidential transfers cannot proceed.
+
+
+<pre><code><b>const</b> <a href="confidential_asset.md#0x7_confidential_asset_ECHAIN_AUDITOR_NOT_SET">ECHAIN_AUDITOR_NOT_SET</a>: u64 = 21;
+</code></pre>
+
+
+
 <a id="0x7_confidential_asset_EINVALID_AUDITORS"></a>
 
 The provided auditors or auditor proofs are invalid.
@@ -881,12 +1086,32 @@ The operation requires the actual balance to be normalized.
 
 
 
+<a id="0x7_confidential_asset_ENOT_ASSET_ISSUER"></a>
+
+Signer is not the FA metadata object's root owner.
+
+
+<pre><code><b>const</b> <a href="confidential_asset.md#0x7_confidential_asset_ENOT_ASSET_ISSUER">ENOT_ASSET_ISSUER</a>: u64 = 22;
+</code></pre>
+
+
+
 <a id="0x7_confidential_asset_ENOT_AUDITOR"></a>
 
 The sender is not the registered auditor.
 
 
 <pre><code><b>const</b> <a href="confidential_asset.md#0x7_confidential_asset_ENOT_AUDITOR">ENOT_AUDITOR</a>: u64 = 5;
+</code></pre>
+
+
+
+<a id="0x7_confidential_asset_ENOT_CHAIN_AUDITOR_ADMIN"></a>
+
+Signer is not the configured chain-auditor admin.
+
+
+<pre><code><b>const</b> <a href="confidential_asset.md#0x7_confidential_asset_ENOT_CHAIN_AUDITOR_ADMIN">ENOT_CHAIN_AUDITOR_ADMIN</a>: u64 = 24;
 </code></pre>
 
 
@@ -1015,11 +1240,15 @@ The maximum number of transactions can be aggregated on the pending balance befo
 
     <b>let</b> deployer_address = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(deployer);
 
-    <b>let</b> fa_controller_ctor_ref = &<a href="../../aptos-framework/doc/object.md#0x1_object_create_object">object::create_object</a>(deployer_address);
+    <b>let</b> global_config_ctor_ref = &<a href="../../aptos-framework/doc/object.md#0x1_object_create_object">object::create_object</a>(deployer_address);
 
-    <b>move_to</b>(deployer, <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a> {
+    <b>move_to</b>(deployer, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
         allow_list_enabled: <a href="../../aptos-framework/doc/chain_id.md#0x1_chain_id_get">chain_id::get</a>() == <a href="confidential_asset.md#0x7_confidential_asset_MAINNET_CHAIN_ID">MAINNET_CHAIN_ID</a>,
-        extend_ref: <a href="../../aptos-framework/doc/object.md#0x1_object_generate_extend_ref">object::generate_extend_ref</a>(fa_controller_ctor_ref),
+        extend_ref: <a href="../../aptos-framework/doc/object.md#0x1_object_generate_extend_ref">object::generate_extend_ref</a>(global_config_ctor_ref),
+        chain_auditor_ek: std::option::none(),
+        chain_auditor_epoch: 0,
+        chain_auditor_history: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[],
+        chain_auditor_admin: std::option::none(),
     });
 }
 </code></pre>
@@ -1052,7 +1281,7 @@ Users are also responsible for generating a Twisted ElGamal key pair on their si
     token: Object&lt;Metadata&gt;,
     ek: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     registration_proof_commitment: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    registration_proof_response: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>
+    registration_proof_response: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>
 {
     <b>let</b> ek = twisted_elgamal::new_pubkey_from_bytes(ek).extract();
 
@@ -1101,7 +1330,7 @@ subsequent transactions.
     sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     token: Object&lt;Metadata&gt;,
     <b>to</b>: <b>address</b>,
-    amount: u64) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>
+    amount: u64) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>
 {
     <a href="confidential_asset.md#0x7_confidential_asset_deposit_to_internal">deposit_to_internal</a>(sender, token, <b>to</b>, amount)
 }
@@ -1130,7 +1359,7 @@ The same as <code>deposit_to</code>, but the recipient is the sender.
 <pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_deposit">deposit</a>(
     sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     token: Object&lt;Metadata&gt;,
-    amount: u64) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>
+    amount: u64) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>
 {
     <a href="confidential_asset.md#0x7_confidential_asset_deposit_to_internal">deposit_to_internal</a>(sender, token, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(sender), amount)
 }
@@ -1159,7 +1388,7 @@ The same as <code>deposit_to</code>, but converts coins to missing FA first.
 <pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_deposit_coins_to">deposit_coins_to</a>&lt;CoinType&gt;(
     sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     <b>to</b>: <b>address</b>,
-    amount: u64) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>
+    amount: u64) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>
 {
     <b>let</b> token = <a href="confidential_asset.md#0x7_confidential_asset_ensure_sufficient_fa">ensure_sufficient_fa</a>&lt;CoinType&gt;(sender, amount).extract();
 
@@ -1189,7 +1418,7 @@ The same as <code>deposit</code>, but converts coins to missing FA first.
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_deposit_coins">deposit_coins</a>&lt;CoinType&gt;(
     sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    amount: u64) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>
+    amount: u64) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>
 {
     <b>let</b> token = <a href="confidential_asset.md#0x7_confidential_asset_ensure_sufficient_fa">ensure_sufficient_fa</a>&lt;CoinType&gt;(sender, amount).extract();
 
@@ -1227,7 +1456,7 @@ The sender provides their new normalized confidential balance, encrypted with fr
     amount: u64,
     new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     zkrp_new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    sigma_proof: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>
+    sigma_proof: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>
 {
     <b>let</b> new_balance = <a href="confidential_balance.md#0x7_confidential_balance_new_actual_balance_from_bytes">confidential_balance::new_actual_balance_from_bytes</a>(new_balance).extract();
     <b>let</b> proof = <a href="confidential_proof.md#0x7_confidential_proof_deserialize_withdrawal_proof">confidential_proof::deserialize_withdrawal_proof</a>(sigma_proof, zkrp_new_balance).extract();
@@ -1262,7 +1491,7 @@ The same as <code>withdraw_to</code>, but the recipient is the sender.
     amount: u64,
     new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     zkrp_new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    sigma_proof: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>
+    sigma_proof: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>
 {
     <a href="confidential_asset.md#0x7_confidential_asset_withdraw_to">withdraw_to</a>(
         sender,
@@ -1288,11 +1517,17 @@ Transfers tokens from the sender's actual balance to the recipient's pending bal
 The function hides the transferred amount while keeping the sender and recipient addresses visible.
 The sender encrypts the transferred amount with the recipient's encryption key and the function updates the
 recipient's confidential balance homomorphically.
-Additionally, the sender encrypts the transferred amount with the auditors' EKs, allowing auditors to decrypt
-it on their side.
+Additionally, the sender encrypts the transferred amount with each auditor's EK, allowing auditors to decrypt
+it on their side. The combined auditor list (<code>auditor_eks</code> / <code>auditor_amounts</code>) has a fixed prefix layout:
+
+```text
+[0]   chain-level compliance auditor (always required; configured via <code>set_chain_auditor</code>)
+[1]   asset-specific auditor         (required iff <code><a href="confidential_asset.md#0x7_confidential_asset_get_asset_auditor">get_asset_auditor</a>(token).is_some()</code>)
+[2..] voluntary auditors             (sender's choice; ordered)
+```
+
+Aborts with [<code><a href="confidential_asset.md#0x7_confidential_asset_ECHAIN_AUDITOR_NOT_SET">ECHAIN_AUDITOR_NOT_SET</a></code>] when the chain-level auditor has not yet been configured.
 The sender provides their new normalized confidential balance, encrypted with fresh randomness to preserve privacy.
-Warning: If the auditor feature is enabled, the sender must include the auditor as the first element in the
-<code>auditor_eks</code> vector.
 
 <code>sender_auditor_hint</code> is emitted on [<code><a href="confidential_asset.md#0x7_confidential_asset_Transferred">Transferred</a></code>] and is **bound into the transfer sigma Fiat–Shamir
 transcript** (must match the hint used when generating the proof). Length must not exceed
@@ -1320,7 +1555,7 @@ transcript** (must match the hint used when generating the proof). Length must n
     zkrp_new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     zkrp_transfer_amount: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     sigma_proof: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    sender_auditor_hint: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>
+    sender_auditor_hint: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>
 {
     <b>let</b> new_balance = <a href="confidential_balance.md#0x7_confidential_balance_new_actual_balance_from_bytes">confidential_balance::new_actual_balance_from_bytes</a>(new_balance).extract();
     <b>let</b> sender_amount = <a href="confidential_balance.md#0x7_confidential_balance_new_pending_balance_from_bytes">confidential_balance::new_pending_balance_from_bytes</a>(sender_amount).extract();
@@ -1615,14 +1850,14 @@ Enables the allow list, restricting confidential transfers to tokens on the allo
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_enable_allow_list">enable_allow_list</a>(aptos_framework: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_enable_allow_list">enable_allow_list</a>(aptos_framework: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
     <a href="../../aptos-framework/doc/system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
 
-    <b>let</b> fa_controller = <b>borrow_global_mut</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>&gt;(@aptos_experimental);
+    <b>let</b> global_config = <b>borrow_global_mut</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>&gt;(@aptos_experimental);
 
-    <b>assert</b>!(!fa_controller.allow_list_enabled, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="confidential_asset.md#0x7_confidential_asset_EALLOW_LIST_ENABLED">EALLOW_LIST_ENABLED</a>));
+    <b>assert</b>!(!global_config.allow_list_enabled, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="confidential_asset.md#0x7_confidential_asset_EALLOW_LIST_ENABLED">EALLOW_LIST_ENABLED</a>));
 
-    fa_controller.allow_list_enabled = <b>true</b>;
+    global_config.allow_list_enabled = <b>true</b>;
 
     <a href="../../aptos-framework/doc/event.md#0x1_event_emit">event::emit</a>(<a href="confidential_asset.md#0x7_confidential_asset_AllowListChanged">AllowListChanged</a> { enabled: <b>true</b> });
 }
@@ -1648,14 +1883,14 @@ Disables the allow list, allowing confidential transfers for all tokens.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_disable_allow_list">disable_allow_list</a>(aptos_framework: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_disable_allow_list">disable_allow_list</a>(aptos_framework: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
     <a href="../../aptos-framework/doc/system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
 
-    <b>let</b> fa_controller = <b>borrow_global_mut</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>&gt;(@aptos_experimental);
+    <b>let</b> global_config = <b>borrow_global_mut</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>&gt;(@aptos_experimental);
 
-    <b>assert</b>!(fa_controller.allow_list_enabled, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="confidential_asset.md#0x7_confidential_asset_EALLOW_LIST_DISABLED">EALLOW_LIST_DISABLED</a>));
+    <b>assert</b>!(global_config.allow_list_enabled, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="confidential_asset.md#0x7_confidential_asset_EALLOW_LIST_DISABLED">EALLOW_LIST_DISABLED</a>));
 
-    fa_controller.allow_list_enabled = <b>false</b>;
+    global_config.allow_list_enabled = <b>false</b>;
 
     <a href="../../aptos-framework/doc/event.md#0x1_event_emit">event::emit</a>(<a href="confidential_asset.md#0x7_confidential_asset_AllowListChanged">AllowListChanged</a> { enabled: <b>false</b> });
 }
@@ -1681,7 +1916,7 @@ Enables confidential transfers for the specified token.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_enable_token">enable_token</a>(aptos_framework: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, token: Object&lt;Metadata&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_enable_token">enable_token</a>(aptos_framework: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, token: Object&lt;Metadata&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
     <a href="../../aptos-framework/doc/system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
 
     <b>let</b> fa_config = <b>borrow_global_mut</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>&gt;(<a href="confidential_asset.md#0x7_confidential_asset_ensure_fa_config_exists">ensure_fa_config_exists</a>(token));
@@ -1717,7 +1952,7 @@ Disables confidential transfers for the specified token.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_disable_token">disable_token</a>(aptos_framework: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, token: Object&lt;Metadata&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_disable_token">disable_token</a>(aptos_framework: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, token: Object&lt;Metadata&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
     <a href="../../aptos-framework/doc/system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
 
     <b>let</b> fa_config = <b>borrow_global_mut</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>&gt;(<a href="confidential_asset.md#0x7_confidential_asset_ensure_fa_config_exists">ensure_fa_config_exists</a>(token));
@@ -1737,14 +1972,19 @@ Disables confidential transfers for the specified token.
 
 </details>
 
-<a id="0x7_confidential_asset_set_auditor"></a>
+<a id="0x7_confidential_asset_set_asset_auditor"></a>
 
-## Function `set_auditor`
+## Function `set_asset_auditor`
 
-Sets the auditor's public key for the specified token.
+Sets, rotates, or clears the asset-specific auditor key for <code>token</code>. Pass an empty
+<code>new_auditor_ek</code> to clear. Bumps <code>asset_auditor_epoch</code> and appends to history.
+
+Callable by <code><a href="../../aptos-framework/doc/object.md#0x1_object_root_owner">object::root_owner</a>(token)</code>; aborts with [<code><a href="confidential_asset.md#0x7_confidential_asset_ENOT_ASSET_ISSUER">ENOT_ASSET_ISSUER</a></code>] otherwise.
+Rotation invalidates pending transfer proofs (auditor key is bound into the
+Fiat–Shamir transcript) — senders must regenerate against the new key.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_set_auditor">set_auditor</a>(aptos_framework: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, token: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;, new_auditor_ek: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_set_asset_auditor">set_asset_auditor</a>(issuer: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, token: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;, new_auditor_ek: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -1753,26 +1993,163 @@ Sets the auditor's public key for the specified token.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_set_auditor">set_auditor</a>(
-    aptos_framework: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+<pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_set_asset_auditor">set_asset_auditor</a>(
+    issuer: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     token: Object&lt;Metadata&gt;,
-    new_auditor_ek: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>
+    new_auditor_ek: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>
 {
-    <a href="../../aptos-framework/doc/system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
+    <b>assert</b>!(
+        <a href="../../aptos-framework/doc/object.md#0x1_object_root_owner">object::root_owner</a>(token) == <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(issuer),
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="confidential_asset.md#0x7_confidential_asset_ENOT_ASSET_ISSUER">ENOT_ASSET_ISSUER</a>)
+    );
 
     <b>let</b> fa_config = <b>borrow_global_mut</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>&gt;(<a href="confidential_asset.md#0x7_confidential_asset_ensure_fa_config_exists">ensure_fa_config_exists</a>(token));
 
-    fa_config.auditor_ek = <b>if</b> (new_auditor_ek.length() == 0) {
+    <b>let</b> new_ek_opt = <b>if</b> (new_auditor_ek.length() == 0) {
         std::option::none()
     } <b>else</b> {
-        <b>let</b> new_auditor_ek = twisted_elgamal::new_pubkey_from_bytes(new_auditor_ek);
-        <b>assert</b>!(new_auditor_ek.is_some(), <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="confidential_asset.md#0x7_confidential_asset_EAUDITOR_EK_DESERIALIZATION_FAILED">EAUDITOR_EK_DESERIALIZATION_FAILED</a>));
-        new_auditor_ek
+        <b>let</b> parsed = twisted_elgamal::new_pubkey_from_bytes(new_auditor_ek);
+        <b>assert</b>!(parsed.is_some(), <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="confidential_asset.md#0x7_confidential_asset_EAUDITOR_EK_DESERIALIZATION_FAILED">EAUDITOR_EK_DESERIALIZATION_FAILED</a>));
+        parsed
     };
 
-    <a href="../../aptos-framework/doc/event.md#0x1_event_emit">event::emit</a>(<a href="confidential_asset.md#0x7_confidential_asset_AuditorChanged">AuditorChanged</a> {
+    <b>let</b> new_epoch = fa_config.asset_auditor_epoch + 1;
+    <b>let</b> prior_ek = fa_config.asset_auditor_ek;
+
+    <b>if</b> (prior_ek.is_some()) {
+        <b>let</b> history_len = fa_config.asset_auditor_history.length();
+        <b>assert</b>!(history_len &gt; 0, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_internal">error::internal</a>(<a href="confidential_asset.md#0x7_confidential_asset_EINTERNAL_ERROR">EINTERNAL_ERROR</a>));
+        <b>let</b> prior_entry = fa_config.asset_auditor_history.borrow_mut(history_len - 1);
+        prior_entry.deactivated_at_epoch = new_epoch;
+    };
+
+    <b>if</b> (new_ek_opt.is_some()) {
+        fa_config.asset_auditor_history.push_back(<a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">AuditorEntry</a> {
+            ek: *new_ek_opt.borrow(),
+            activated_at_epoch: new_epoch,
+            deactivated_at_epoch: 0,
+        });
+    };
+
+    fa_config.asset_auditor_ek = new_ek_opt;
+    fa_config.asset_auditor_epoch = new_epoch;
+
+    <a href="../../aptos-framework/doc/event.md#0x1_event_emit">event::emit</a>(<a href="confidential_asset.md#0x7_confidential_asset_AssetAuditorChanged">AssetAuditorChanged</a> {
         asset_type: <a href="../../aptos-framework/doc/object.md#0x1_object_object_address">object::object_address</a>(&token),
-        new_auditor_ek: fa_config.auditor_ek,
+        new_asset_auditor_ek: fa_config.asset_auditor_ek,
+        new_epoch,
+    });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_confidential_asset_set_chain_auditor_admin"></a>
+
+## Function `set_chain_auditor_admin`
+
+Designates (or rotates) the account authorized to call [<code>set_chain_auditor</code>].
+Governance-only. No clear form — rotate to a successor instead.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_set_chain_auditor_admin">set_chain_auditor_admin</a>(aptos_framework: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_admin: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_set_chain_auditor_admin">set_chain_auditor_admin</a>(
+    aptos_framework: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    new_admin: <b>address</b>) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>
+{
+    <a href="../../aptos-framework/doc/system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
+
+    <b>let</b> global_config = <b>borrow_global_mut</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>&gt;(@aptos_experimental);
+    global_config.chain_auditor_admin = std::option::some(new_admin);
+
+    <a href="../../aptos-framework/doc/event.md#0x1_event_emit">event::emit</a>(<a href="confidential_asset.md#0x7_confidential_asset_ChainAuditorAdminChanged">ChainAuditorAdminChanged</a> { new_admin });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_confidential_asset_set_chain_auditor"></a>
+
+## Function `set_chain_auditor`
+
+Sets, rotates, or clears the chain-level auditor key. Pass an empty
+<code>new_chain_auditor_ek</code> to clear (which disables all confidential transfers until a
+successor is set). Bumps <code>chain_auditor_epoch</code> and appends to history.
+
+Callable only by [<code><a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>.chain_auditor_admin</code>]. Aborts with
+[<code><a href="confidential_asset.md#0x7_confidential_asset_ECHAIN_AUDITOR_ADMIN_NOT_SET">ECHAIN_AUDITOR_ADMIN_NOT_SET</a></code>] before an admin is assigned, or
+[<code><a href="confidential_asset.md#0x7_confidential_asset_ENOT_CHAIN_AUDITOR_ADMIN">ENOT_CHAIN_AUDITOR_ADMIN</a></code>] for any other signer. Rotation invalidates pending
+transfer proofs — see [<code>set_asset_auditor</code>].
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_set_chain_auditor">set_chain_auditor</a>(admin: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_chain_auditor_ek: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_set_chain_auditor">set_chain_auditor</a>(
+    admin: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    new_chain_auditor_ek: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>
+{
+    <b>let</b> global_config = <b>borrow_global_mut</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>&gt;(@aptos_experimental);
+
+    <b>assert</b>!(
+        global_config.chain_auditor_admin.is_some(),
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="confidential_asset.md#0x7_confidential_asset_ECHAIN_AUDITOR_ADMIN_NOT_SET">ECHAIN_AUDITOR_ADMIN_NOT_SET</a>)
+    );
+    <b>assert</b>!(
+        *global_config.chain_auditor_admin.borrow() == <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(admin),
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="confidential_asset.md#0x7_confidential_asset_ENOT_CHAIN_AUDITOR_ADMIN">ENOT_CHAIN_AUDITOR_ADMIN</a>)
+    );
+
+    <b>let</b> new_ek_opt = <b>if</b> (new_chain_auditor_ek.length() == 0) {
+        std::option::none()
+    } <b>else</b> {
+        <b>let</b> parsed = twisted_elgamal::new_pubkey_from_bytes(new_chain_auditor_ek);
+        <b>assert</b>!(parsed.is_some(), <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="confidential_asset.md#0x7_confidential_asset_EAUDITOR_EK_DESERIALIZATION_FAILED">EAUDITOR_EK_DESERIALIZATION_FAILED</a>));
+        parsed
+    };
+
+    <b>let</b> new_epoch = global_config.chain_auditor_epoch + 1;
+    <b>let</b> prior_ek = global_config.chain_auditor_ek;
+
+    <b>if</b> (prior_ek.is_some()) {
+        <b>let</b> history_len = global_config.chain_auditor_history.length();
+        <b>assert</b>!(history_len &gt; 0, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_internal">error::internal</a>(<a href="confidential_asset.md#0x7_confidential_asset_EINTERNAL_ERROR">EINTERNAL_ERROR</a>));
+        <b>let</b> prior_entry = global_config.chain_auditor_history.borrow_mut(history_len - 1);
+        prior_entry.deactivated_at_epoch = new_epoch;
+    };
+
+    <b>if</b> (new_ek_opt.is_some()) {
+        global_config.chain_auditor_history.push_back(<a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">AuditorEntry</a> {
+            ek: *new_ek_opt.borrow(),
+            activated_at_epoch: new_epoch,
+            deactivated_at_epoch: 0,
+        });
+    };
+
+    global_config.chain_auditor_ek = new_ek_opt;
+    global_config.chain_auditor_epoch = new_epoch;
+
+    <a href="../../aptos-framework/doc/event.md#0x1_event_emit">event::emit</a>(<a href="confidential_asset.md#0x7_confidential_asset_ChainAuditorChanged">ChainAuditorChanged</a> {
+        new_chain_auditor_ek: global_config.chain_auditor_ek,
+        new_epoch,
     });
 }
 </code></pre>
@@ -1824,7 +2201,7 @@ Checks if the token is allowed for confidential transfers.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_is_token_allowed">is_token_allowed</a>(token: Object&lt;Metadata&gt;): bool <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_is_token_allowed">is_token_allowed</a>(token: Object&lt;Metadata&gt;): bool <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a> {
     <b>if</b> (!<a href="confidential_asset.md#0x7_confidential_asset_is_allow_list_enabled">is_allow_list_enabled</a>()) {
         <b>return</b> <b>true</b>
     };
@@ -1862,8 +2239,8 @@ Otherwise, all tokens are allowed.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_is_allow_list_enabled">is_allow_list_enabled</a>(): bool <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a> {
-    <b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>&gt;(@aptos_experimental).allow_list_enabled
+<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_is_allow_list_enabled">is_allow_list_enabled</a>(): bool <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
+    <b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>&gt;(@aptos_experimental).allow_list_enabled
 }
 </code></pre>
 
@@ -2024,16 +2401,15 @@ Checks if the user's confidential asset store is frozen for the specified token.
 
 </details>
 
-<a id="0x7_confidential_asset_get_auditor"></a>
+<a id="0x7_confidential_asset_get_asset_auditor"></a>
 
-## Function `get_auditor`
+## Function `get_asset_auditor`
 
-Returns the asset-specific auditor's encryption key.
-If the auditing feature is disabled for the token, the encryption key is set to <code>None</code>.
+Asset auditor encryption key for <code>token</code>, or <code>None</code> if unset.
 
 
 <pre><code>#[view]
-<b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_auditor">get_auditor</a>(token: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>&gt;
+<b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_asset_auditor">get_asset_auditor</a>(token: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>&gt;
 </code></pre>
 
 
@@ -2042,8 +2418,8 @@ If the auditing feature is disabled for the token, the encryption key is set to 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_auditor">get_auditor</a>(
-    token: Object&lt;Metadata&gt;): Option&lt;twisted_elgamal::CompressedPubkey&gt; <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>
+<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_asset_auditor">get_asset_auditor</a>(
+    token: Object&lt;Metadata&gt;): Option&lt;twisted_elgamal::CompressedPubkey&gt; <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>
 {
     <b>let</b> fa_config_address = <a href="confidential_asset.md#0x7_confidential_asset_get_fa_config_address">get_fa_config_address</a>(token);
 
@@ -2051,7 +2427,173 @@ If the auditing feature is disabled for the token, the encryption key is set to 
         <b>return</b> std::option::none();
     };
 
-    <b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>&gt;(fa_config_address).auditor_ek
+    <b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>&gt;(fa_config_address).asset_auditor_ek
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_confidential_asset_get_asset_auditor_epoch"></a>
+
+## Function `get_asset_auditor_epoch`
+
+Asset auditor epoch for <code>token</code>. <code>0</code> if no asset auditor has been set.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_asset_auditor_epoch">get_asset_auditor_epoch</a>(token: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_asset_auditor_epoch">get_asset_auditor_epoch</a>(token: Object&lt;Metadata&gt;): u64 <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
+    <b>let</b> fa_config_address = <a href="confidential_asset.md#0x7_confidential_asset_get_fa_config_address">get_fa_config_address</a>(token);
+    <b>if</b> (!<b>exists</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>&gt;(fa_config_address)) {
+        <b>return</b> 0;
+    };
+    <b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>&gt;(fa_config_address).asset_auditor_epoch
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_confidential_asset_get_asset_auditor_history"></a>
+
+## Function `get_asset_auditor_history`
+
+Append-only history of asset auditor keys for <code>token</code>.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_asset_auditor_history">get_asset_auditor_history</a>(token: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">confidential_asset::AuditorEntry</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_asset_auditor_history">get_asset_auditor_history</a>(
+    token: Object&lt;Metadata&gt;): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">AuditorEntry</a>&gt; <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>
+{
+    <b>let</b> fa_config_address = <a href="confidential_asset.md#0x7_confidential_asset_get_fa_config_address">get_fa_config_address</a>(token);
+    <b>if</b> (!<b>exists</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>&gt;(fa_config_address)) {
+        <b>return</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+    };
+    <b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>&gt;(fa_config_address).asset_auditor_history
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_confidential_asset_get_chain_auditor"></a>
+
+## Function `get_chain_auditor`
+
+Chain auditor encryption key, or <code>None</code> if unset.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_chain_auditor">get_chain_auditor</a>(): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_chain_auditor">get_chain_auditor</a>(): Option&lt;twisted_elgamal::CompressedPubkey&gt; <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
+    <b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>&gt;(@aptos_experimental).chain_auditor_ek
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_confidential_asset_get_chain_auditor_epoch"></a>
+
+## Function `get_chain_auditor_epoch`
+
+Chain auditor epoch. <code>0</code> before any chain auditor has been configured.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_chain_auditor_epoch">get_chain_auditor_epoch</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_chain_auditor_epoch">get_chain_auditor_epoch</a>(): u64 <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
+    <b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>&gt;(@aptos_experimental).chain_auditor_epoch
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_confidential_asset_get_chain_auditor_history"></a>
+
+## Function `get_chain_auditor_history`
+
+Append-only history of chain auditor keys.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_chain_auditor_history">get_chain_auditor_history</a>(): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">confidential_asset::AuditorEntry</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_chain_auditor_history">get_chain_auditor_history</a>(): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">AuditorEntry</a>&gt; <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
+    <b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>&gt;(@aptos_experimental).chain_auditor_history
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_confidential_asset_get_chain_auditor_admin"></a>
+
+## Function `get_chain_auditor_admin`
+
+Chain-auditor admin address, or <code>None</code> if governance hasn't assigned one yet.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_chain_auditor_admin">get_chain_auditor_admin</a>(): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_chain_auditor_admin">get_chain_auditor_admin</a>(): Option&lt;<b>address</b>&gt; <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
+    <b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>&gt;(@aptos_experimental).chain_auditor_admin
 }
 </code></pre>
 
@@ -2076,7 +2618,7 @@ Returns the circulating supply of the confidential asset.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_confidential_asset_balance">confidential_asset_balance</a>(token: Object&lt;Metadata&gt;): u64 <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_confidential_asset_balance">confidential_asset_balance</a>(token: Object&lt;Metadata&gt;): u64 <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
     <a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset_balance">fungible_asset::balance</a>(<a href="confidential_asset.md#0x7_confidential_asset_get_pool_fa_store">get_pool_fa_store</a>(token))
 }
 </code></pre>
@@ -2104,7 +2646,7 @@ Implementation of the <code>register</code> entry function.
 <pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_register_internal">register_internal</a>(
     sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     token: Object&lt;Metadata&gt;,
-    ek: twisted_elgamal::CompressedPubkey) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>
+    ek: twisted_elgamal::CompressedPubkey) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>
 {
     <b>assert</b>!(<a href="confidential_asset.md#0x7_confidential_asset_is_safe_for_confidentiality">is_safe_for_confidentiality</a>(&token), <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="confidential_asset.md#0x7_confidential_asset_EUNSAFE_DISPATCHABLE_FA">EUNSAFE_DISPATCHABLE_FA</a>));
     <b>assert</b>!(<a href="confidential_asset.md#0x7_confidential_asset_is_token_allowed">is_token_allowed</a>(token), <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="confidential_asset.md#0x7_confidential_asset_ETOKEN_DISABLED">ETOKEN_DISABLED</a>));
@@ -2156,7 +2698,7 @@ Implementation of the <code>deposit_to</code> entry function.
     sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     token: Object&lt;Metadata&gt;,
     <b>to</b>: <b>address</b>,
-    amount: u64) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>
+    amount: u64) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>
 {
     <b>assert</b>!(<a href="confidential_asset.md#0x7_confidential_asset_is_safe_for_confidentiality">is_safe_for_confidentiality</a>(&token), <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="confidential_asset.md#0x7_confidential_asset_EUNSAFE_DISPATCHABLE_FA">EUNSAFE_DISPATCHABLE_FA</a>));
     <b>assert</b>!(<a href="confidential_asset.md#0x7_confidential_asset_is_token_allowed">is_token_allowed</a>(token), <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="confidential_asset.md#0x7_confidential_asset_ETOKEN_DISABLED">ETOKEN_DISABLED</a>));
@@ -2229,7 +2771,7 @@ Withdrawals are always allowed, regardless of the token allow status.
     <b>to</b>: <b>address</b>,
     amount: u64,
     new_balance: <a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
-    proof: WithdrawalProof) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>
+    proof: WithdrawalProof) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>
 {
     <b>assert</b>!(<a href="confidential_asset.md#0x7_confidential_asset_is_safe_for_confidentiality">is_safe_for_confidentiality</a>(&token), <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="confidential_asset.md#0x7_confidential_asset_EUNSAFE_DISPATCHABLE_FA">EUNSAFE_DISPATCHABLE_FA</a>));
 
@@ -2306,7 +2848,7 @@ Implementation of the <code>confidential_transfer</code> entry function.
     auditor_eks: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;twisted_elgamal::CompressedPubkey&gt;,
     auditor_amounts: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>&gt;,
     proof: TransferProof,
-    sender_auditor_hint: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>
+    sender_auditor_hint: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>
 {
     <b>assert</b>!(<a href="confidential_asset.md#0x7_confidential_asset_is_safe_for_confidentiality">is_safe_for_confidentiality</a>(&token), <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="confidential_asset.md#0x7_confidential_asset_EUNSAFE_DISPATCHABLE_FA">EUNSAFE_DISPATCHABLE_FA</a>));
     <b>assert</b>!(<a href="confidential_asset.md#0x7_confidential_asset_is_token_allowed">is_token_allowed</a>(token), <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="confidential_asset.md#0x7_confidential_asset_ETOKEN_DISABLED">ETOKEN_DISABLED</a>));
@@ -2378,6 +2920,9 @@ Implementation of the <code>confidential_transfer</code> entry function.
     <b>let</b> new_recip_pending_balance = <a href="confidential_balance.md#0x7_confidential_balance_compress_balance">confidential_balance::compress_balance</a>(&recipient_pending_balance);
     recipient_ca_store.pending_balance = new_recip_pending_balance;
 
+    <b>let</b> chain_auditor_epoch = <b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>&gt;(@aptos_experimental).chain_auditor_epoch;
+    <b>let</b> asset_auditor_epoch = <a href="confidential_asset.md#0x7_confidential_asset_get_asset_auditor_epoch">get_asset_auditor_epoch</a>(token);
+
     <a href="../../aptos-framework/doc/event.md#0x1_event_emit">event::emit</a>(<a href="confidential_asset.md#0x7_confidential_asset_Transferred">Transferred</a> {
         from,
         <b>to</b>,
@@ -2388,6 +2933,8 @@ Implementation of the <code>confidential_transfer</code> entry function.
         new_sender_available_balance,
         new_recip_pending_balance,
         memo: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[],
+        chain_auditor_epoch,
+        asset_auditor_epoch,
     });
 }
 </code></pre>
@@ -2703,7 +3250,7 @@ Used only for internal purposes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_ensure_fa_config_exists">ensure_fa_config_exists</a>(token: Object&lt;Metadata&gt;): <b>address</b> <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a> {
+<pre><code><b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_ensure_fa_config_exists">ensure_fa_config_exists</a>(token: Object&lt;Metadata&gt;): <b>address</b> <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
     <b>let</b> fa_config_address = <a href="confidential_asset.md#0x7_confidential_asset_get_fa_config_address">get_fa_config_address</a>(token);
 
     <b>if</b> (!<b>exists</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>&gt;(fa_config_address)) {
@@ -2711,7 +3258,9 @@ Used only for internal purposes.
 
         <b>move_to</b>(&fa_config_singer, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a> {
             allowed: <b>false</b>,
-            auditor_ek: std::option::none(),
+            asset_auditor_ek: std::option::none(),
+            asset_auditor_epoch: 0,
+            asset_auditor_history: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[],
         });
     };
 
@@ -2739,8 +3288,8 @@ Returns an object for handling all the FA primary stores, and returns a signer f
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_fa_store_signer">get_fa_store_signer</a>(): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a> {
-    <a href="../../aptos-framework/doc/object.md#0x1_object_generate_signer_for_extending">object::generate_signer_for_extending</a>(&<b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>&gt;(@aptos_experimental).extend_ref)
+<pre><code><b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_fa_store_signer">get_fa_store_signer</a>(): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
+    <a href="../../aptos-framework/doc/object.md#0x1_object_generate_signer_for_extending">object::generate_signer_for_extending</a>(&<b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>&gt;(@aptos_experimental).extend_ref)
 }
 </code></pre>
 
@@ -2764,8 +3313,8 @@ Returns the address that handles all the FA primary stores.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_fa_store_address">get_fa_store_address</a>(): <b>address</b> <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a> {
-    <a href="../../aptos-framework/doc/object.md#0x1_object_address_from_extend_ref">object::address_from_extend_ref</a>(&<b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>&gt;(@aptos_experimental).extend_ref)
+<pre><code><b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_fa_store_address">get_fa_store_address</a>(): <b>address</b> <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
+    <a href="../../aptos-framework/doc/object.md#0x1_object_address_from_extend_ref">object::address_from_extend_ref</a>(&<b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>&gt;(@aptos_experimental).extend_ref)
 }
 </code></pre>
 
@@ -2789,7 +3338,7 @@ Returns the pool's primary fungible store for the given token, aborting if it do
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_pool_fa_store">get_pool_fa_store</a>(token: Object&lt;Metadata&gt;): Object&lt;FungibleStore&gt; <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a> {
+<pre><code><b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_pool_fa_store">get_pool_fa_store</a>(token: Object&lt;Metadata&gt;): Object&lt;FungibleStore&gt; <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
     <b>let</b> pool_addr = <a href="confidential_asset.md#0x7_confidential_asset_get_fa_store_address">get_fa_store_address</a>();
     <b>assert</b>!(<a href="../../aptos-framework/doc/primary_fungible_store.md#0x1_primary_fungible_store_primary_store_exists">primary_fungible_store::primary_store_exists</a>(pool_addr, token), <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="confidential_asset.md#0x7_confidential_asset_ENO_CONFIDENTIAL_ASSET_POOL">ENO_CONFIDENTIAL_ASSET_POOL</a>));
     <a href="../../aptos-framework/doc/primary_fungible_store.md#0x1_primary_fungible_store_primary_store">primary_fungible_store::primary_store</a>(pool_addr, token)
@@ -2816,7 +3365,7 @@ Returns the pool's primary fungible store for the given token, creating it if ne
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_ensure_pool_fa_store">ensure_pool_fa_store</a>(token: Object&lt;Metadata&gt;): Object&lt;FungibleStore&gt; <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a> {
+<pre><code><b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_ensure_pool_fa_store">ensure_pool_fa_store</a>(token: Object&lt;Metadata&gt;): Object&lt;FungibleStore&gt; <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
     <a href="../../aptos-framework/doc/primary_fungible_store.md#0x1_primary_fungible_store_ensure_primary_store_exists">primary_fungible_store::ensure_primary_store_exists</a>(<a href="confidential_asset.md#0x7_confidential_asset_get_fa_store_address">get_fa_store_address</a>(), token)
 }
 </code></pre>
@@ -2893,8 +3442,8 @@ Returns an object for handling the <code><a href="confidential_asset.md#0x7_conf
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_fa_config_signer">get_fa_config_signer</a>(token: Object&lt;Metadata&gt;): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a> {
-    <b>let</b> fa_ext = &<b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>&gt;(@aptos_experimental).extend_ref;
+<pre><code><b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_fa_config_signer">get_fa_config_signer</a>(token: Object&lt;Metadata&gt;): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
+    <b>let</b> fa_ext = &<b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>&gt;(@aptos_experimental).extend_ref;
     <b>let</b> fa_ext_signer = <a href="../../aptos-framework/doc/object.md#0x1_object_generate_signer_for_extending">object::generate_signer_for_extending</a>(fa_ext);
 
     <b>let</b> fa_ctor = &<a href="../../aptos-framework/doc/object.md#0x1_object_create_named_object">object::create_named_object</a>(&fa_ext_signer, <a href="confidential_asset.md#0x7_confidential_asset_construct_fa_seed">construct_fa_seed</a>(token));
@@ -2923,8 +3472,8 @@ Returns the address that handles primary FA store and <code><a href="confidentia
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_fa_config_address">get_fa_config_address</a>(token: Object&lt;Metadata&gt;): <b>address</b> <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a> {
-    <b>let</b> fa_ext = &<b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>&gt;(@aptos_experimental).extend_ref;
+<pre><code><b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_fa_config_address">get_fa_config_address</a>(token: Object&lt;Metadata&gt;): <b>address</b> <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
+    <b>let</b> fa_ext = &<b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>&gt;(@aptos_experimental).extend_ref;
     <b>let</b> fa_ext_address = <a href="../../aptos-framework/doc/object.md#0x1_object_address_from_extend_ref">object::address_from_extend_ref</a>(fa_ext);
 
     <a href="../../aptos-framework/doc/object.md#0x1_object_create_object_address">object::create_object_address</a>(&fa_ext_address, <a href="confidential_asset.md#0x7_confidential_asset_construct_fa_seed">construct_fa_seed</a>(token))
@@ -3003,12 +3552,28 @@ As all the <code><a href="confidential_asset.md#0x7_confidential_asset_FAConfig"
 
 ## Function `validate_auditors`
 
-Validates that the auditor-related fields in the confidential transfer are correct.
-Returns <code><b>false</b></code> if the transfer amount is not the same as the auditor amounts.
-Returns <code><b>false</b></code> if the number of auditors in the transfer proof and auditor lists do not match.
-Returns <code><b>false</b></code> if the first auditor in the list and the asset-specific auditor do not match.
-Note: If the asset-specific auditor is not set, the validation is successful for any list of auditors.
-Otherwise, returns <code><b>true</b></code>.
+Validates the auditor-related fields of a confidential transfer.
+
+Aborts with [<code><a href="confidential_asset.md#0x7_confidential_asset_ECHAIN_AUDITOR_NOT_SET">ECHAIN_AUDITOR_NOT_SET</a></code>] if no chain-level auditor has been
+configured (transfers cannot proceed in that state).
+
+Returns <code><b>false</b></code> (rejecting the transfer) if any of:
+- any <code>auditor_amount</code> does not encrypt the same plaintext as <code>transfer_amount</code>;
+- the lengths of <code>auditor_eks</code>, <code>auditor_amounts</code>, and the transfer-proof auditor
+row count disagree;
+- <code>auditor_eks</code> is missing the required prefix (see slot layout below);
+- the prefix slot keys do not equal the active chain / asset auditor keys.
+
+**Slot layout of <code>auditor_eks</code>** (and <code>auditor_amounts</code>):
+```text
+[0]   chain-level auditor       (always required)
+[1]   asset-specific auditor    (required iff <code><a href="confidential_asset.md#0x7_confidential_asset_get_asset_auditor">get_asset_auditor</a>(token).is_some()</code>)
+[2..] voluntary auditors        (sender's choice, ordered)
+```
+Auditor identity at slots 0 and 1 is bound into the transfer's Fiat–Shamir
+transcript (via the order in which <code>auditor_eks</code> is hashed in
+<code><a href="confidential_proof.md#0x7_confidential_proof_fiat_shamir_transfer_sigma_proof_challenge">confidential_proof::fiat_shamir_transfer_sigma_proof_challenge</a></code>), so a sender
+cannot substitute one auditor's slot for another's.
 
 
 <pre><code><b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_validate_auditors">validate_auditors</a>(token: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;, transfer_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, auditor_eks: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>&gt;, auditor_amounts: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>&gt;, proof: &<a href="confidential_proof.md#0x7_confidential_proof_TransferProof">confidential_proof::TransferProof</a>): bool
@@ -3025,7 +3590,7 @@ Otherwise, returns <code><b>true</b></code>.
     transfer_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
     auditor_eks: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;twisted_elgamal::CompressedPubkey&gt;,
     auditor_amounts: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>&gt;,
-    proof: &TransferProof): bool <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>
+    proof: &TransferProof): bool <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>
 {
     <b>if</b> (
         !auditor_amounts.all(|auditor_amount| {
@@ -3042,19 +3607,31 @@ Otherwise, returns <code><b>true</b></code>.
         <b>return</b> <b>false</b>
     };
 
-    <b>let</b> asset_auditor_ek = <a href="confidential_asset.md#0x7_confidential_asset_get_auditor">get_auditor</a>(token);
-    <b>if</b> (asset_auditor_ek.is_none()) {
-        <b>return</b> <b>true</b>
-    };
+    <b>let</b> chain_auditor_ek_opt = <b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>&gt;(@aptos_experimental).chain_auditor_ek;
+    <b>assert</b>!(chain_auditor_ek_opt.is_some(), <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="confidential_asset.md#0x7_confidential_asset_ECHAIN_AUDITOR_NOT_SET">ECHAIN_AUDITOR_NOT_SET</a>));
 
-    <b>if</b> (auditor_eks.length() == 0) {
+    <b>let</b> asset_auditor_ek_opt = <a href="confidential_asset.md#0x7_confidential_asset_get_asset_auditor">get_asset_auditor</a>(token);
+    <b>let</b> required_prefix = <b>if</b> (asset_auditor_ek_opt.is_some()) 2 <b>else</b> 1;
+
+    <b>if</b> (auditor_eks.length() &lt; required_prefix) {
         <b>return</b> <b>false</b>
     };
 
-    <b>let</b> asset_auditor_ek = twisted_elgamal::pubkey_to_point(&asset_auditor_ek.extract());
-    <b>let</b> first_auditor_ek = twisted_elgamal::pubkey_to_point(&auditor_eks[0]);
+    <b>let</b> chain_auditor_point = twisted_elgamal::pubkey_to_point(&chain_auditor_ek_opt.extract());
+    <b>let</b> slot0_point = twisted_elgamal::pubkey_to_point(&auditor_eks[0]);
+    <b>if</b> (!<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_equals">ristretto255::point_equals</a>(&chain_auditor_point, &slot0_point)) {
+        <b>return</b> <b>false</b>
+    };
 
-    <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_equals">ristretto255::point_equals</a>(&asset_auditor_ek, &first_auditor_ek)
+    <b>if</b> (asset_auditor_ek_opt.is_some()) {
+        <b>let</b> asset_auditor_point = twisted_elgamal::pubkey_to_point(&asset_auditor_ek_opt.extract());
+        <b>let</b> slot1_point = twisted_elgamal::pubkey_to_point(&auditor_eks[1]);
+        <b>if</b> (!<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_equals">ristretto255::point_equals</a>(&asset_auditor_point, &slot1_point)) {
+            <b>return</b> <b>false</b>
+        };
+    };
+
+    <b>true</b>
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-experimental/doc/confidential_asset.md
+++ b/aptos-move/framework/aptos-experimental/doc/confidential_asset.md
@@ -8,7 +8,6 @@ It enables private transfers by obfuscating token amounts while keeping sender a
 
 
 -  [Resource `ConfidentialAssetStore`](#0x7_confidential_asset_ConfidentialAssetStore)
--  [Struct `AuditorEntry`](#0x7_confidential_asset_AuditorEntry)
 -  [Resource `GlobalConfig`](#0x7_confidential_asset_GlobalConfig)
 -  [Resource `FAConfig`](#0x7_confidential_asset_FAConfig)
 -  [Struct `Registered`](#0x7_confidential_asset_Registered)
@@ -59,10 +58,8 @@ It enables private transfers by obfuscating token amounts while keeping sender a
 -  [Function `is_frozen`](#0x7_confidential_asset_is_frozen)
 -  [Function `get_asset_auditor`](#0x7_confidential_asset_get_asset_auditor)
 -  [Function `get_asset_auditor_epoch`](#0x7_confidential_asset_get_asset_auditor_epoch)
--  [Function `get_asset_auditor_history`](#0x7_confidential_asset_get_asset_auditor_history)
 -  [Function `get_chain_auditor`](#0x7_confidential_asset_get_chain_auditor)
 -  [Function `get_chain_auditor_epoch`](#0x7_confidential_asset_get_chain_auditor_epoch)
--  [Function `get_chain_auditor_history`](#0x7_confidential_asset_get_chain_auditor_history)
 -  [Function `get_chain_auditor_admin`](#0x7_confidential_asset_get_chain_auditor_admin)
 -  [Function `confidential_asset_balance`](#0x7_confidential_asset_confidential_asset_balance)
 -  [Function `register_internal`](#0x7_confidential_asset_register_internal)
@@ -192,50 +189,6 @@ The <code><a href="confidential_asset.md#0x7_confidential_asset">confidential_as
 
 </details>
 
-<a id="0x7_confidential_asset_AuditorEntry"></a>
-
-## Struct `AuditorEntry`
-
-One entry in an auditor key history vector — used for both the chain-level auditor
-(on [<code><a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a></code>]) and the per-asset auditor (on [<code><a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a></code>]). Rotated keys are
-retained so transfers stamped with a prior epoch can still be decrypted.
-
-
-<pre><code><b>struct</b> <a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">AuditorEntry</a> <b>has</b> <b>copy</b>, drop, store
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>ek: <a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a></code>
-</dt>
-<dd>
-
-</dd>
-<dt>
-<code>activated_at_epoch: u64</code>
-</dt>
-<dd>
- First epoch in which <code>ek</code> was the active auditor key. Monotonically increasing
- per layer (chain or asset).
-</dd>
-<dt>
-<code>deactivated_at_epoch: u64</code>
-</dt>
-<dd>
- Epoch at which this entry was deactivated (i.e. the <code>activated_at_epoch</code> of its
- successor). <code>0</code> means the entry is still the active key.
-</dd>
-</dl>
-
-
-</details>
-
 <a id="0x7_confidential_asset_GlobalConfig"></a>
 
 ## Resource `GlobalConfig`
@@ -287,15 +240,8 @@ Global configuration for confidential assets: primary FA stores, <code><a href="
 </dt>
 <dd>
  Bumped on every [<code>set_chain_auditor</code>] call (including clears). Stamped on each
- [<code><a href="confidential_asset.md#0x7_confidential_asset_Transferred">Transferred</a></code>] event.
-</dd>
-<dt>
-<code>chain_auditor_history: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">confidential_asset::AuditorEntry</a>&gt;</code>
-</dt>
-<dd>
- Append-only history of chain auditor keys. Each entry's
- <code>[activated_at_epoch, deactivated_at_epoch)</code> half-open interval is the range
- of <code>chain_auditor_epoch</code> values during which it was active.
+ [<code><a href="confidential_asset.md#0x7_confidential_asset_Transferred">Transferred</a></code>] event so off-chain auditors / gateways can identify which
+ historical chain-auditor key was in force at that transfer.
 </dd>
 </dl>
 
@@ -339,14 +285,9 @@ Represents the configuration of a token.
 <code>asset_auditor_epoch: u64</code>
 </dt>
 <dd>
- Bumped on every [<code>set_asset_auditor</code>] call. Stamped on each [<code><a href="confidential_asset.md#0x7_confidential_asset_Transferred">Transferred</a></code>]
- event for this asset.
-</dd>
-<dt>
-<code>asset_auditor_history: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">confidential_asset::AuditorEntry</a>&gt;</code>
-</dt>
-<dd>
- Append-only history of asset auditor keys. See [<code><a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">AuditorEntry</a></code>].
+ Bumped on every [<code>set_asset_auditor</code>] call (including clears). Stamped on each
+ [<code><a href="confidential_asset.md#0x7_confidential_asset_Transferred">Transferred</a></code>] event for this asset so off-chain auditors / gateways can
+ identify which historical asset-auditor key was in force at that transfer.
 </dd>
 </dl>
 
@@ -595,7 +536,11 @@ from the verified proof. See the technical whitepaper (<code>whitepaper.md</code
 </dt>
 <dd>
  Value of [<code><a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>.asset_auditor_epoch</code>] for this asset at the time of the
- transfer. <code>0</code> when this asset has no asset-level auditor configured.
+ transfer. <code>0</code> only when [<code>set_asset_auditor</code>] has never been called for this
+ asset; once called (including a clear with empty bytes) the epoch is bumped
+ and stamped here even if the current <code>asset_auditor_ek</code> is <code>None</code>. Off-chain
+ auditors / gateways resolve <code>(asset_type, asset_auditor_epoch)</code> to the active
+ key by indexing [<code><a href="confidential_asset.md#0x7_confidential_asset_AssetAuditorChanged">AssetAuditorChanged</a></code>] events.
 </dd>
 </dl>
 
@@ -1247,7 +1192,6 @@ The maximum number of transactions can be aggregated on the pending balance befo
         extend_ref: <a href="../../aptos-framework/doc/object.md#0x1_object_generate_extend_ref">object::generate_extend_ref</a>(global_config_ctor_ref),
         chain_auditor_ek: std::option::none(),
         chain_auditor_epoch: 0,
-        chain_auditor_history: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[],
         chain_auditor_admin: std::option::none(),
     });
 }
@@ -1977,7 +1921,7 @@ Disables confidential transfers for the specified token.
 ## Function `set_asset_auditor`
 
 Sets, rotates, or clears the asset-specific auditor key for <code>token</code>. Pass an empty
-<code>new_auditor_ek</code> to clear. Bumps <code>asset_auditor_epoch</code> and appends to history.
+<code>new_auditor_ek</code> to clear. Bumps <code>asset_auditor_epoch</code> and emits [<code><a href="confidential_asset.md#0x7_confidential_asset_AssetAuditorChanged">AssetAuditorChanged</a></code>].
 
 Callable by <code><a href="../../aptos-framework/doc/object.md#0x1_object_root_owner">object::root_owner</a>(token)</code>; aborts with [<code><a href="confidential_asset.md#0x7_confidential_asset_ENOT_ASSET_ISSUER">ENOT_ASSET_ISSUER</a></code>] otherwise.
 Rotation invalidates pending transfer proofs (auditor key is bound into the
@@ -2014,22 +1958,6 @@ Fiat–Shamir transcript) — senders must regenerate against the new key.
     };
 
     <b>let</b> new_epoch = fa_config.asset_auditor_epoch + 1;
-    <b>let</b> prior_ek = fa_config.asset_auditor_ek;
-
-    <b>if</b> (prior_ek.is_some()) {
-        <b>let</b> history_len = fa_config.asset_auditor_history.length();
-        <b>assert</b>!(history_len &gt; 0, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_internal">error::internal</a>(<a href="confidential_asset.md#0x7_confidential_asset_EINTERNAL_ERROR">EINTERNAL_ERROR</a>));
-        <b>let</b> prior_entry = fa_config.asset_auditor_history.borrow_mut(history_len - 1);
-        prior_entry.deactivated_at_epoch = new_epoch;
-    };
-
-    <b>if</b> (new_ek_opt.is_some()) {
-        fa_config.asset_auditor_history.push_back(<a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">AuditorEntry</a> {
-            ek: *new_ek_opt.borrow(),
-            activated_at_epoch: new_epoch,
-            deactivated_at_epoch: 0,
-        });
-    };
 
     fa_config.asset_auditor_ek = new_ek_opt;
     fa_config.asset_auditor_epoch = new_epoch;
@@ -2086,7 +2014,7 @@ Governance-only. No clear form — rotate to a successor instead.
 
 Sets, rotates, or clears the chain-level auditor key. Pass an empty
 <code>new_chain_auditor_ek</code> to clear (which disables all confidential transfers until a
-successor is set). Bumps <code>chain_auditor_epoch</code> and appends to history.
+successor is set). Bumps <code>chain_auditor_epoch</code> and emits [<code><a href="confidential_asset.md#0x7_confidential_asset_ChainAuditorChanged">ChainAuditorChanged</a></code>].
 
 Callable only by [<code><a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>.chain_auditor_admin</code>]. Aborts with
 [<code><a href="confidential_asset.md#0x7_confidential_asset_ECHAIN_AUDITOR_ADMIN_NOT_SET">ECHAIN_AUDITOR_ADMIN_NOT_SET</a></code>] before an admin is assigned, or
@@ -2127,22 +2055,6 @@ transfer proofs — see [<code>set_asset_auditor</code>].
     };
 
     <b>let</b> new_epoch = global_config.chain_auditor_epoch + 1;
-    <b>let</b> prior_ek = global_config.chain_auditor_ek;
-
-    <b>if</b> (prior_ek.is_some()) {
-        <b>let</b> history_len = global_config.chain_auditor_history.length();
-        <b>assert</b>!(history_len &gt; 0, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_internal">error::internal</a>(<a href="confidential_asset.md#0x7_confidential_asset_EINTERNAL_ERROR">EINTERNAL_ERROR</a>));
-        <b>let</b> prior_entry = global_config.chain_auditor_history.borrow_mut(history_len - 1);
-        prior_entry.deactivated_at_epoch = new_epoch;
-    };
-
-    <b>if</b> (new_ek_opt.is_some()) {
-        global_config.chain_auditor_history.push_back(<a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">AuditorEntry</a> {
-            ek: *new_ek_opt.borrow(),
-            activated_at_epoch: new_epoch,
-            deactivated_at_epoch: 0,
-        });
-    };
 
     global_config.chain_auditor_ek = new_ek_opt;
     global_config.chain_auditor_epoch = new_epoch;
@@ -2465,38 +2377,6 @@ Asset auditor epoch for <code>token</code>. <code>0</code> if no asset auditor h
 
 </details>
 
-<a id="0x7_confidential_asset_get_asset_auditor_history"></a>
-
-## Function `get_asset_auditor_history`
-
-Append-only history of asset auditor keys for <code>token</code>.
-
-
-<pre><code>#[view]
-<b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_asset_auditor_history">get_asset_auditor_history</a>(token: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">confidential_asset::AuditorEntry</a>&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_asset_auditor_history">get_asset_auditor_history</a>(
-    token: Object&lt;Metadata&gt;): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">AuditorEntry</a>&gt; <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>
-{
-    <b>let</b> fa_config_address = <a href="confidential_asset.md#0x7_confidential_asset_get_fa_config_address">get_fa_config_address</a>(token);
-    <b>if</b> (!<b>exists</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>&gt;(fa_config_address)) {
-        <b>return</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-    };
-    <b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>&gt;(fa_config_address).asset_auditor_history
-}
-</code></pre>
-
-
-
-</details>
-
 <a id="0x7_confidential_asset_get_chain_auditor"></a>
 
 ## Function `get_chain_auditor`
@@ -2542,32 +2422,6 @@ Chain auditor epoch. <code>0</code> before any chain auditor has been configured
 
 <pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_chain_auditor_epoch">get_chain_auditor_epoch</a>(): u64 <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
     <b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>&gt;(@aptos_experimental).chain_auditor_epoch
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x7_confidential_asset_get_chain_auditor_history"></a>
-
-## Function `get_chain_auditor_history`
-
-Append-only history of chain auditor keys.
-
-
-<pre><code>#[view]
-<b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_chain_auditor_history">get_chain_auditor_history</a>(): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">confidential_asset::AuditorEntry</a>&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_get_chain_auditor_history">get_chain_auditor_history</a>(): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_asset.md#0x7_confidential_asset_AuditorEntry">AuditorEntry</a>&gt; <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a> {
-    <b>borrow_global</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>&gt;(@aptos_experimental).chain_auditor_history
 }
 </code></pre>
 
@@ -3260,7 +3114,6 @@ Used only for internal purposes.
             allowed: <b>false</b>,
             asset_auditor_ek: std::option::none(),
             asset_auditor_epoch: 0,
-            asset_auditor_history: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[],
         });
     };
 

--- a/aptos-move/framework/aptos-experimental/doc/confidential_asset.md
+++ b/aptos-move/framework/aptos-experimental/doc/confidential_asset.md
@@ -26,6 +26,9 @@ It enables private transfers by obfuscating token amounts while keeping sender a
 -  [Constants](#@Constants_0)
 -  [Function `init_module`](#0x7_confidential_asset_init_module)
 -  [Function `register`](#0x7_confidential_asset_register)
+-  [Function `register_and_deposit_and_rollover_pending_balance`](#0x7_confidential_asset_register_and_deposit_and_rollover_pending_balance)
+-  [Function `deposit_and_rollover_pending_balance`](#0x7_confidential_asset_deposit_and_rollover_pending_balance)
+-  [Function `deposit_and_normalize_and_rollover_pending_balance`](#0x7_confidential_asset_deposit_and_normalize_and_rollover_pending_balance)
 -  [Function `deposit_to`](#0x7_confidential_asset_deposit_to)
 -  [Function `deposit`](#0x7_confidential_asset_deposit)
 -  [Function `deposit_coins_to`](#0x7_confidential_asset_deposit_coins_to)
@@ -39,6 +42,7 @@ It enables private transfers by obfuscating token amounts while keeping sender a
 -  [Function `freeze_token`](#0x7_confidential_asset_freeze_token)
 -  [Function `unfreeze_token`](#0x7_confidential_asset_unfreeze_token)
 -  [Function `rollover_pending_balance`](#0x7_confidential_asset_rollover_pending_balance)
+-  [Function `normalize_and_rollover_pending_balance`](#0x7_confidential_asset_normalize_and_rollover_pending_balance)
 -  [Function `rollover_pending_balance_and_freeze`](#0x7_confidential_asset_rollover_pending_balance_and_freeze)
 -  [Function `rotate_encryption_key_and_unfreeze`](#0x7_confidential_asset_rotate_encryption_key_and_unfreeze)
 -  [Function `enable_allow_list`](#0x7_confidential_asset_enable_allow_list)
@@ -1250,6 +1254,117 @@ Users are also responsible for generating a Twisted ElGamal key pair on their si
 
 </details>
 
+<a id="0x7_confidential_asset_register_and_deposit_and_rollover_pending_balance"></a>
+
+## Function `register_and_deposit_and_rollover_pending_balance`
+
+Atomically [<code>register</code>], [<code>deposit</code>], and [<code>rollover_pending_balance</code>] for first-time users — public
+FA lands as spendable confidential (actual) balance in one tx. Aborts with
+[<code><a href="confidential_asset.md#0x7_confidential_asset_ECA_STORE_ALREADY_PUBLISHED">ECA_STORE_ALREADY_PUBLISHED</a></code>] if the sender is already registered.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_register_and_deposit_and_rollover_pending_balance">register_and_deposit_and_rollover_pending_balance</a>(sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, token: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;, amount: u64, ek: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, registration_proof_commitment: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, registration_proof_response: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_register_and_deposit_and_rollover_pending_balance">register_and_deposit_and_rollover_pending_balance</a>(
+    sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    token: Object&lt;Metadata&gt;,
+    amount: u64,
+    ek: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    registration_proof_commitment: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    registration_proof_response: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>
+{
+    // The fresh store created by `register` is `normalized = <b>true</b>` <b>with</b> empty actual_balance,
+    // so `deposit_and_rollover_pending_balance`'s normalized-state assertion passes — no need
+    // for a separate normalize step here.
+    <a href="confidential_asset.md#0x7_confidential_asset_register">register</a>(sender, token, ek, registration_proof_commitment, registration_proof_response);
+    <a href="confidential_asset.md#0x7_confidential_asset_deposit_and_rollover_pending_balance">deposit_and_rollover_pending_balance</a>(sender, token, amount);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_confidential_asset_deposit_and_rollover_pending_balance"></a>
+
+## Function `deposit_and_rollover_pending_balance`
+
+Atomically [<code>deposit</code>] and [<code>rollover_pending_balance</code>] when the sender's actual balance is already
+normalized — no proofs needed. Aborts with [<code><a href="confidential_asset.md#0x7_confidential_asset_ENORMALIZATION_REQUIRED">ENORMALIZATION_REQUIRED</a></code>] otherwise; use
+[<code>deposit_and_normalize_and_rollover_pending_balance</code>] in that case.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_deposit_and_rollover_pending_balance">deposit_and_rollover_pending_balance</a>(sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, token: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;, amount: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_deposit_and_rollover_pending_balance">deposit_and_rollover_pending_balance</a>(
+    sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    token: Object&lt;Metadata&gt;,
+    amount: u64) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>
+{
+    <b>let</b> user = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(sender);
+    <a href="confidential_asset.md#0x7_confidential_asset_deposit_to_internal">deposit_to_internal</a>(sender, token, user, amount);
+    <a href="confidential_asset.md#0x7_confidential_asset_rollover_pending_balance_internal">rollover_pending_balance_internal</a>(sender, token);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_confidential_asset_deposit_and_normalize_and_rollover_pending_balance"></a>
+
+## Function `deposit_and_normalize_and_rollover_pending_balance`
+
+Atomically [<code>deposit</code>], [<code>normalize</code>] the actual balance, and [<code>rollover_pending_balance</code>] when the
+sender's actual balance is NOT normalized. Same proof arguments as [<code>normalize</code>]. Aborts with
+[<code><a href="confidential_asset.md#0x7_confidential_asset_EALREADY_NORMALIZED">EALREADY_NORMALIZED</a></code>] if already normalized; use [<code>deposit_and_rollover_pending_balance</code>] then.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_deposit_and_normalize_and_rollover_pending_balance">deposit_and_normalize_and_rollover_pending_balance</a>(sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, token: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;, amount: u64, new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, zkrp_new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, sigma_proof: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_deposit_and_normalize_and_rollover_pending_balance">deposit_and_normalize_and_rollover_pending_balance</a>(
+    sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    token: Object&lt;Metadata&gt;,
+    amount: u64,
+    new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    zkrp_new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    sigma_proof: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_GlobalConfig">GlobalConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>
+{
+    <b>let</b> new_balance = <a href="confidential_balance.md#0x7_confidential_balance_new_actual_balance_from_bytes">confidential_balance::new_actual_balance_from_bytes</a>(new_balance).extract();
+    <b>let</b> proof = <a href="confidential_proof.md#0x7_confidential_proof_deserialize_normalization_proof">confidential_proof::deserialize_normalization_proof</a>(sigma_proof, zkrp_new_balance).extract();
+
+    <b>let</b> user = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(sender);
+    <a href="confidential_asset.md#0x7_confidential_asset_deposit_to_internal">deposit_to_internal</a>(sender, token, user, amount);
+    <a href="confidential_asset.md#0x7_confidential_asset_normalize_internal">normalize_internal</a>(sender, token, new_balance, proof);
+    <a href="confidential_asset.md#0x7_confidential_asset_rollover_pending_balance_internal">rollover_pending_balance_internal</a>(sender, token);
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x7_confidential_asset_deposit_to"></a>
 
 ## Function `deposit_to`
@@ -1706,6 +1821,42 @@ This operation is necessary to use tokens from the pending balance for outgoing 
     sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     token: Object&lt;Metadata&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>
 {
+    <a href="confidential_asset.md#0x7_confidential_asset_rollover_pending_balance_internal">rollover_pending_balance_internal</a>(sender, token);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_confidential_asset_normalize_and_rollover_pending_balance"></a>
+
+## Function `normalize_and_rollover_pending_balance`
+
+Atomically [<code>normalize</code>] the actual balance and [<code>rollover_pending_balance</code>] in one transaction. Takes the
+same proof arguments as [<code>normalize</code>].
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_normalize_and_rollover_pending_balance">normalize_and_rollover_pending_balance</a>(sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, token: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;, new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, zkrp_new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, sigma_proof: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_normalize_and_rollover_pending_balance">normalize_and_rollover_pending_balance</a>(
+    sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    token: Object&lt;Metadata&gt;,
+    new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    zkrp_new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    sigma_proof: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>
+{
+    <b>let</b> new_balance = <a href="confidential_balance.md#0x7_confidential_balance_new_actual_balance_from_bytes">confidential_balance::new_actual_balance_from_bytes</a>(new_balance).extract();
+    <b>let</b> proof = <a href="confidential_proof.md#0x7_confidential_proof_deserialize_normalization_proof">confidential_proof::deserialize_normalization_proof</a>(sigma_proof, zkrp_new_balance).extract();
+
+    <a href="confidential_asset.md#0x7_confidential_asset_normalize_internal">normalize_internal</a>(sender, token, new_balance, proof);
     <a href="confidential_asset.md#0x7_confidential_asset_rollover_pending_balance_internal">rollover_pending_balance_internal</a>(sender, token);
 }
 </code></pre>

--- a/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
+++ b/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
@@ -97,6 +97,11 @@ module aptos_experimental::confidential_asset {
     /// covering every confidential asset on the chain.
     const ECHAIN_AUDITOR_NOT_SET: u64 = 21;
 
+    /// The signer is not authorized to update the asset auditor for this token. The asset
+    /// auditor can only be updated by the root owner of the FA metadata object (see
+    /// [`set_asset_auditor`]).
+    const ENOT_ASSET_ISSUER: u64 = 22;
+
     //
     // Constants
     //
@@ -210,10 +215,13 @@ module aptos_experimental::confidential_asset {
         /// key at `auditor_eks[1]` (immediately after the chain-level auditor at
         /// `auditor_eks[0]`).
         ///
-        /// Asset auditors are appointed by governance on a case-by-case basis for assets
-        /// with specific regulatory obligations (e.g. a stablecoin with a banking
-        /// regulator, or a tokenized security). They are *additive* to the chain-level
-        /// auditor, not a substitute.
+        /// Asset auditors are appointed by the asset issuer on a case-by-case basis for
+        /// assets with specific regulatory obligations (e.g. a stablecoin with a banking
+        /// regulator, or a tokenized security). The "issuer" is the root owner of the FA
+        /// metadata object — for framework-managed FAs (root = `@0x1`) this is governance
+        /// via the `aptos_framework` signer; for issuer-deployed FAs it is the account
+        /// (or multisig) at the top of the metadata object's ownership chain. Asset
+        /// auditors are *additive* to the chain-level auditor, not a substitute.
         asset_auditor_ek: Option<twisted_elgamal::CompressedPubkey>,
 
         /// Monotonic counter, incremented on every successful [`set_asset_auditor`] call.
@@ -728,12 +736,23 @@ module aptos_experimental::confidential_asset {
     /// Fiat–Shamir transcript via the order of `auditor_eks`; rotating the asset auditor
     /// therefore invalidates any user transactions that were already signed under the old
     /// key but not yet executed. Senders must regenerate proofs against the new key.
-    public fun set_asset_auditor(
-        aptos_framework: &signer,
+    ///
+    /// **Authorization.** Callable by the root owner of `token`'s metadata object — i.e.
+    /// the account at the top of the object ownership chain (walked via
+    /// [`object::root_owner`]). For framework-managed FAs whose root owner is `@0x1`,
+    /// this is governance acting through the `aptos_framework` signer. For
+    /// issuer-deployed FAs (including the common pattern where a contract object owns
+    /// the metadata and is in turn owned by a multisig), the multisig at the chain root
+    /// can call this directly. Aborts with [`ENOT_ASSET_ISSUER`] otherwise.
+    public entry fun set_asset_auditor(
+        issuer: &signer,
         token: Object<Metadata>,
         new_auditor_ek: vector<u8>) acquires FAConfig, FAController
     {
-        system_addresses::assert_aptos_framework(aptos_framework);
+        assert!(
+            object::root_owner(token) == signer::address_of(issuer),
+            error::permission_denied(ENOT_ASSET_ISSUER)
+        );
 
         let fa_config = borrow_global_mut<FAConfig>(ensure_fa_config_exists(token));
 

--- a/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
+++ b/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
@@ -92,6 +92,11 @@ module aptos_experimental::confidential_asset {
     /// No confidential asset pool exists for the given asset type.
     const ENO_CONFIDENTIAL_ASSET_POOL: u64 = 20;
 
+    /// The chain-level auditor must be configured (via [`set_chain_auditor`]) before any
+    /// confidential transfer can be executed. Required as a baseline compliance guarantee
+    /// covering every confidential asset on the chain.
+    const ECHAIN_AUDITOR_NOT_SET: u64 = 21;
+
     //
     // Constants
     //
@@ -146,6 +151,21 @@ module aptos_experimental::confidential_asset {
         ek: twisted_elgamal::CompressedPubkey,
     }
 
+    /// One entry in an auditor key history vector — used for both the chain-level auditor
+    /// (on [`FAController`]) and the per-asset auditor (on [`FAConfig`]). The history exists
+    /// for compliance reasons: U.S./EU regulations require us to be able to decrypt past
+    /// transfers for up to 7 years on demand, so when a key is rotated we record the prior
+    /// key alongside the epoch range during which it was active.
+    struct AuditorEntry has store, drop, copy {
+        ek: twisted_elgamal::CompressedPubkey,
+        /// First epoch in which `ek` was the active auditor key. Monotonically increasing
+        /// per layer (chain or asset).
+        activated_at_epoch: u64,
+        /// Epoch at which this entry was deactivated (i.e. the `activated_at_epoch` of its
+        /// successor). `0` means the entry is still the active key.
+        deactivated_at_epoch: u64,
+    }
+
     /// Represents the controller for the primary FA stores and `FAConfig` objects.
     struct FAController has key {
         /// Indicates whether the allow list is enabled. If `true`, only tokens from the allow list can be transferred.
@@ -153,7 +173,29 @@ module aptos_experimental::confidential_asset {
         allow_list_enabled: bool,
 
         /// Used to derive a signer that owns all the FAs' primary stores and `FAConfig` objects.
-        extend_ref: ExtendRef
+        extend_ref: ExtendRef,
+
+        /// The chain-level compliance auditor's encryption key. Set via [`set_chain_auditor`]
+        /// by governance. Every confidential transfer must include this key as the first
+        /// element (`auditor_eks[0]`) of its auditor list, ensuring no transfer on the chain
+        /// is fully unauditable. `None` only before the chain-level auditor has been
+        /// configured for the first time — `confidential_transfer` aborts with
+        /// [`ECHAIN_AUDITOR_NOT_SET`] in that state.
+        chain_auditor_ek: Option<twisted_elgamal::CompressedPubkey>,
+
+        /// Monotonic counter, incremented on every successful [`set_chain_auditor`] call
+        /// (including clears, in which case the entry is appended to history with no
+        /// successor key). Stamped on each [`Transferred`] event so future audits can
+        /// determine which historical chain auditor key was in force at the time of
+        /// transfer and decrypt the transcript accordingly.
+        chain_auditor_epoch: u64,
+
+        /// Append-only history of past chain auditor keys. Each entry's
+        /// `[activated_at_epoch, deactivated_at_epoch)` half-open interval describes the
+        /// range of `chain_auditor_epoch` values during which it was the active key.
+        /// Note: pre-launch this is unbounded; if rotations become frequent in production,
+        /// consider trimming or paginating.
+        chain_auditor_history: vector<AuditorEntry>,
     }
 
     /// Represents the configuration of a token.
@@ -163,10 +205,26 @@ module aptos_experimental::confidential_asset {
         /// Can be toggled by the governance module. The withdrawals are always allowed.
         allowed: bool,
 
-        /// The auditor's public key for the token. If the auditor is not set, this field is `None`.
-        /// Otherwise, each confidential transfer must include the auditor as an additional party,
-        /// alongside the recipient, who has access to the decrypted transferred amount.
-        auditor_ek: Option<twisted_elgamal::CompressedPubkey>,
+        /// The asset-specific auditor's public key for the token. If unset, this field is
+        /// `None`. When set, every confidential transfer of this asset must include this
+        /// key at `auditor_eks[1]` (immediately after the chain-level auditor at
+        /// `auditor_eks[0]`).
+        ///
+        /// Asset auditors are appointed by governance on a case-by-case basis for assets
+        /// with specific regulatory obligations (e.g. a stablecoin with a banking
+        /// regulator, or a tokenized security). They are *additive* to the chain-level
+        /// auditor, not a substitute.
+        asset_auditor_ek: Option<twisted_elgamal::CompressedPubkey>,
+
+        /// Monotonic counter, incremented on every successful [`set_asset_auditor`] call.
+        /// Stamped on each [`Transferred`] event of this asset so future audits can map a
+        /// past transfer to the asset auditor key in force at that time. `0` while no
+        /// asset auditor has ever been set.
+        asset_auditor_epoch: u64,
+
+        /// Append-only history of past asset auditor keys. See [`AuditorEntry`] for entry
+        /// semantics and [`FAController.chain_auditor_history`] for the sizing caveat.
+        asset_auditor_history: vector<AuditorEntry>,
     }
 
     //
@@ -236,6 +294,14 @@ module aptos_experimental::confidential_asset {
         new_recip_pending_balance: confidential_balance::CompressedConfidentialBalance,
         /// Reserved memo payload for future or off-chain conventions; currently emitted as an empty `vector`.
         memo: vector<u8>,
+        /// Value of [`FAController.chain_auditor_epoch`] at the time of the transfer.
+        /// Required for compliance: lets future audits identify which historical
+        /// chain-level auditor key was in force, so that the transcript can still be
+        /// decrypted years after a key rotation.
+        chain_auditor_epoch: u64,
+        /// Value of [`FAConfig.asset_auditor_epoch`] for this asset at the time of the
+        /// transfer. `0` when this asset has no asset-level auditor configured.
+        asset_auditor_epoch: u64,
     }
 
     #[event]
@@ -285,10 +351,23 @@ module aptos_experimental::confidential_asset {
     }
 
     #[event]
-    /// Emitted when the asset-specific auditor is set or removed.
-    struct AuditorChanged has drop, store {
+    /// Emitted when the asset-specific auditor is set, rotated, or cleared.
+    /// `new_epoch` is the post-change value of [`FAConfig.asset_auditor_epoch`] and matches
+    /// the value stamped on subsequent [`Transferred`] events for this asset.
+    struct AssetAuditorChanged has drop, store {
         asset_type: address,
-        new_auditor_ek: Option<twisted_elgamal::CompressedPubkey>,
+        new_asset_auditor_ek: Option<twisted_elgamal::CompressedPubkey>,
+        new_epoch: u64,
+    }
+
+    #[event]
+    /// Emitted when the chain-level compliance auditor is set, rotated, or cleared by
+    /// governance. `new_epoch` is the post-change value of
+    /// [`FAController.chain_auditor_epoch`] and matches the value stamped on subsequent
+    /// [`Transferred`] events.
+    struct ChainAuditorChanged has drop, store {
+        new_chain_auditor_ek: Option<twisted_elgamal::CompressedPubkey>,
+        new_epoch: u64,
     }
 
     //
@@ -308,6 +387,9 @@ module aptos_experimental::confidential_asset {
         move_to(deployer, FAController {
             allow_list_enabled: chain_id::get() == MAINNET_CHAIN_ID,
             extend_ref: object::generate_extend_ref(fa_controller_ctor_ref),
+            chain_auditor_ek: std::option::none(),
+            chain_auditor_epoch: 0,
+            chain_auditor_history: vector[],
         });
     }
 
@@ -431,11 +513,17 @@ module aptos_experimental::confidential_asset {
     /// The function hides the transferred amount while keeping the sender and recipient addresses visible.
     /// The sender encrypts the transferred amount with the recipient's encryption key and the function updates the
     /// recipient's confidential balance homomorphically.
-    /// Additionally, the sender encrypts the transferred amount with the auditors' EKs, allowing auditors to decrypt
-    /// it on their side.
+    /// Additionally, the sender encrypts the transferred amount with each auditor's EK, allowing auditors to decrypt
+    /// it on their side. The combined auditor list (`auditor_eks` / `auditor_amounts`) has a fixed prefix layout:
+    ///
+    /// ```text
+    ///   [0]   chain-level compliance auditor (always required; configured via `set_chain_auditor`)
+    ///   [1]   asset-specific auditor         (required iff `get_asset_auditor(token).is_some()`)
+    ///   [2..] voluntary auditors             (sender's choice; ordered)
+    /// ```
+    ///
+    /// Aborts with [`ECHAIN_AUDITOR_NOT_SET`] when the chain-level auditor has not yet been configured.
     /// The sender provides their new normalized confidential balance, encrypted with fresh randomness to preserve privacy.
-    /// Warning: If the auditor feature is enabled, the sender must include the auditor as the first element in the
-    /// `auditor_eks` vector.
     ///
     /// `sender_auditor_hint` is emitted on [`Transferred`] and is **bound into the transfer sigma Fiat–Shamir
     /// transcript** (must match the hint used when generating the proof). Length must not exceed
@@ -628,8 +716,19 @@ module aptos_experimental::confidential_asset {
         });
     }
 
-    /// Sets the auditor's public key for the specified token.
-    public fun set_auditor(
+    /// Sets, rotates, or clears the asset-specific auditor's public key for `token`.
+    /// Pass an empty `new_auditor_ek` to clear.
+    ///
+    /// Bumps `asset_auditor_epoch` on every successful call (including clears) and appends
+    /// the prior key to `asset_auditor_history` with `deactivated_at_epoch = new_epoch`,
+    /// so future audits can decrypt historical transfers under the key that was in force
+    /// at the time.
+    ///
+    /// **In-flight proof invalidation.** Auditor identity is bound into each transfer's
+    /// Fiat–Shamir transcript via the order of `auditor_eks`; rotating the asset auditor
+    /// therefore invalidates any user transactions that were already signed under the old
+    /// key but not yet executed. Senders must regenerate proofs against the new key.
+    public fun set_asset_auditor(
         aptos_framework: &signer,
         token: Object<Metadata>,
         new_auditor_ek: vector<u8>) acquires FAConfig, FAController
@@ -638,17 +737,97 @@ module aptos_experimental::confidential_asset {
 
         let fa_config = borrow_global_mut<FAConfig>(ensure_fa_config_exists(token));
 
-        fa_config.auditor_ek = if (new_auditor_ek.length() == 0) {
+        let new_ek_opt = if (new_auditor_ek.length() == 0) {
             std::option::none()
         } else {
-            let new_auditor_ek = twisted_elgamal::new_pubkey_from_bytes(new_auditor_ek);
-            assert!(new_auditor_ek.is_some(), error::invalid_argument(EAUDITOR_EK_DESERIALIZATION_FAILED));
-            new_auditor_ek
+            let parsed = twisted_elgamal::new_pubkey_from_bytes(new_auditor_ek);
+            assert!(parsed.is_some(), error::invalid_argument(EAUDITOR_EK_DESERIALIZATION_FAILED));
+            parsed
         };
 
-        event::emit(AuditorChanged {
+        let new_epoch = fa_config.asset_auditor_epoch + 1;
+        let prior_ek = fa_config.asset_auditor_ek;
+
+        if (prior_ek.is_some()) {
+            let history_len = fa_config.asset_auditor_history.length();
+            assert!(history_len > 0, error::internal(EINTERNAL_ERROR));
+            let prior_entry = fa_config.asset_auditor_history.borrow_mut(history_len - 1);
+            prior_entry.deactivated_at_epoch = new_epoch;
+        };
+
+        if (new_ek_opt.is_some()) {
+            fa_config.asset_auditor_history.push_back(AuditorEntry {
+                ek: *new_ek_opt.borrow(),
+                activated_at_epoch: new_epoch,
+                deactivated_at_epoch: 0,
+            });
+        };
+
+        fa_config.asset_auditor_ek = new_ek_opt;
+        fa_config.asset_auditor_epoch = new_epoch;
+
+        event::emit(AssetAuditorChanged {
             asset_type: object::object_address(&token),
-            new_auditor_ek: fa_config.auditor_ek,
+            new_asset_auditor_ek: fa_config.asset_auditor_ek,
+            new_epoch,
+        });
+    }
+
+    /// Sets, rotates, or clears the chain-level compliance auditor's public key.
+    /// Pass an empty `new_chain_auditor_ek` to clear.
+    ///
+    /// The chain-level auditor is the baseline legal protection covering every confidential
+    /// asset on the chain: every confidential transfer must encrypt the transferred amount
+    /// under this key (placed at `auditor_eks[0]`). Per-asset auditors are *additive*, not
+    /// substitutes.
+    ///
+    /// Bumps `chain_auditor_epoch` and appends history; same in-flight invalidation
+    /// caveat as [`set_asset_auditor`] applies.
+    ///
+    /// Clearing the chain auditor (passing an empty key) bumps the epoch and disables all
+    /// confidential transfers chain-wide until a successor is set, since
+    /// [`validate_auditors`] aborts with [`ECHAIN_AUDITOR_NOT_SET`] when no chain auditor
+    /// is configured.
+    public fun set_chain_auditor(
+        aptos_framework: &signer,
+        new_chain_auditor_ek: vector<u8>) acquires FAController
+    {
+        system_addresses::assert_aptos_framework(aptos_framework);
+
+        let controller = borrow_global_mut<FAController>(@aptos_experimental);
+
+        let new_ek_opt = if (new_chain_auditor_ek.length() == 0) {
+            std::option::none()
+        } else {
+            let parsed = twisted_elgamal::new_pubkey_from_bytes(new_chain_auditor_ek);
+            assert!(parsed.is_some(), error::invalid_argument(EAUDITOR_EK_DESERIALIZATION_FAILED));
+            parsed
+        };
+
+        let new_epoch = controller.chain_auditor_epoch + 1;
+        let prior_ek = controller.chain_auditor_ek;
+
+        if (prior_ek.is_some()) {
+            let history_len = controller.chain_auditor_history.length();
+            assert!(history_len > 0, error::internal(EINTERNAL_ERROR));
+            let prior_entry = controller.chain_auditor_history.borrow_mut(history_len - 1);
+            prior_entry.deactivated_at_epoch = new_epoch;
+        };
+
+        if (new_ek_opt.is_some()) {
+            controller.chain_auditor_history.push_back(AuditorEntry {
+                ek: *new_ek_opt.borrow(),
+                activated_at_epoch: new_epoch,
+                deactivated_at_epoch: 0,
+            });
+        };
+
+        controller.chain_auditor_ek = new_ek_opt;
+        controller.chain_auditor_epoch = new_epoch;
+
+        event::emit(ChainAuditorChanged {
+            new_chain_auditor_ek: controller.chain_auditor_ek,
+            new_epoch,
         });
     }
 
@@ -741,8 +920,8 @@ module aptos_experimental::confidential_asset {
 
     #[view]
     /// Returns the asset-specific auditor's encryption key.
-    /// If the auditing feature is disabled for the token, the encryption key is set to `None`.
-    public fun get_auditor(
+    /// `None` if no asset auditor has been set for `token`.
+    public fun get_asset_auditor(
         token: Object<Metadata>): Option<twisted_elgamal::CompressedPubkey> acquires FAConfig, FAController
     {
         let fa_config_address = get_fa_config_address(token);
@@ -751,7 +930,52 @@ module aptos_experimental::confidential_asset {
             return std::option::none();
         };
 
-        borrow_global<FAConfig>(fa_config_address).auditor_ek
+        borrow_global<FAConfig>(fa_config_address).asset_auditor_ek
+    }
+
+    #[view]
+    /// Returns the asset-specific auditor's monotonic epoch. `0` if no asset auditor has
+    /// ever been set for `token`.
+    public fun get_asset_auditor_epoch(token: Object<Metadata>): u64 acquires FAConfig, FAController {
+        let fa_config_address = get_fa_config_address(token);
+        if (!exists<FAConfig>(fa_config_address)) {
+            return 0;
+        };
+        borrow_global<FAConfig>(fa_config_address).asset_auditor_epoch
+    }
+
+    #[view]
+    /// Returns the append-only history of asset auditor keys for `token`. Empty if no
+    /// asset auditor has ever been set.
+    public fun get_asset_auditor_history(
+        token: Object<Metadata>): vector<AuditorEntry> acquires FAConfig, FAController
+    {
+        let fa_config_address = get_fa_config_address(token);
+        if (!exists<FAConfig>(fa_config_address)) {
+            return vector[];
+        };
+        borrow_global<FAConfig>(fa_config_address).asset_auditor_history
+    }
+
+    #[view]
+    /// Returns the chain-level compliance auditor's encryption key. `None` only before
+    /// [`set_chain_auditor`] has been called for the first time, in which case
+    /// confidential transfers abort with [`ECHAIN_AUDITOR_NOT_SET`].
+    public fun get_chain_auditor(): Option<twisted_elgamal::CompressedPubkey> acquires FAController {
+        borrow_global<FAController>(@aptos_experimental).chain_auditor_ek
+    }
+
+    #[view]
+    /// Returns the chain-level auditor's monotonic epoch. `0` before any chain auditor
+    /// has been configured.
+    public fun get_chain_auditor_epoch(): u64 acquires FAController {
+        borrow_global<FAController>(@aptos_experimental).chain_auditor_epoch
+    }
+
+    #[view]
+    /// Returns the append-only history of chain-level auditor keys.
+    public fun get_chain_auditor_history(): vector<AuditorEntry> acquires FAController {
+        borrow_global<FAController>(@aptos_experimental).chain_auditor_history
     }
 
     #[view]
@@ -983,6 +1207,9 @@ module aptos_experimental::confidential_asset {
         let new_recip_pending_balance = confidential_balance::compress_balance(&recipient_pending_balance);
         recipient_ca_store.pending_balance = new_recip_pending_balance;
 
+        let chain_auditor_epoch = borrow_global<FAController>(@aptos_experimental).chain_auditor_epoch;
+        let asset_auditor_epoch = get_asset_auditor_epoch(token);
+
         event::emit(Transferred {
             from,
             to,
@@ -993,6 +1220,8 @@ module aptos_experimental::confidential_asset {
             new_sender_available_balance,
             new_recip_pending_balance,
             memo: vector[],
+            chain_auditor_epoch,
+            asset_auditor_epoch,
         });
     }
 
@@ -1180,7 +1409,9 @@ module aptos_experimental::confidential_asset {
 
             move_to(&fa_config_singer, FAConfig {
                 allowed: false,
-                auditor_ek: std::option::none(),
+                asset_auditor_ek: std::option::none(),
+                asset_auditor_epoch: 0,
+                asset_auditor_history: vector[],
             });
         };
 
@@ -1263,12 +1494,28 @@ module aptos_experimental::confidential_asset {
         )
     }
 
-    /// Validates that the auditor-related fields in the confidential transfer are correct.
-    /// Returns `false` if the transfer amount is not the same as the auditor amounts.
-    /// Returns `false` if the number of auditors in the transfer proof and auditor lists do not match.
-    /// Returns `false` if the first auditor in the list and the asset-specific auditor do not match.
-    /// Note: If the asset-specific auditor is not set, the validation is successful for any list of auditors.
-    /// Otherwise, returns `true`.
+    /// Validates the auditor-related fields of a confidential transfer.
+    ///
+    /// Aborts with [`ECHAIN_AUDITOR_NOT_SET`] if no chain-level auditor has been
+    /// configured (transfers cannot proceed in that state).
+    ///
+    /// Returns `false` (rejecting the transfer) if any of:
+    /// - any `auditor_amount` does not encrypt the same plaintext as `transfer_amount`;
+    /// - the lengths of `auditor_eks`, `auditor_amounts`, and the transfer-proof auditor
+    ///   row count disagree;
+    /// - `auditor_eks` is missing the required prefix (see slot layout below);
+    /// - the prefix slot keys do not equal the active chain / asset auditor keys.
+    ///
+    /// **Slot layout of `auditor_eks`** (and `auditor_amounts`):
+    /// ```text
+    ///   [0]   chain-level auditor       (always required)
+    ///   [1]   asset-specific auditor    (required iff `get_asset_auditor(token).is_some()`)
+    ///   [2..] voluntary auditors        (sender's choice, ordered)
+    /// ```
+    /// Auditor identity at slots 0 and 1 is bound into the transfer's Fiat–Shamir
+    /// transcript (via the order in which `auditor_eks` is hashed in
+    /// `confidential_proof::fiat_shamir_transfer_sigma_proof_challenge`), so a sender
+    /// cannot substitute one auditor's slot for another's.
     fun validate_auditors(
         token: Object<Metadata>,
         transfer_amount: &confidential_balance::ConfidentialBalance,
@@ -1291,19 +1538,31 @@ module aptos_experimental::confidential_asset {
             return false
         };
 
-        let asset_auditor_ek = get_auditor(token);
-        if (asset_auditor_ek.is_none()) {
-            return true
-        };
+        let chain_auditor_ek_opt = borrow_global<FAController>(@aptos_experimental).chain_auditor_ek;
+        assert!(chain_auditor_ek_opt.is_some(), error::invalid_state(ECHAIN_AUDITOR_NOT_SET));
 
-        if (auditor_eks.length() == 0) {
+        let asset_auditor_ek_opt = get_asset_auditor(token);
+        let required_prefix = if (asset_auditor_ek_opt.is_some()) 2 else 1;
+
+        if (auditor_eks.length() < required_prefix) {
             return false
         };
 
-        let asset_auditor_ek = twisted_elgamal::pubkey_to_point(&asset_auditor_ek.extract());
-        let first_auditor_ek = twisted_elgamal::pubkey_to_point(&auditor_eks[0]);
+        let chain_auditor_point = twisted_elgamal::pubkey_to_point(&chain_auditor_ek_opt.extract());
+        let slot0_point = twisted_elgamal::pubkey_to_point(&auditor_eks[0]);
+        if (!ristretto255::point_equals(&chain_auditor_point, &slot0_point)) {
+            return false
+        };
 
-        ristretto255::point_equals(&asset_auditor_ek, &first_auditor_ek)
+        if (asset_auditor_ek_opt.is_some()) {
+            let asset_auditor_point = twisted_elgamal::pubkey_to_point(&asset_auditor_ek_opt.extract());
+            let slot1_point = twisted_elgamal::pubkey_to_point(&auditor_eks[1]);
+            if (!ristretto255::point_equals(&asset_auditor_point, &slot1_point)) {
+                return false
+            };
+        };
+
+        true
     }
 
     /// Deserializes the auditor EKs from a byte array.
@@ -1460,6 +1719,8 @@ module aptos_experimental::confidential_asset {
         expected_to: address,
         expected_auditor_entry_count: u64,
         expected_sender_auditor_hint: vector<u8>,
+        expected_chain_auditor_epoch: u64,
+        expected_asset_auditor_epoch: u64,
     ) acquires ConfidentialAssetStore {
         let evts = event::emitted_events<Transferred>();
         let len = vector::length(&evts);
@@ -1477,6 +1738,8 @@ module aptos_experimental::confidential_asset {
         let on_chain_recip_pending = pending_balance(expected_to, token);
         assert!(e.new_sender_available_balance == on_chain_sender, 6);
         assert!(e.new_recip_pending_balance == on_chain_recip_pending, 7);
+        assert!(e.chain_auditor_epoch == expected_chain_auditor_epoch, 10);
+        assert!(e.asset_auditor_epoch == expected_asset_auditor_epoch, 11);
     }
 
     #[test_only]
@@ -1596,10 +1859,19 @@ module aptos_experimental::confidential_asset {
     }
 
     #[test_only]
-    public fun assert_last_auditor_changed_event(token: Object<Metadata>) {
-        let evts = event::emitted_events<AuditorChanged>();
+    public fun assert_last_asset_auditor_changed_event(token: Object<Metadata>, expected_epoch: u64) {
+        let evts = event::emitted_events<AssetAuditorChanged>();
         assert!(evts.length() > 0, 190);
         let e = &evts[evts.length() - 1];
         assert!(e.asset_type == object::object_address(&token), 191);
+        assert!(e.new_epoch == expected_epoch, 192);
+    }
+
+    #[test_only]
+    public fun assert_last_chain_auditor_changed_event(expected_epoch: u64) {
+        let evts = event::emitted_events<ChainAuditorChanged>();
+        assert!(evts.length() > 0, 195);
+        let e = &evts[evts.length() - 1];
+        assert!(e.new_epoch == expected_epoch, 196);
     }
 }

--- a/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
+++ b/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
@@ -92,15 +92,17 @@ module aptos_experimental::confidential_asset {
     /// No confidential asset pool exists for the given asset type.
     const ENO_CONFIDENTIAL_ASSET_POOL: u64 = 20;
 
-    /// The chain-level auditor must be configured (via [`set_chain_auditor`]) before any
-    /// confidential transfer can be executed. Required as a baseline compliance guarantee
-    /// covering every confidential asset on the chain.
+    /// Chain auditor not configured; confidential transfers cannot proceed.
     const ECHAIN_AUDITOR_NOT_SET: u64 = 21;
 
-    /// The signer is not authorized to update the asset auditor for this token. The asset
-    /// auditor can only be updated by the root owner of the FA metadata object (see
-    /// [`set_asset_auditor`]).
+    /// Signer is not the FA metadata object's root owner.
     const ENOT_ASSET_ISSUER: u64 = 22;
+
+    /// Chain-auditor admin not assigned by governance.
+    const ECHAIN_AUDITOR_ADMIN_NOT_SET: u64 = 23;
+
+    /// Signer is not the configured chain-auditor admin.
+    const ENOT_CHAIN_AUDITOR_ADMIN: u64 = 24;
 
     //
     // Constants
@@ -157,10 +159,8 @@ module aptos_experimental::confidential_asset {
     }
 
     /// One entry in an auditor key history vector — used for both the chain-level auditor
-    /// (on [`FAController`]) and the per-asset auditor (on [`FAConfig`]). The history exists
-    /// for compliance reasons: U.S./EU regulations require us to be able to decrypt past
-    /// transfers for up to 7 years on demand, so when a key is rotated we record the prior
-    /// key alongside the epoch range during which it was active.
+    /// (on [`GlobalConfig`]) and the per-asset auditor (on [`FAConfig`]). Rotated keys are
+    /// retained so transfers stamped with a prior epoch can still be decrypted.
     struct AuditorEntry has store, drop, copy {
         ek: twisted_elgamal::CompressedPubkey,
         /// First epoch in which `ek` was the active auditor key. Monotonically increasing
@@ -171,8 +171,8 @@ module aptos_experimental::confidential_asset {
         deactivated_at_epoch: u64,
     }
 
-    /// Represents the controller for the primary FA stores and `FAConfig` objects.
-    struct FAController has key {
+    /// Global configuration for confidential assets: primary FA stores, `FAConfig` derivation, and chain-level auditor state.
+    struct GlobalConfig has key {
         /// Indicates whether the allow list is enabled. If `true`, only tokens from the allow list can be transferred.
         /// This flag is managed by the governance module.
         allow_list_enabled: bool,
@@ -180,26 +180,23 @@ module aptos_experimental::confidential_asset {
         /// Used to derive a signer that owns all the FAs' primary stores and `FAConfig` objects.
         extend_ref: ExtendRef,
 
-        /// The chain-level compliance auditor's encryption key. Set via [`set_chain_auditor`]
-        /// by governance. Every confidential transfer must include this key as the first
-        /// element (`auditor_eks[0]`) of its auditor list, ensuring no transfer on the chain
-        /// is fully unauditable. `None` only before the chain-level auditor has been
-        /// configured for the first time — `confidential_transfer` aborts with
-        /// [`ECHAIN_AUDITOR_NOT_SET`] in that state.
+        /// Chain-level auditor encryption key. Required at `auditor_eks[0]` on every
+        /// confidential transfer. `None` until set via [`set_chain_auditor`]; transfers
+        /// abort with [`ECHAIN_AUDITOR_NOT_SET`] in that state.
         chain_auditor_ek: Option<twisted_elgamal::CompressedPubkey>,
 
-        /// Monotonic counter, incremented on every successful [`set_chain_auditor`] call
-        /// (including clears, in which case the entry is appended to history with no
-        /// successor key). Stamped on each [`Transferred`] event so future audits can
-        /// determine which historical chain auditor key was in force at the time of
-        /// transfer and decrypt the transcript accordingly.
+        /// Account authorized to call [`set_chain_auditor`]. Set by governance via
+        /// [`set_chain_auditor_admin`]. `None` until governance assigns one, during which
+        /// window `set_chain_auditor` aborts with [`ECHAIN_AUDITOR_ADMIN_NOT_SET`].
+        chain_auditor_admin: Option<address>,
+
+        /// Bumped on every [`set_chain_auditor`] call (including clears). Stamped on each
+        /// [`Transferred`] event.
         chain_auditor_epoch: u64,
 
-        /// Append-only history of past chain auditor keys. Each entry's
-        /// `[activated_at_epoch, deactivated_at_epoch)` half-open interval describes the
-        /// range of `chain_auditor_epoch` values during which it was the active key.
-        /// Note: pre-launch this is unbounded; if rotations become frequent in production,
-        /// consider trimming or paginating.
+        /// Append-only history of chain auditor keys. Each entry's
+        /// `[activated_at_epoch, deactivated_at_epoch)` half-open interval is the range
+        /// of `chain_auditor_epoch` values during which it was active.
         chain_auditor_history: vector<AuditorEntry>,
     }
 
@@ -210,28 +207,16 @@ module aptos_experimental::confidential_asset {
         /// Can be toggled by the governance module. The withdrawals are always allowed.
         allowed: bool,
 
-        /// The asset-specific auditor's public key for the token. If unset, this field is
-        /// `None`. When set, every confidential transfer of this asset must include this
-        /// key at `auditor_eks[1]` (immediately after the chain-level auditor at
-        /// `auditor_eks[0]`).
-        ///
-        /// Asset auditors are appointed by the asset issuer on a case-by-case basis for
-        /// assets with specific regulatory obligations (e.g. a stablecoin with a banking
-        /// regulator, or a tokenized security). The "issuer" is the root owner of the FA
-        /// metadata object — for framework-managed FAs (root = `@0x1`) this is governance
-        /// via the `aptos_framework` signer; for issuer-deployed FAs it is the account
-        /// (or multisig) at the top of the metadata object's ownership chain. Asset
-        /// auditors are *additive* to the chain-level auditor, not a substitute.
+        /// Per-asset auditor encryption key. When set, required at `auditor_eks[1]` on
+        /// every transfer of this asset (additive to the chain auditor at `[0]`). Set via
+        /// [`set_asset_auditor`] by the FA metadata object's root owner.
         asset_auditor_ek: Option<twisted_elgamal::CompressedPubkey>,
 
-        /// Monotonic counter, incremented on every successful [`set_asset_auditor`] call.
-        /// Stamped on each [`Transferred`] event of this asset so future audits can map a
-        /// past transfer to the asset auditor key in force at that time. `0` while no
-        /// asset auditor has ever been set.
+        /// Bumped on every [`set_asset_auditor`] call. Stamped on each [`Transferred`]
+        /// event for this asset.
         asset_auditor_epoch: u64,
 
-        /// Append-only history of past asset auditor keys. See [`AuditorEntry`] for entry
-        /// semantics and [`FAController.chain_auditor_history`] for the sizing caveat.
+        /// Append-only history of asset auditor keys. See [`AuditorEntry`].
         asset_auditor_history: vector<AuditorEntry>,
     }
 
@@ -302,7 +287,7 @@ module aptos_experimental::confidential_asset {
         new_recip_pending_balance: confidential_balance::CompressedConfidentialBalance,
         /// Reserved memo payload for future or off-chain conventions; currently emitted as an empty `vector`.
         memo: vector<u8>,
-        /// Value of [`FAController.chain_auditor_epoch`] at the time of the transfer.
+        /// Value of [`GlobalConfig.chain_auditor_epoch`] at the time of the transfer.
         /// Required for compliance: lets future audits identify which historical
         /// chain-level auditor key was in force, so that the transcript can still be
         /// decrypted years after a key rotation.
@@ -359,9 +344,7 @@ module aptos_experimental::confidential_asset {
     }
 
     #[event]
-    /// Emitted when the asset-specific auditor is set, rotated, or cleared.
-    /// `new_epoch` is the post-change value of [`FAConfig.asset_auditor_epoch`] and matches
-    /// the value stamped on subsequent [`Transferred`] events for this asset.
+    /// Asset auditor set, rotated, or cleared.
     struct AssetAuditorChanged has drop, store {
         asset_type: address,
         new_asset_auditor_ek: Option<twisted_elgamal::CompressedPubkey>,
@@ -369,13 +352,16 @@ module aptos_experimental::confidential_asset {
     }
 
     #[event]
-    /// Emitted when the chain-level compliance auditor is set, rotated, or cleared by
-    /// governance. `new_epoch` is the post-change value of
-    /// [`FAController.chain_auditor_epoch`] and matches the value stamped on subsequent
-    /// [`Transferred`] events.
+    /// Chain auditor set, rotated, or cleared.
     struct ChainAuditorChanged has drop, store {
         new_chain_auditor_ek: Option<twisted_elgamal::CompressedPubkey>,
         new_epoch: u64,
+    }
+
+    #[event]
+    /// Chain-auditor admin assigned or rotated by governance.
+    struct ChainAuditorAdminChanged has drop, store {
+        new_admin: address,
     }
 
     //
@@ -390,14 +376,15 @@ module aptos_experimental::confidential_asset {
 
         let deployer_address = signer::address_of(deployer);
 
-        let fa_controller_ctor_ref = &object::create_object(deployer_address);
+        let global_config_ctor_ref = &object::create_object(deployer_address);
 
-        move_to(deployer, FAController {
+        move_to(deployer, GlobalConfig {
             allow_list_enabled: chain_id::get() == MAINNET_CHAIN_ID,
-            extend_ref: object::generate_extend_ref(fa_controller_ctor_ref),
+            extend_ref: object::generate_extend_ref(global_config_ctor_ref),
             chain_auditor_ek: std::option::none(),
             chain_auditor_epoch: 0,
             chain_auditor_history: vector[],
+            chain_auditor_admin: std::option::none(),
         });
     }
 
@@ -414,7 +401,7 @@ module aptos_experimental::confidential_asset {
         token: Object<Metadata>,
         ek: vector<u8>,
         registration_proof_commitment: vector<u8>,
-        registration_proof_response: vector<u8>) acquires FAController, FAConfig
+        registration_proof_response: vector<u8>) acquires GlobalConfig, FAConfig
     {
         let ek = twisted_elgamal::new_pubkey_from_bytes(ek).extract();
 
@@ -443,7 +430,7 @@ module aptos_experimental::confidential_asset {
         sender: &signer,
         token: Object<Metadata>,
         to: address,
-        amount: u64) acquires ConfidentialAssetStore, FAController, FAConfig
+        amount: u64) acquires ConfidentialAssetStore, GlobalConfig, FAConfig
     {
         deposit_to_internal(sender, token, to, amount)
     }
@@ -452,7 +439,7 @@ module aptos_experimental::confidential_asset {
     public entry fun deposit(
         sender: &signer,
         token: Object<Metadata>,
-        amount: u64) acquires ConfidentialAssetStore, FAController, FAConfig
+        amount: u64) acquires ConfidentialAssetStore, GlobalConfig, FAConfig
     {
         deposit_to_internal(sender, token, signer::address_of(sender), amount)
     }
@@ -461,7 +448,7 @@ module aptos_experimental::confidential_asset {
     public entry fun deposit_coins_to<CoinType>(
         sender: &signer,
         to: address,
-        amount: u64) acquires ConfidentialAssetStore, FAController, FAConfig
+        amount: u64) acquires ConfidentialAssetStore, GlobalConfig, FAConfig
     {
         let token = ensure_sufficient_fa<CoinType>(sender, amount).extract();
 
@@ -471,7 +458,7 @@ module aptos_experimental::confidential_asset {
     /// The same as `deposit`, but converts coins to missing FA first.
     public entry fun deposit_coins<CoinType>(
         sender: &signer,
-        amount: u64) acquires ConfidentialAssetStore, FAController, FAConfig
+        amount: u64) acquires ConfidentialAssetStore, GlobalConfig, FAConfig
     {
         let token = ensure_sufficient_fa<CoinType>(sender, amount).extract();
 
@@ -489,7 +476,7 @@ module aptos_experimental::confidential_asset {
         amount: u64,
         new_balance: vector<u8>,
         zkrp_new_balance: vector<u8>,
-        sigma_proof: vector<u8>) acquires ConfidentialAssetStore, FAController
+        sigma_proof: vector<u8>) acquires ConfidentialAssetStore, GlobalConfig
     {
         let new_balance = confidential_balance::new_actual_balance_from_bytes(new_balance).extract();
         let proof = confidential_proof::deserialize_withdrawal_proof(sigma_proof, zkrp_new_balance).extract();
@@ -504,7 +491,7 @@ module aptos_experimental::confidential_asset {
         amount: u64,
         new_balance: vector<u8>,
         zkrp_new_balance: vector<u8>,
-        sigma_proof: vector<u8>) acquires ConfidentialAssetStore, FAController
+        sigma_proof: vector<u8>) acquires ConfidentialAssetStore, GlobalConfig
     {
         withdraw_to(
             sender,
@@ -548,7 +535,7 @@ module aptos_experimental::confidential_asset {
         zkrp_new_balance: vector<u8>,
         zkrp_transfer_amount: vector<u8>,
         sigma_proof: vector<u8>,
-        sender_auditor_hint: vector<u8>) acquires ConfidentialAssetStore, FAConfig, FAController
+        sender_auditor_hint: vector<u8>) acquires ConfidentialAssetStore, FAConfig, GlobalConfig
     {
         let new_balance = confidential_balance::new_actual_balance_from_bytes(new_balance).extract();
         let sender_amount = confidential_balance::new_pending_balance_from_bytes(sender_amount).extract();
@@ -667,33 +654,33 @@ module aptos_experimental::confidential_asset {
     //
 
     /// Enables the allow list, restricting confidential transfers to tokens on the allow list.
-    public fun enable_allow_list(aptos_framework: &signer) acquires FAController {
+    public fun enable_allow_list(aptos_framework: &signer) acquires GlobalConfig {
         system_addresses::assert_aptos_framework(aptos_framework);
 
-        let fa_controller = borrow_global_mut<FAController>(@aptos_experimental);
+        let global_config = borrow_global_mut<GlobalConfig>(@aptos_experimental);
 
-        assert!(!fa_controller.allow_list_enabled, error::invalid_state(EALLOW_LIST_ENABLED));
+        assert!(!global_config.allow_list_enabled, error::invalid_state(EALLOW_LIST_ENABLED));
 
-        fa_controller.allow_list_enabled = true;
+        global_config.allow_list_enabled = true;
 
         event::emit(AllowListChanged { enabled: true });
     }
 
     /// Disables the allow list, allowing confidential transfers for all tokens.
-    public fun disable_allow_list(aptos_framework: &signer) acquires FAController {
+    public fun disable_allow_list(aptos_framework: &signer) acquires GlobalConfig {
         system_addresses::assert_aptos_framework(aptos_framework);
 
-        let fa_controller = borrow_global_mut<FAController>(@aptos_experimental);
+        let global_config = borrow_global_mut<GlobalConfig>(@aptos_experimental);
 
-        assert!(fa_controller.allow_list_enabled, error::invalid_state(EALLOW_LIST_DISABLED));
+        assert!(global_config.allow_list_enabled, error::invalid_state(EALLOW_LIST_DISABLED));
 
-        fa_controller.allow_list_enabled = false;
+        global_config.allow_list_enabled = false;
 
         event::emit(AllowListChanged { enabled: false });
     }
 
     /// Enables confidential transfers for the specified token.
-    public fun enable_token(aptos_framework: &signer, token: Object<Metadata>) acquires FAConfig, FAController {
+    public fun enable_token(aptos_framework: &signer, token: Object<Metadata>) acquires FAConfig, GlobalConfig {
         system_addresses::assert_aptos_framework(aptos_framework);
 
         let fa_config = borrow_global_mut<FAConfig>(ensure_fa_config_exists(token));
@@ -709,7 +696,7 @@ module aptos_experimental::confidential_asset {
     }
 
     /// Disables confidential transfers for the specified token.
-    public fun disable_token(aptos_framework: &signer, token: Object<Metadata>) acquires FAConfig, FAController {
+    public fun disable_token(aptos_framework: &signer, token: Object<Metadata>) acquires FAConfig, GlobalConfig {
         system_addresses::assert_aptos_framework(aptos_framework);
 
         let fa_config = borrow_global_mut<FAConfig>(ensure_fa_config_exists(token));
@@ -724,30 +711,16 @@ module aptos_experimental::confidential_asset {
         });
     }
 
-    /// Sets, rotates, or clears the asset-specific auditor's public key for `token`.
-    /// Pass an empty `new_auditor_ek` to clear.
+    /// Sets, rotates, or clears the asset-specific auditor key for `token`. Pass an empty
+    /// `new_auditor_ek` to clear. Bumps `asset_auditor_epoch` and appends to history.
     ///
-    /// Bumps `asset_auditor_epoch` on every successful call (including clears) and appends
-    /// the prior key to `asset_auditor_history` with `deactivated_at_epoch = new_epoch`,
-    /// so future audits can decrypt historical transfers under the key that was in force
-    /// at the time.
-    ///
-    /// **In-flight proof invalidation.** Auditor identity is bound into each transfer's
-    /// Fiat–Shamir transcript via the order of `auditor_eks`; rotating the asset auditor
-    /// therefore invalidates any user transactions that were already signed under the old
-    /// key but not yet executed. Senders must regenerate proofs against the new key.
-    ///
-    /// **Authorization.** Callable by the root owner of `token`'s metadata object — i.e.
-    /// the account at the top of the object ownership chain (walked via
-    /// [`object::root_owner`]). For framework-managed FAs whose root owner is `@0x1`,
-    /// this is governance acting through the `aptos_framework` signer. For
-    /// issuer-deployed FAs (including the common pattern where a contract object owns
-    /// the metadata and is in turn owned by a multisig), the multisig at the chain root
-    /// can call this directly. Aborts with [`ENOT_ASSET_ISSUER`] otherwise.
+    /// Callable by `object::root_owner(token)`; aborts with [`ENOT_ASSET_ISSUER`] otherwise.
+    /// Rotation invalidates pending transfer proofs (auditor key is bound into the
+    /// Fiat–Shamir transcript) — senders must regenerate against the new key.
     public entry fun set_asset_auditor(
         issuer: &signer,
         token: Object<Metadata>,
-        new_auditor_ek: vector<u8>) acquires FAConfig, FAController
+        new_auditor_ek: vector<u8>) acquires FAConfig, GlobalConfig
     {
         assert!(
             object::root_owner(token) == signer::address_of(issuer),
@@ -792,28 +765,42 @@ module aptos_experimental::confidential_asset {
         });
     }
 
-    /// Sets, rotates, or clears the chain-level compliance auditor's public key.
-    /// Pass an empty `new_chain_auditor_ek` to clear.
-    ///
-    /// The chain-level auditor is the baseline legal protection covering every confidential
-    /// asset on the chain: every confidential transfer must encrypt the transferred amount
-    /// under this key (placed at `auditor_eks[0]`). Per-asset auditors are *additive*, not
-    /// substitutes.
-    ///
-    /// Bumps `chain_auditor_epoch` and appends history; same in-flight invalidation
-    /// caveat as [`set_asset_auditor`] applies.
-    ///
-    /// Clearing the chain auditor (passing an empty key) bumps the epoch and disables all
-    /// confidential transfers chain-wide until a successor is set, since
-    /// [`validate_auditors`] aborts with [`ECHAIN_AUDITOR_NOT_SET`] when no chain auditor
-    /// is configured.
-    public fun set_chain_auditor(
+    /// Designates (or rotates) the account authorized to call [`set_chain_auditor`].
+    /// Governance-only. No clear form — rotate to a successor instead.
+    public entry fun set_chain_auditor_admin(
         aptos_framework: &signer,
-        new_chain_auditor_ek: vector<u8>) acquires FAController
+        new_admin: address) acquires GlobalConfig
     {
         system_addresses::assert_aptos_framework(aptos_framework);
 
-        let controller = borrow_global_mut<FAController>(@aptos_experimental);
+        let global_config = borrow_global_mut<GlobalConfig>(@aptos_experimental);
+        global_config.chain_auditor_admin = std::option::some(new_admin);
+
+        event::emit(ChainAuditorAdminChanged { new_admin });
+    }
+
+    /// Sets, rotates, or clears the chain-level auditor key. Pass an empty
+    /// `new_chain_auditor_ek` to clear (which disables all confidential transfers until a
+    /// successor is set). Bumps `chain_auditor_epoch` and appends to history.
+    ///
+    /// Callable only by [`GlobalConfig.chain_auditor_admin`]. Aborts with
+    /// [`ECHAIN_AUDITOR_ADMIN_NOT_SET`] before an admin is assigned, or
+    /// [`ENOT_CHAIN_AUDITOR_ADMIN`] for any other signer. Rotation invalidates pending
+    /// transfer proofs — see [`set_asset_auditor`].
+    public entry fun set_chain_auditor(
+        admin: &signer,
+        new_chain_auditor_ek: vector<u8>) acquires GlobalConfig
+    {
+        let global_config = borrow_global_mut<GlobalConfig>(@aptos_experimental);
+
+        assert!(
+            global_config.chain_auditor_admin.is_some(),
+            error::invalid_state(ECHAIN_AUDITOR_ADMIN_NOT_SET)
+        );
+        assert!(
+            *global_config.chain_auditor_admin.borrow() == signer::address_of(admin),
+            error::permission_denied(ENOT_CHAIN_AUDITOR_ADMIN)
+        );
 
         let new_ek_opt = if (new_chain_auditor_ek.length() == 0) {
             std::option::none()
@@ -823,29 +810,29 @@ module aptos_experimental::confidential_asset {
             parsed
         };
 
-        let new_epoch = controller.chain_auditor_epoch + 1;
-        let prior_ek = controller.chain_auditor_ek;
+        let new_epoch = global_config.chain_auditor_epoch + 1;
+        let prior_ek = global_config.chain_auditor_ek;
 
         if (prior_ek.is_some()) {
-            let history_len = controller.chain_auditor_history.length();
+            let history_len = global_config.chain_auditor_history.length();
             assert!(history_len > 0, error::internal(EINTERNAL_ERROR));
-            let prior_entry = controller.chain_auditor_history.borrow_mut(history_len - 1);
+            let prior_entry = global_config.chain_auditor_history.borrow_mut(history_len - 1);
             prior_entry.deactivated_at_epoch = new_epoch;
         };
 
         if (new_ek_opt.is_some()) {
-            controller.chain_auditor_history.push_back(AuditorEntry {
+            global_config.chain_auditor_history.push_back(AuditorEntry {
                 ek: *new_ek_opt.borrow(),
                 activated_at_epoch: new_epoch,
                 deactivated_at_epoch: 0,
             });
         };
 
-        controller.chain_auditor_ek = new_ek_opt;
-        controller.chain_auditor_epoch = new_epoch;
+        global_config.chain_auditor_ek = new_ek_opt;
+        global_config.chain_auditor_epoch = new_epoch;
 
         event::emit(ChainAuditorChanged {
-            new_chain_auditor_ek: controller.chain_auditor_ek,
+            new_chain_auditor_ek: global_config.chain_auditor_ek,
             new_epoch,
         });
     }
@@ -862,7 +849,7 @@ module aptos_experimental::confidential_asset {
 
     #[view]
     /// Checks if the token is allowed for confidential transfers.
-    public fun is_token_allowed(token: Object<Metadata>): bool acquires FAController, FAConfig {
+    public fun is_token_allowed(token: Object<Metadata>): bool acquires GlobalConfig, FAConfig {
         if (!is_allow_list_enabled()) {
             return true
         };
@@ -880,8 +867,8 @@ module aptos_experimental::confidential_asset {
     /// Checks if the allow list is enabled.
     /// If the allow list is enabled, only tokens from the allow list can be transferred.
     /// Otherwise, all tokens are allowed.
-    public fun is_allow_list_enabled(): bool acquires FAController {
-        borrow_global<FAController>(@aptos_experimental).allow_list_enabled
+    public fun is_allow_list_enabled(): bool acquires GlobalConfig {
+        borrow_global<GlobalConfig>(@aptos_experimental).allow_list_enabled
     }
 
     #[view]
@@ -938,10 +925,9 @@ module aptos_experimental::confidential_asset {
     }
 
     #[view]
-    /// Returns the asset-specific auditor's encryption key.
-    /// `None` if no asset auditor has been set for `token`.
+    /// Asset auditor encryption key for `token`, or `None` if unset.
     public fun get_asset_auditor(
-        token: Object<Metadata>): Option<twisted_elgamal::CompressedPubkey> acquires FAConfig, FAController
+        token: Object<Metadata>): Option<twisted_elgamal::CompressedPubkey> acquires FAConfig, GlobalConfig
     {
         let fa_config_address = get_fa_config_address(token);
 
@@ -953,9 +939,8 @@ module aptos_experimental::confidential_asset {
     }
 
     #[view]
-    /// Returns the asset-specific auditor's monotonic epoch. `0` if no asset auditor has
-    /// ever been set for `token`.
-    public fun get_asset_auditor_epoch(token: Object<Metadata>): u64 acquires FAConfig, FAController {
+    /// Asset auditor epoch for `token`. `0` if no asset auditor has been set.
+    public fun get_asset_auditor_epoch(token: Object<Metadata>): u64 acquires FAConfig, GlobalConfig {
         let fa_config_address = get_fa_config_address(token);
         if (!exists<FAConfig>(fa_config_address)) {
             return 0;
@@ -964,10 +949,9 @@ module aptos_experimental::confidential_asset {
     }
 
     #[view]
-    /// Returns the append-only history of asset auditor keys for `token`. Empty if no
-    /// asset auditor has ever been set.
+    /// Append-only history of asset auditor keys for `token`.
     public fun get_asset_auditor_history(
-        token: Object<Metadata>): vector<AuditorEntry> acquires FAConfig, FAController
+        token: Object<Metadata>): vector<AuditorEntry> acquires FAConfig, GlobalConfig
     {
         let fa_config_address = get_fa_config_address(token);
         if (!exists<FAConfig>(fa_config_address)) {
@@ -977,29 +961,32 @@ module aptos_experimental::confidential_asset {
     }
 
     #[view]
-    /// Returns the chain-level compliance auditor's encryption key. `None` only before
-    /// [`set_chain_auditor`] has been called for the first time, in which case
-    /// confidential transfers abort with [`ECHAIN_AUDITOR_NOT_SET`].
-    public fun get_chain_auditor(): Option<twisted_elgamal::CompressedPubkey> acquires FAController {
-        borrow_global<FAController>(@aptos_experimental).chain_auditor_ek
+    /// Chain auditor encryption key, or `None` if unset.
+    public fun get_chain_auditor(): Option<twisted_elgamal::CompressedPubkey> acquires GlobalConfig {
+        borrow_global<GlobalConfig>(@aptos_experimental).chain_auditor_ek
     }
 
     #[view]
-    /// Returns the chain-level auditor's monotonic epoch. `0` before any chain auditor
-    /// has been configured.
-    public fun get_chain_auditor_epoch(): u64 acquires FAController {
-        borrow_global<FAController>(@aptos_experimental).chain_auditor_epoch
+    /// Chain auditor epoch. `0` before any chain auditor has been configured.
+    public fun get_chain_auditor_epoch(): u64 acquires GlobalConfig {
+        borrow_global<GlobalConfig>(@aptos_experimental).chain_auditor_epoch
     }
 
     #[view]
-    /// Returns the append-only history of chain-level auditor keys.
-    public fun get_chain_auditor_history(): vector<AuditorEntry> acquires FAController {
-        borrow_global<FAController>(@aptos_experimental).chain_auditor_history
+    /// Append-only history of chain auditor keys.
+    public fun get_chain_auditor_history(): vector<AuditorEntry> acquires GlobalConfig {
+        borrow_global<GlobalConfig>(@aptos_experimental).chain_auditor_history
+    }
+
+    #[view]
+    /// Chain-auditor admin address, or `None` if governance hasn't assigned one yet.
+    public fun get_chain_auditor_admin(): Option<address> acquires GlobalConfig {
+        borrow_global<GlobalConfig>(@aptos_experimental).chain_auditor_admin
     }
 
     #[view]
     /// Returns the circulating supply of the confidential asset.
-    public fun confidential_asset_balance(token: Object<Metadata>): u64 acquires FAController {
+    public fun confidential_asset_balance(token: Object<Metadata>): u64 acquires GlobalConfig {
         fungible_asset::balance(get_pool_fa_store(token))
     }
 
@@ -1012,7 +999,7 @@ module aptos_experimental::confidential_asset {
     public fun register_internal(
         sender: &signer,
         token: Object<Metadata>,
-        ek: twisted_elgamal::CompressedPubkey) acquires FAController, FAConfig
+        ek: twisted_elgamal::CompressedPubkey) acquires GlobalConfig, FAConfig
     {
         assert!(is_safe_for_confidentiality(&token), error::invalid_argument(EUNSAFE_DISPATCHABLE_FA));
         assert!(is_token_allowed(token), error::invalid_argument(ETOKEN_DISABLED));
@@ -1044,7 +1031,7 @@ module aptos_experimental::confidential_asset {
         sender: &signer,
         token: Object<Metadata>,
         to: address,
-        amount: u64) acquires ConfidentialAssetStore, FAController, FAConfig
+        amount: u64) acquires ConfidentialAssetStore, GlobalConfig, FAConfig
     {
         assert!(is_safe_for_confidentiality(&token), error::invalid_argument(EUNSAFE_DISPATCHABLE_FA));
         assert!(is_token_allowed(token), error::invalid_argument(ETOKEN_DISABLED));
@@ -1097,7 +1084,7 @@ module aptos_experimental::confidential_asset {
         to: address,
         amount: u64,
         new_balance: confidential_balance::ConfidentialBalance,
-        proof: WithdrawalProof) acquires ConfidentialAssetStore, FAController
+        proof: WithdrawalProof) acquires ConfidentialAssetStore, GlobalConfig
     {
         assert!(is_safe_for_confidentiality(&token), error::invalid_argument(EUNSAFE_DISPATCHABLE_FA));
 
@@ -1154,7 +1141,7 @@ module aptos_experimental::confidential_asset {
         auditor_eks: vector<twisted_elgamal::CompressedPubkey>,
         auditor_amounts: vector<confidential_balance::ConfidentialBalance>,
         proof: TransferProof,
-        sender_auditor_hint: vector<u8>) acquires ConfidentialAssetStore, FAConfig, FAController
+        sender_auditor_hint: vector<u8>) acquires ConfidentialAssetStore, FAConfig, GlobalConfig
     {
         assert!(is_safe_for_confidentiality(&token), error::invalid_argument(EUNSAFE_DISPATCHABLE_FA));
         assert!(is_token_allowed(token), error::invalid_argument(ETOKEN_DISABLED));
@@ -1226,7 +1213,7 @@ module aptos_experimental::confidential_asset {
         let new_recip_pending_balance = confidential_balance::compress_balance(&recipient_pending_balance);
         recipient_ca_store.pending_balance = new_recip_pending_balance;
 
-        let chain_auditor_epoch = borrow_global<FAController>(@aptos_experimental).chain_auditor_epoch;
+        let chain_auditor_epoch = borrow_global<GlobalConfig>(@aptos_experimental).chain_auditor_epoch;
         let asset_auditor_epoch = get_asset_auditor_epoch(token);
 
         event::emit(Transferred {
@@ -1420,7 +1407,7 @@ module aptos_experimental::confidential_asset {
     /// Ensures that the `FAConfig` object exists for the specified token.
     /// If the object does not exist, creates it.
     /// Used only for internal purposes.
-    fun ensure_fa_config_exists(token: Object<Metadata>): address acquires FAController {
+    fun ensure_fa_config_exists(token: Object<Metadata>): address acquires GlobalConfig {
         let fa_config_address = get_fa_config_address(token);
 
         if (!exists<FAConfig>(fa_config_address)) {
@@ -1438,24 +1425,24 @@ module aptos_experimental::confidential_asset {
     }
 
     /// Returns an object for handling all the FA primary stores, and returns a signer for it.
-    fun get_fa_store_signer(): signer acquires FAController {
-        object::generate_signer_for_extending(&borrow_global<FAController>(@aptos_experimental).extend_ref)
+    fun get_fa_store_signer(): signer acquires GlobalConfig {
+        object::generate_signer_for_extending(&borrow_global<GlobalConfig>(@aptos_experimental).extend_ref)
     }
 
     /// Returns the address that handles all the FA primary stores.
-    fun get_fa_store_address(): address acquires FAController {
-        object::address_from_extend_ref(&borrow_global<FAController>(@aptos_experimental).extend_ref)
+    fun get_fa_store_address(): address acquires GlobalConfig {
+        object::address_from_extend_ref(&borrow_global<GlobalConfig>(@aptos_experimental).extend_ref)
     }
 
     /// Returns the pool's primary fungible store for the given token, aborting if it does not exist.
-    fun get_pool_fa_store(token: Object<Metadata>): Object<FungibleStore> acquires FAController {
+    fun get_pool_fa_store(token: Object<Metadata>): Object<FungibleStore> acquires GlobalConfig {
         let pool_addr = get_fa_store_address();
         assert!(primary_fungible_store::primary_store_exists(pool_addr, token), error::not_found(ENO_CONFIDENTIAL_ASSET_POOL));
         primary_fungible_store::primary_store(pool_addr, token)
     }
 
     /// Returns the pool's primary fungible store for the given token, creating it if necessary.
-    fun ensure_pool_fa_store(token: Object<Metadata>): Object<FungibleStore> acquires FAController {
+    fun ensure_pool_fa_store(token: Object<Metadata>): Object<FungibleStore> acquires GlobalConfig {
         primary_fungible_store::ensure_primary_store_exists(get_fa_store_address(), token)
     }
 
@@ -1472,8 +1459,8 @@ module aptos_experimental::confidential_asset {
     }
 
     /// Returns an object for handling the `FAConfig`, and returns a signer for it.
-    fun get_fa_config_signer(token: Object<Metadata>): signer acquires FAController {
-        let fa_ext = &borrow_global<FAController>(@aptos_experimental).extend_ref;
+    fun get_fa_config_signer(token: Object<Metadata>): signer acquires GlobalConfig {
+        let fa_ext = &borrow_global<GlobalConfig>(@aptos_experimental).extend_ref;
         let fa_ext_signer = object::generate_signer_for_extending(fa_ext);
 
         let fa_ctor = &object::create_named_object(&fa_ext_signer, construct_fa_seed(token));
@@ -1482,8 +1469,8 @@ module aptos_experimental::confidential_asset {
     }
 
     /// Returns the address that handles primary FA store and `FAConfig` objects for the specified token.
-    fun get_fa_config_address(token: Object<Metadata>): address acquires FAController {
-        let fa_ext = &borrow_global<FAController>(@aptos_experimental).extend_ref;
+    fun get_fa_config_address(token: Object<Metadata>): address acquires GlobalConfig {
+        let fa_ext = &borrow_global<GlobalConfig>(@aptos_experimental).extend_ref;
         let fa_ext_address = object::address_from_extend_ref(fa_ext);
 
         object::create_object_address(&fa_ext_address, construct_fa_seed(token))
@@ -1540,7 +1527,7 @@ module aptos_experimental::confidential_asset {
         transfer_amount: &confidential_balance::ConfidentialBalance,
         auditor_eks: &vector<twisted_elgamal::CompressedPubkey>,
         auditor_amounts: &vector<confidential_balance::ConfidentialBalance>,
-        proof: &TransferProof): bool acquires FAConfig, FAController
+        proof: &TransferProof): bool acquires FAConfig, GlobalConfig
     {
         if (
             !auditor_amounts.all(|auditor_amount| {
@@ -1557,7 +1544,7 @@ module aptos_experimental::confidential_asset {
             return false
         };
 
-        let chain_auditor_ek_opt = borrow_global<FAController>(@aptos_experimental).chain_auditor_ek;
+        let chain_auditor_ek_opt = borrow_global<GlobalConfig>(@aptos_experimental).chain_auditor_ek;
         assert!(chain_auditor_ek_opt.is_some(), error::invalid_state(ECHAIN_AUDITOR_NOT_SET));
 
         let asset_auditor_ek_opt = get_asset_auditor(token);
@@ -1670,7 +1657,7 @@ module aptos_experimental::confidential_asset {
     public fun register_for_testing(
         sender: &signer,
         token: Object<Metadata>,
-        ek: vector<u8>) acquires FAController, FAConfig
+        ek: vector<u8>) acquires GlobalConfig, FAConfig
     {
         let ek = twisted_elgamal::new_pubkey_from_bytes(ek).extract();
         register_internal(sender, token, ek);
@@ -1892,5 +1879,13 @@ module aptos_experimental::confidential_asset {
         assert!(evts.length() > 0, 195);
         let e = &evts[evts.length() - 1];
         assert!(e.new_epoch == expected_epoch, 196);
+    }
+
+    #[test_only]
+    public fun assert_last_chain_auditor_admin_changed_event(expected_admin: address) {
+        let evts = event::emitted_events<ChainAuditorAdminChanged>();
+        assert!(evts.length() > 0, 197);
+        let e = &evts[evts.length() - 1];
+        assert!(e.new_admin == expected_admin, 198);
     }
 }

--- a/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
+++ b/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
@@ -405,6 +405,57 @@ module aptos_experimental::confidential_asset {
         register_internal(sender, token, ek);
     }
 
+    /// Atomically [`register`], [`deposit`], and [`rollover_pending_balance`] for first-time users — public
+    /// FA lands as spendable confidential (actual) balance in one tx. Aborts with
+    /// [`ECA_STORE_ALREADY_PUBLISHED`] if the sender is already registered.
+    public entry fun register_and_deposit_and_rollover_pending_balance(
+        sender: &signer,
+        token: Object<Metadata>,
+        amount: u64,
+        ek: vector<u8>,
+        registration_proof_commitment: vector<u8>,
+        registration_proof_response: vector<u8>) acquires ConfidentialAssetStore, GlobalConfig, FAConfig
+    {
+        // The fresh store created by `register` is `normalized = true` with empty actual_balance,
+        // so `deposit_and_rollover_pending_balance`'s normalized-state assertion passes — no need
+        // for a separate normalize step here.
+        register(sender, token, ek, registration_proof_commitment, registration_proof_response);
+        deposit_and_rollover_pending_balance(sender, token, amount);
+    }
+
+    /// Atomically [`deposit`] and [`rollover_pending_balance`] when the sender's actual balance is already
+    /// normalized — no proofs needed. Aborts with [`ENORMALIZATION_REQUIRED`] otherwise; use
+    /// [`deposit_and_normalize_and_rollover_pending_balance`] in that case.
+    public entry fun deposit_and_rollover_pending_balance(
+        sender: &signer,
+        token: Object<Metadata>,
+        amount: u64) acquires ConfidentialAssetStore, GlobalConfig, FAConfig
+    {
+        let user = signer::address_of(sender);
+        deposit_to_internal(sender, token, user, amount);
+        rollover_pending_balance_internal(sender, token);
+    }
+
+    /// Atomically [`deposit`], [`normalize`] the actual balance, and [`rollover_pending_balance`] when the
+    /// sender's actual balance is NOT normalized. Same proof arguments as [`normalize`]. Aborts with
+    /// [`EALREADY_NORMALIZED`] if already normalized; use [`deposit_and_rollover_pending_balance`] then.
+    public entry fun deposit_and_normalize_and_rollover_pending_balance(
+        sender: &signer,
+        token: Object<Metadata>,
+        amount: u64,
+        new_balance: vector<u8>,
+        zkrp_new_balance: vector<u8>,
+        sigma_proof: vector<u8>) acquires ConfidentialAssetStore, GlobalConfig, FAConfig
+    {
+        let new_balance = confidential_balance::new_actual_balance_from_bytes(new_balance).extract();
+        let proof = confidential_proof::deserialize_normalization_proof(sigma_proof, zkrp_new_balance).extract();
+
+        let user = signer::address_of(sender);
+        deposit_to_internal(sender, token, user, amount);
+        normalize_internal(sender, token, new_balance, proof);
+        rollover_pending_balance_internal(sender, token);
+    }
+
     /// Brings tokens into the protocol, transferring the passed amount from the sender's primary FA store
     /// to the pending balance of the recipient.
     /// The initial confidential balance is publicly visible, as entering the protocol requires a normal transfer.
@@ -606,6 +657,22 @@ module aptos_experimental::confidential_asset {
         sender: &signer,
         token: Object<Metadata>) acquires ConfidentialAssetStore
     {
+        rollover_pending_balance_internal(sender, token);
+    }
+
+    /// Atomically [`normalize`] the actual balance and [`rollover_pending_balance`] in one transaction. Takes the
+    /// same proof arguments as [`normalize`].
+    public entry fun normalize_and_rollover_pending_balance(
+        sender: &signer,
+        token: Object<Metadata>,
+        new_balance: vector<u8>,
+        zkrp_new_balance: vector<u8>,
+        sigma_proof: vector<u8>) acquires ConfidentialAssetStore
+    {
+        let new_balance = confidential_balance::new_actual_balance_from_bytes(new_balance).extract();
+        let proof = confidential_proof::deserialize_normalization_proof(sigma_proof, zkrp_new_balance).extract();
+
+        normalize_internal(sender, token, new_balance, proof);
         rollover_pending_balance_internal(sender, token);
     }
 

--- a/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
+++ b/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
@@ -158,19 +158,6 @@ module aptos_experimental::confidential_asset {
         ek: twisted_elgamal::CompressedPubkey,
     }
 
-    /// One entry in an auditor key history vector — used for both the chain-level auditor
-    /// (on [`GlobalConfig`]) and the per-asset auditor (on [`FAConfig`]). Rotated keys are
-    /// retained so transfers stamped with a prior epoch can still be decrypted.
-    struct AuditorEntry has store, drop, copy {
-        ek: twisted_elgamal::CompressedPubkey,
-        /// First epoch in which `ek` was the active auditor key. Monotonically increasing
-        /// per layer (chain or asset).
-        activated_at_epoch: u64,
-        /// Epoch at which this entry was deactivated (i.e. the `activated_at_epoch` of its
-        /// successor). `0` means the entry is still the active key.
-        deactivated_at_epoch: u64,
-    }
-
     /// Global configuration for confidential assets: primary FA stores, `FAConfig` derivation, and chain-level auditor state.
     struct GlobalConfig has key {
         /// Indicates whether the allow list is enabled. If `true`, only tokens from the allow list can be transferred.
@@ -191,13 +178,9 @@ module aptos_experimental::confidential_asset {
         chain_auditor_admin: Option<address>,
 
         /// Bumped on every [`set_chain_auditor`] call (including clears). Stamped on each
-        /// [`Transferred`] event.
+        /// [`Transferred`] event so off-chain auditors / gateways can identify which
+        /// historical chain-auditor key was in force at that transfer.
         chain_auditor_epoch: u64,
-
-        /// Append-only history of chain auditor keys. Each entry's
-        /// `[activated_at_epoch, deactivated_at_epoch)` half-open interval is the range
-        /// of `chain_auditor_epoch` values during which it was active.
-        chain_auditor_history: vector<AuditorEntry>,
     }
 
     /// Represents the configuration of a token.
@@ -212,12 +195,10 @@ module aptos_experimental::confidential_asset {
         /// [`set_asset_auditor`] by the FA metadata object's root owner.
         asset_auditor_ek: Option<twisted_elgamal::CompressedPubkey>,
 
-        /// Bumped on every [`set_asset_auditor`] call. Stamped on each [`Transferred`]
-        /// event for this asset.
+        /// Bumped on every [`set_asset_auditor`] call (including clears). Stamped on each
+        /// [`Transferred`] event for this asset so off-chain auditors / gateways can
+        /// identify which historical asset-auditor key was in force at that transfer.
         asset_auditor_epoch: u64,
-
-        /// Append-only history of asset auditor keys. See [`AuditorEntry`].
-        asset_auditor_history: vector<AuditorEntry>,
     }
 
     //
@@ -295,9 +276,9 @@ module aptos_experimental::confidential_asset {
         /// Value of [`FAConfig.asset_auditor_epoch`] for this asset at the time of the
         /// transfer. `0` only when [`set_asset_auditor`] has never been called for this
         /// asset; once called (including a clear with empty bytes) the epoch is bumped
-        /// and stamped here even if the current `asset_auditor_ek` is `None`. Consult
-        /// [`FAConfig.asset_auditor_history`] to recover the key (if any) active at this
-        /// epoch.
+        /// and stamped here even if the current `asset_auditor_ek` is `None`. Off-chain
+        /// auditors / gateways resolve `(asset_type, asset_auditor_epoch)` to the active
+        /// key by indexing [`AssetAuditorChanged`] events.
         asset_auditor_epoch: u64,
     }
 
@@ -387,7 +368,6 @@ module aptos_experimental::confidential_asset {
             extend_ref: object::generate_extend_ref(global_config_ctor_ref),
             chain_auditor_ek: std::option::none(),
             chain_auditor_epoch: 0,
-            chain_auditor_history: vector[],
             chain_auditor_admin: std::option::none(),
         });
     }
@@ -716,7 +696,7 @@ module aptos_experimental::confidential_asset {
     }
 
     /// Sets, rotates, or clears the asset-specific auditor key for `token`. Pass an empty
-    /// `new_auditor_ek` to clear. Bumps `asset_auditor_epoch` and appends to history.
+    /// `new_auditor_ek` to clear. Bumps `asset_auditor_epoch` and emits [`AssetAuditorChanged`].
     ///
     /// Callable by `object::root_owner(token)`; aborts with [`ENOT_ASSET_ISSUER`] otherwise.
     /// Rotation invalidates pending transfer proofs (auditor key is bound into the
@@ -742,22 +722,6 @@ module aptos_experimental::confidential_asset {
         };
 
         let new_epoch = fa_config.asset_auditor_epoch + 1;
-        let prior_ek = fa_config.asset_auditor_ek;
-
-        if (prior_ek.is_some()) {
-            let history_len = fa_config.asset_auditor_history.length();
-            assert!(history_len > 0, error::internal(EINTERNAL_ERROR));
-            let prior_entry = fa_config.asset_auditor_history.borrow_mut(history_len - 1);
-            prior_entry.deactivated_at_epoch = new_epoch;
-        };
-
-        if (new_ek_opt.is_some()) {
-            fa_config.asset_auditor_history.push_back(AuditorEntry {
-                ek: *new_ek_opt.borrow(),
-                activated_at_epoch: new_epoch,
-                deactivated_at_epoch: 0,
-            });
-        };
 
         fa_config.asset_auditor_ek = new_ek_opt;
         fa_config.asset_auditor_epoch = new_epoch;
@@ -785,7 +749,7 @@ module aptos_experimental::confidential_asset {
 
     /// Sets, rotates, or clears the chain-level auditor key. Pass an empty
     /// `new_chain_auditor_ek` to clear (which disables all confidential transfers until a
-    /// successor is set). Bumps `chain_auditor_epoch` and appends to history.
+    /// successor is set). Bumps `chain_auditor_epoch` and emits [`ChainAuditorChanged`].
     ///
     /// Callable only by [`GlobalConfig.chain_auditor_admin`]. Aborts with
     /// [`ECHAIN_AUDITOR_ADMIN_NOT_SET`] before an admin is assigned, or
@@ -815,22 +779,6 @@ module aptos_experimental::confidential_asset {
         };
 
         let new_epoch = global_config.chain_auditor_epoch + 1;
-        let prior_ek = global_config.chain_auditor_ek;
-
-        if (prior_ek.is_some()) {
-            let history_len = global_config.chain_auditor_history.length();
-            assert!(history_len > 0, error::internal(EINTERNAL_ERROR));
-            let prior_entry = global_config.chain_auditor_history.borrow_mut(history_len - 1);
-            prior_entry.deactivated_at_epoch = new_epoch;
-        };
-
-        if (new_ek_opt.is_some()) {
-            global_config.chain_auditor_history.push_back(AuditorEntry {
-                ek: *new_ek_opt.borrow(),
-                activated_at_epoch: new_epoch,
-                deactivated_at_epoch: 0,
-            });
-        };
 
         global_config.chain_auditor_ek = new_ek_opt;
         global_config.chain_auditor_epoch = new_epoch;
@@ -953,18 +901,6 @@ module aptos_experimental::confidential_asset {
     }
 
     #[view]
-    /// Append-only history of asset auditor keys for `token`.
-    public fun get_asset_auditor_history(
-        token: Object<Metadata>): vector<AuditorEntry> acquires FAConfig, GlobalConfig
-    {
-        let fa_config_address = get_fa_config_address(token);
-        if (!exists<FAConfig>(fa_config_address)) {
-            return vector[];
-        };
-        borrow_global<FAConfig>(fa_config_address).asset_auditor_history
-    }
-
-    #[view]
     /// Chain auditor encryption key, or `None` if unset.
     public fun get_chain_auditor(): Option<twisted_elgamal::CompressedPubkey> acquires GlobalConfig {
         borrow_global<GlobalConfig>(@aptos_experimental).chain_auditor_ek
@@ -974,12 +910,6 @@ module aptos_experimental::confidential_asset {
     /// Chain auditor epoch. `0` before any chain auditor has been configured.
     public fun get_chain_auditor_epoch(): u64 acquires GlobalConfig {
         borrow_global<GlobalConfig>(@aptos_experimental).chain_auditor_epoch
-    }
-
-    #[view]
-    /// Append-only history of chain auditor keys.
-    public fun get_chain_auditor_history(): vector<AuditorEntry> acquires GlobalConfig {
-        borrow_global<GlobalConfig>(@aptos_experimental).chain_auditor_history
     }
 
     #[view]
@@ -1421,7 +1351,6 @@ module aptos_experimental::confidential_asset {
                 allowed: false,
                 asset_auditor_ek: std::option::none(),
                 asset_auditor_epoch: 0,
-                asset_auditor_history: vector[],
             });
         };
 

--- a/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
+++ b/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
@@ -293,7 +293,11 @@ module aptos_experimental::confidential_asset {
         /// decrypted years after a key rotation.
         chain_auditor_epoch: u64,
         /// Value of [`FAConfig.asset_auditor_epoch`] for this asset at the time of the
-        /// transfer. `0` when this asset has no asset-level auditor configured.
+        /// transfer. `0` only when [`set_asset_auditor`] has never been called for this
+        /// asset; once called (including a clear with empty bytes) the epoch is bumped
+        /// and stamped here even if the current `asset_auditor_ek` is `None`. Consult
+        /// [`FAConfig.asset_auditor_history`] to recover the key (if any) active at this
+        /// epoch.
         asset_auditor_epoch: u64,
     }
 

--- a/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_gas_e2e_helpers.move
+++ b/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_gas_e2e_helpers.move
@@ -43,7 +43,9 @@ module aptos_experimental::confidential_gas_e2e_helpers {
         (new_balance_bytes, zkrp_new_balance, sigma_proof)
     }
 
-    /// Same as `pack_confidential_transfer_proof` with no voluntary auditors (`auditor_eks` empty).
+    /// Builds a transfer proof with no extra auditors. The chain-level auditor is fetched
+    /// from on-chain state and automatically placed at `auditor_eks[0]`, so the resulting
+    /// proof satisfies `validate_auditors` for any token without an asset auditor.
     public fun pack_confidential_transfer_proof_simple(
         chain_id: u8,
         sender: address,
@@ -63,7 +65,7 @@ module aptos_experimental::confidential_gas_e2e_helpers {
         vector<u8>,
         vector<u8>,
     ) {
-        let no_extra_auditors = vector::empty<CompressedPubkey>();
+        let auditors = build_auditor_list_with_chain_prefix(vector::empty<vector<u8>>());
         pack_confidential_transfer_proof_inner(
             chain_id,
             sender,
@@ -72,14 +74,71 @@ module aptos_experimental::confidential_gas_e2e_helpers {
             transfer_amount,
             new_balance_amount,
             token,
-            &no_extra_auditors,
+            &auditors,
             sender_auditor_hint,
         )
     }
 
-    /// Includes voluntary auditors (each 32-byte compressed pubkey) plus optional asset auditor
-    /// (first key) when `set_auditor` was called on-chain.
+    /// Builds a transfer proof and automatically prepends the on-chain chain-level auditor
+    /// at `auditor_eks[0]`. `extra_auditor_eks` (each 32-byte compressed pubkey) becomes
+    /// `auditor_eks[1..]` in order — i.e. the asset auditor (when set) followed by any
+    /// voluntary auditors.
     public fun pack_confidential_transfer_proof_with_auditors(
+        chain_id: u8,
+        sender: address,
+        recipient: address,
+        sender_dk: &Scalar,
+        transfer_amount: u64,
+        new_balance_amount: u128,
+        token: Object<Metadata>,
+        extra_auditor_eks: vector<vector<u8>>,
+        sender_auditor_hint: vector<u8>,
+    ): (
+        vector<u8>,
+        vector<u8>,
+        vector<u8>,
+        vector<u8>,
+        vector<u8>,
+        vector<u8>,
+        vector<u8>,
+        vector<u8>,
+    ) {
+        let auditors = build_auditor_list_with_chain_prefix(extra_auditor_eks);
+        pack_confidential_transfer_proof_inner(
+            chain_id,
+            sender,
+            recipient,
+            sender_dk,
+            transfer_amount,
+            new_balance_amount,
+            token,
+            &auditors,
+            sender_auditor_hint,
+        )
+    }
+
+    fun build_auditor_list_with_chain_prefix(
+        extra_auditor_eks: vector<vector<u8>>): vector<CompressedPubkey>
+    {
+        let chain_ek = confidential_asset::get_chain_auditor().extract();
+        let acc = vector[chain_ek];
+        let len = extra_auditor_eks.length();
+        let i = 0;
+        while (i < len) {
+            vector::push_back(
+                &mut acc,
+                twisted_elgamal::new_pubkey_from_bytes(extra_auditor_eks[i]).extract(),
+            );
+            i = i + 1;
+        };
+        acc
+    }
+
+    /// Like [`pack_confidential_transfer_proof_with_auditors`] but uses `auditor_eks` *verbatim*
+    /// without prepending the chain-level auditor. Used by rejection-path e2e tests that need
+    /// to construct intentionally invalid auditor prefixes (wrong slot 0, missing prefix,
+    /// post-rotation old key).
+    public fun pack_confidential_transfer_proof_verbatim(
         chain_id: u8,
         sender: address,
         recipient: address,
@@ -99,18 +158,15 @@ module aptos_experimental::confidential_gas_e2e_helpers {
         vector<u8>,
         vector<u8>,
     ) {
-        let parsed = {
-            let acc = vector::empty<CompressedPubkey>();
-            let len = auditor_eks.length();
-            let i = 0;
-            while (i < len) {
-                vector::push_back(
-                    &mut acc,
-                    twisted_elgamal::new_pubkey_from_bytes(auditor_eks[i]).extract(),
-                );
-                i = i + 1;
-            };
-            acc
+        let parsed = vector::empty<CompressedPubkey>();
+        let len = auditor_eks.length();
+        let i = 0;
+        while (i < len) {
+            vector::push_back(
+                &mut parsed,
+                twisted_elgamal::new_pubkey_from_bytes(auditor_eks[i]).extract(),
+            );
+            i = i + 1;
         };
         pack_confidential_transfer_proof_inner(
             chain_id,

--- a/aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_asset_tests.move
+++ b/aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_asset_tests.move
@@ -260,6 +260,39 @@ module aptos_experimental::confidential_asset_tests {
         );
     }
 
+    fun normalize_and_rollover(
+        sender: &signer,
+        sender_dk: &Scalar,
+        token: Object<Metadata>,
+        amount: u128)
+    {
+        let from = signer::address_of(sender);
+        let sender_ek = confidential_asset::encryption_key(from, token);
+        let current_balance = confidential_balance::decompress_balance(
+            &confidential_asset::actual_balance(from, token)
+        );
+
+        let (proof, new_balance) = confidential_proof::prove_normalization(
+            4u8, // test chain ID
+            from,
+            @aptos_experimental,
+            object::object_address(&token),
+            sender_dk,
+            &sender_ek,
+            amount,
+            &current_balance);
+
+        let (sigma_proof, zkrp_new_balance) = confidential_proof::serialize_normalization_proof(&proof);
+
+        confidential_asset::normalize_and_rollover_pending_balance(
+            sender,
+            token,
+            confidential_balance::balance_to_bytes(&new_balance),
+            zkrp_new_balance,
+            sigma_proof
+        );
+    }
+
     public fun set_up_for_confidential_asset_test(
         confidential_asset: &signer,
         aptos_fx: &signer,
@@ -420,6 +453,280 @@ module aptos_experimental::confidential_asset_tests {
 
         assert!(confidential_asset::verify_actual_balance(alice_addr, token, &alice_dk, 0), 1);
         assert!(confidential_asset::verify_pending_balance(alice_addr, token, &alice_dk, 100), 1);
+    }
+
+    // First-time combined entry point: register + deposit + rollover in one transaction. After
+    // success, the store is published, public FA moved into the protocol, and the deposited
+    // amount is in actual_balance (spendable) — not pending.
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        fa = @0xfa,
+        alice = @0xa1,
+        bob = @0xb0
+    )]
+    fun success_register_and_deposit_and_rollover_pending_balance(
+        confidential_asset: signer,
+        aptos_fx: signer,
+        fa: signer,
+        alice: signer,
+        bob: signer)
+    {
+        let token = set_up_for_confidential_asset_test(&confidential_asset, &aptos_fx, &fa, &alice, &bob, 500, 500);
+
+        let alice_addr = signer::address_of(&alice);
+        let (alice_dk, alice_ek) = generate_twisted_elgamal_keypair();
+        let (commitment, response) = confidential_proof::prove_registration(
+            4u8,
+            alice_addr,
+            @aptos_experimental,
+            &alice_dk,
+            &alice_ek,
+            object::object_address(&token),
+        );
+
+        confidential_asset::register_and_deposit_and_rollover_pending_balance(
+            &alice,
+            token,
+            100,
+            twisted_elgamal::pubkey_to_bytes(&alice_ek),
+            commitment,
+            response,
+        );
+
+        assert!(confidential_asset::has_confidential_asset_store(alice_addr, token), 1);
+        assert!(primary_fungible_store::balance(alice_addr, token) == 400, 2);
+        // Funds landed in actual (spendable), not pending. Pending is empty after rollover.
+        assert!(confidential_asset::verify_actual_balance(alice_addr, token, &alice_dk, 100), 3);
+        assert!(confidential_asset::verify_pending_balance(alice_addr, token, &alice_dk, 0), 4);
+    }
+
+    // Submitting a malformed registration proof through the combined entry must abort before any
+    // state mutates: store is not created, fungible balance is not moved, no rollover happens.
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        fa = @0xfa,
+        alice = @0xa1,
+        bob = @0xb0
+    )]
+    #[expected_failure(abort_code = 65537, location = aptos_experimental::confidential_proof)]
+    fun fail_register_and_deposit_and_rollover_with_bad_registration_proof(
+        confidential_asset: signer,
+        aptos_fx: signer,
+        fa: signer,
+        alice: signer,
+        bob: signer)
+    {
+        let token = set_up_for_confidential_asset_test(&confidential_asset, &aptos_fx, &fa, &alice, &bob, 500, 500);
+
+        let alice_addr = signer::address_of(&alice);
+        let (alice_dk, alice_ek) = generate_twisted_elgamal_keypair();
+        let (_other_dk, other_ek) = generate_twisted_elgamal_keypair();
+
+        // Build a registration proof for `alice_ek` but submit it alongside a different `ek`.
+        // verify_registration_proof recomputes the challenge against the *submitted* ek and the
+        // proof fails Schnorr verification.
+        let (commitment, response) = confidential_proof::prove_registration(
+            4u8,
+            alice_addr,
+            @aptos_experimental,
+            &alice_dk,
+            &alice_ek,
+            object::object_address(&token),
+        );
+
+        confidential_asset::register_and_deposit_and_rollover_pending_balance(
+            &alice,
+            token,
+            100,
+            twisted_elgamal::pubkey_to_bytes(&other_ek),
+            commitment,
+            response,
+        );
+    }
+
+    // The combined entry aborts when the sender is already registered for the token.
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        fa = @0xfa,
+        alice = @0xa1,
+        bob = @0xb0
+    )]
+    #[expected_failure(abort_code = 524290, location = aptos_experimental::confidential_asset)]
+    fun fail_register_and_deposit_and_rollover_when_already_registered(
+        confidential_asset: signer,
+        aptos_fx: signer,
+        fa: signer,
+        alice: signer,
+        bob: signer)
+    {
+        let token = set_up_for_confidential_asset_test(&confidential_asset, &aptos_fx, &fa, &alice, &bob, 500, 500);
+
+        let alice_addr = signer::address_of(&alice);
+        let (alice_dk, alice_ek) = generate_twisted_elgamal_keypair();
+
+        confidential_asset::register_for_testing(&alice, token, twisted_elgamal::pubkey_to_bytes(&alice_ek));
+
+        let (commitment, response) = confidential_proof::prove_registration(
+            4u8,
+            alice_addr,
+            @aptos_experimental,
+            &alice_dk,
+            &alice_ek,
+            object::object_address(&token),
+        );
+
+        confidential_asset::register_and_deposit_and_rollover_pending_balance(
+            &alice,
+            token,
+            10,
+            twisted_elgamal::pubkey_to_bytes(&alice_ek),
+            commitment,
+            response,
+        );
+    }
+
+    // Subsequent combined entry (already registered, currently normalized): deposit + rollover.
+    // We arrange a normalized state by sending a confidential transfer first (which sets
+    // normalized=true on the sender's store).
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        fa = @0xfa,
+        alice = @0xa1,
+        bob = @0xb0
+    )]
+    fun success_deposit_and_rollover_pending_balance(
+        confidential_asset: signer,
+        aptos_fx: signer,
+        fa: signer,
+        alice: signer,
+        bob: signer)
+    {
+        let token = set_up_for_confidential_asset_test(&confidential_asset, &aptos_fx, &fa, &alice, &bob, 500, 500);
+
+        let alice_addr = signer::address_of(&alice);
+        let bob_addr = signer::address_of(&bob);
+        let (alice_dk, alice_ek) = generate_twisted_elgamal_keypair();
+        let (_bob_dk, bob_ek) = generate_twisted_elgamal_keypair();
+
+        confidential_asset::register_for_testing(&alice, token, twisted_elgamal::pubkey_to_bytes(&alice_ek));
+        confidential_asset::register_for_testing(&bob, token, twisted_elgamal::pubkey_to_bytes(&bob_ek));
+
+        // Bring Alice into a normalized=true state. After register_for_testing, deposit, then
+        // rollover, normalized=false. After a confidential_transfer the sender's store is set
+        // normalized=true, which is the precondition this entry point asserts.
+        confidential_asset::deposit(&alice, token, 100);
+        confidential_asset::rollover_pending_balance(&alice, token);
+        transfer(&alice, &alice_dk, token, bob_addr, 1, 99, vector[]);
+        // sanity-check our setup
+        assert!(confidential_asset::is_normalized(alice_addr, token), 99);
+
+        // Now exercise the combined entry: deposit + rollover, no normalize required.
+        confidential_asset::deposit_and_rollover_pending_balance(&alice, token, 50);
+
+        // 99 (post-transfer actual) + 50 (just deposited) = 149 in actual; pending empty.
+        assert!(confidential_asset::verify_actual_balance(alice_addr, token, &alice_dk, 149), 1);
+        assert!(confidential_asset::verify_pending_balance(alice_addr, token, &alice_dk, 0), 2);
+    }
+
+    // `deposit_and_rollover_pending_balance` aborts when the actual balance is not normalized.
+    // The state arrives after any prior `rollover_pending_balance` (which sets normalized=false),
+    // so this is the common post-make-private state and the wallet must route to
+    // `deposit_and_normalize_and_rollover_pending_balance` instead.
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        fa = @0xfa,
+        alice = @0xa1,
+        bob = @0xb0
+    )]
+    #[expected_failure(abort_code = 196618, location = aptos_experimental::confidential_asset)]
+    fun fail_deposit_and_rollover_when_not_normalized(
+        confidential_asset: signer,
+        aptos_fx: signer,
+        fa: signer,
+        alice: signer,
+        bob: signer)
+    {
+        let token = set_up_for_confidential_asset_test(&confidential_asset, &aptos_fx, &fa, &alice, &bob, 500, 500);
+
+        let alice_addr = signer::address_of(&alice);
+        let (_alice_dk, alice_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::register_for_testing(&alice, token, twisted_elgamal::pubkey_to_bytes(&alice_ek));
+
+        // After deposit + rollover, normalized=false. Subsequent combined call must abort.
+        confidential_asset::deposit(&alice, token, 100);
+        confidential_asset::rollover_pending_balance(&alice, token);
+        assert!(!confidential_asset::is_normalized(alice_addr, token), 99);
+
+        confidential_asset::deposit_and_rollover_pending_balance(&alice, token, 50);
+    }
+
+    // Subsequent combined entry with normalize: deposit + normalize + rollover. Used after a
+    // prior rollover (which left the store with normalized=false). After this call, normalized
+    // is back to false (rollover always sets it false), but the actual balance is the canonical
+    // sum so the next deposit-then-rollover call goes through the same path.
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        fa = @0xfa,
+        alice = @0xa1,
+        bob = @0xb0
+    )]
+    fun success_deposit_and_normalize_and_rollover_pending_balance(
+        confidential_asset: signer,
+        aptos_fx: signer,
+        fa: signer,
+        alice: signer,
+        bob: signer)
+    {
+        let token = set_up_for_confidential_asset_test(&confidential_asset, &aptos_fx, &fa, &alice, &bob, 500, 500);
+
+        let alice_addr = signer::address_of(&alice);
+        let (alice_dk, alice_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::register_for_testing(&alice, token, twisted_elgamal::pubkey_to_bytes(&alice_ek));
+
+        // Establish a normalized=false state (deposit then rollover).
+        confidential_asset::deposit(&alice, token, 100);
+        confidential_asset::rollover_pending_balance(&alice, token);
+        assert!(!confidential_asset::is_normalized(alice_addr, token), 99);
+
+        // Build the normalize proof off-chain against the *current* actual balance (100).
+        // `deposit_to_internal` only mutates pending, so the actual balance the proof is bound
+        // to matches the actual balance at on-chain `normalize_internal` time.
+        let cid = 4u8;
+        let sender_ek = confidential_asset::encryption_key(alice_addr, token);
+        let current_actual = confidential_balance::decompress_balance(
+            &confidential_asset::actual_balance(alice_addr, token)
+        );
+        let (proof, new_balance) = confidential_proof::prove_normalization(
+            cid,
+            alice_addr,
+            @aptos_experimental,
+            object::object_address(&token),
+            &alice_dk,
+            &sender_ek,
+            100,
+            &current_actual,
+        );
+        let new_balance_bytes = confidential_balance::balance_to_bytes(&new_balance);
+        let (sigma, zkrp) = confidential_proof::serialize_normalization_proof(&proof);
+
+        // deposit 30, then normalize, then rollover → actual = 100 + 30 = 130.
+        confidential_asset::deposit_and_normalize_and_rollover_pending_balance(
+            &alice,
+            token,
+            30,
+            new_balance_bytes,
+            zkrp,
+            sigma,
+        );
+
+        assert!(confidential_asset::verify_actual_balance(alice_addr, token, &alice_dk, 130), 1);
+        assert!(confidential_asset::verify_pending_balance(alice_addr, token, &alice_dk, 0), 2);
     }
 
     #[test(
@@ -757,6 +1064,82 @@ module aptos_experimental::confidential_asset_tests {
         assert!(confidential_asset::is_normalized(alice_addr, token));
         assert!(
             confidential_asset::verify_actual_balance(alice_addr, token, &alice_dk, (2 * max_chunk_value as u128)), 1);
+    }
+
+    // `normalize_and_rollover_pending_balance` from an unnormalized state combines the two
+    // steps in one tx. After: pending is empty, balance becomes (old available + pending),
+    // and `normalized` is back to `false` (rollover resets it).
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        fa = @0xfa,
+        alice = @0xa1,
+        bob = @0xb0
+    )]
+    fun success_normalize_and_rollover_from_unnormalized(
+        confidential_asset: signer,
+        aptos_fx: signer,
+        fa: signer,
+        alice: signer,
+        bob: signer)
+    {
+        let max_chunk_value = 1 << 16 - 1;
+        let token = set_up_for_confidential_asset_test(
+            &confidential_asset, &aptos_fx, &fa, &alice, &bob,
+            max_chunk_value + 50, max_chunk_value);
+
+        let alice_addr = signer::address_of(&alice);
+        let (alice_dk, alice_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::register_for_testing(&alice, token, twisted_elgamal::pubkey_to_bytes(&alice_ek));
+
+        // Two deposits + a rollover stack max-chunk values into a single chunk, leaving the
+        // available balance unnormalized.
+        confidential_asset::deposit(&alice, token, max_chunk_value);
+        confidential_asset::deposit_to(&bob, token, alice_addr, max_chunk_value);
+        confidential_asset::rollover_pending_balance(&alice, token);
+        assert!(!confidential_asset::is_normalized(alice_addr, token), 1);
+
+        // A fresh deposit lands in pending; the combined entry must roll it in.
+        confidential_asset::deposit(&alice, token, 50);
+
+        let total: u128 = (2 * max_chunk_value as u128) + 50;
+        normalize_and_rollover(&alice, &alice_dk, token, (2 * max_chunk_value as u128));
+
+        // Available reflects normalized old + pending; not normalized
+        // (rollover always leaves the merged balance unnormalized — same as plain rollover).
+        assert!(!confidential_asset::is_normalized(alice_addr, token), 3);
+        assert!(
+            confidential_asset::verify_actual_balance(alice_addr, token, &alice_dk, total), 5);
+    }
+
+    // Calling `normalize_and_rollover_pending_balance` while already normalized aborts at
+    // the `normalize_internal` step (`EALREADY_NORMALIZED`, invalid_state = category 3).
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        fa = @0xfa,
+        alice = @0xa1,
+        bob = @0xb0
+    )]
+    #[expected_failure(abort_code = 0x03000B, location = aptos_experimental::confidential_asset)]
+    fun fail_normalize_and_rollover_when_already_normalized(
+        confidential_asset: signer,
+        aptos_fx: signer,
+        fa: signer,
+        alice: signer,
+        bob: signer)
+    {
+        let token = set_up_for_confidential_asset_test(
+            &confidential_asset, &aptos_fx, &fa, &alice, &bob, 500, 500);
+        let alice_addr = signer::address_of(&alice);
+        let (alice_dk, alice_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::register_for_testing(&alice, token, twisted_elgamal::pubkey_to_bytes(&alice_ek));
+
+        // A freshly registered store starts with `normalized == true` and an empty available
+        // balance, so the wrapper must abort at `normalize_internal`'s `EALREADY_NORMALIZED`.
+        assert!(confidential_asset::is_normalized(alice_addr, token), 1);
+
+        normalize_and_rollover(&alice, &alice_dk, token, 0);
     }
 
     #[test(

--- a/aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_asset_tests.move
+++ b/aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_asset_tests.move
@@ -292,10 +292,13 @@ module aptos_experimental::confidential_asset_tests {
 
         features::change_feature_flags_for_testing(aptos_fx, vector[features::get_bulletproofs_feature()], vector[]);
 
-        // Every confidential transfer requires the chain-level auditor to be set, so the
-        // shared setup configures it with a deterministic-but-fresh keypair. Tests that
-        // need direct access to the chain auditor's keys can call
-        // `set_chain_auditor_for_test` themselves to override.
+        // Every confidential transfer requires the chain-level auditor to be set. Since
+        // `set_chain_auditor` is now gated on the chain-auditor admin (governance does
+        // *not* hold rotation authority directly), governance first delegates the admin
+        // role to `aptos_fx` itself in tests so the shared setup can install a fresh key
+        // without standing up a separate admin account. Tests that exercise the
+        // governance-vs-admin separation install their own admin.
+        confidential_asset::set_chain_auditor_admin(aptos_fx, signer::address_of(aptos_fx));
         let (_chain_dk, chain_ek) = generate_twisted_elgamal_keypair();
         confidential_asset::set_chain_auditor(aptos_fx, twisted_elgamal::pubkey_to_bytes(&chain_ek));
 
@@ -1370,6 +1373,7 @@ module aptos_experimental::confidential_asset_tests {
         features::change_feature_flags_for_testing(
             aptos_fx, vector[features::get_bulletproofs_feature()], vector[]
         );
+        confidential_asset::set_chain_auditor_admin(aptos_fx, signer::address_of(aptos_fx));
         let (_, chain_ek) = generate_twisted_elgamal_keypair();
         confidential_asset::set_chain_auditor(aptos_fx, twisted_elgamal::pubkey_to_bytes(&chain_ek));
     }
@@ -1459,7 +1463,8 @@ module aptos_experimental::confidential_asset_tests {
         // root_owner(token) == @0xfa, signer::address_of(&aptos_fx) == @0x1 — mismatch.
         confidential_asset::set_asset_auditor(&aptos_fx, token, twisted_elgamal::pubkey_to_bytes(&ek));
 
-        let _ = (fa, alice);
+        let _ = fa;
+        let _ = alice;
     }
 
     #[test(
@@ -1550,5 +1555,189 @@ module aptos_experimental::confidential_asset_tests {
         );
 
         let _ = alice;
+    }
+
+    // ============================================================================
+    // Chain-auditor admin authorization tests
+    //
+    // Movement governance does NOT directly hold rotation authority over the chain-level
+    // auditor key. Instead, governance designates a chain-auditor admin account via
+    // `set_chain_auditor_admin`, and only that account may subsequently call
+    // `set_chain_auditor`.
+    //
+    // The shared `set_up_for_confidential_asset_test` helper papers over this by
+    // designating `aptos_fx` itself as the admin so other tests don't need to know the
+    // detail; the tests below stand up their own state (no shared setup) to exercise the
+    // authorization boundary directly.
+    // ============================================================================
+
+    /// Helper: minimal init without setting the chain-auditor admin or the chain auditor
+    /// itself, so admin-related tests can exercise the bootstrap path explicitly.
+    fun set_up_chain_admin_test(confidential_asset: &signer, aptos_fx: &signer) {
+        chain_id::initialize_for_test(aptos_fx, 4);
+        confidential_asset::init_module_for_testing(confidential_asset);
+        features::change_feature_flags_for_testing(
+            aptos_fx, vector[features::get_bulletproofs_feature()], vector[]
+        );
+    }
+
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        ca_admin = @0xCA
+    )]
+    /// Happy path: governance designates a chain-auditor admin, that admin then sets the
+    /// chain auditor. Verifies the admin view, the emitted admin-changed event, and that
+    /// the chain auditor key actually lands.
+    fun success_set_chain_auditor_by_designated_admin(
+        confidential_asset: signer, aptos_fx: signer, ca_admin: signer)
+    {
+        set_up_chain_admin_test(&confidential_asset, &aptos_fx);
+
+        // Admin starts unset.
+        assert!(confidential_asset::get_chain_auditor_admin().is_none(), 1);
+
+        // Governance designates ca_admin.
+        let ca_admin_addr = signer::address_of(&ca_admin);
+        confidential_asset::set_chain_auditor_admin(&aptos_fx, ca_admin_addr);
+        assert!(confidential_asset::get_chain_auditor_admin() == option::some(ca_admin_addr), 2);
+        confidential_asset::assert_last_chain_auditor_admin_changed_event(ca_admin_addr);
+
+        // Designated admin can install a chain auditor.
+        let (_, chain_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::set_chain_auditor(&ca_admin, twisted_elgamal::pubkey_to_bytes(&chain_ek));
+        assert!(confidential_asset::get_chain_auditor_epoch() == 1, 3);
+        assert!(confidential_asset::get_chain_auditor().is_some(), 4);
+    }
+
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        ca_admin = @0xCA
+    )]
+    /// Admin rotation: governance can hand the role to a successor account. The previous
+    /// admin loses authority; the new admin gains it.
+    fun success_chain_auditor_admin_rotation(
+        confidential_asset: signer, aptos_fx: signer, ca_admin: signer)
+    {
+        set_up_chain_admin_test(&confidential_asset, &aptos_fx);
+        let ca_admin_addr = signer::address_of(&ca_admin);
+        confidential_asset::set_chain_auditor_admin(&aptos_fx, ca_admin_addr);
+
+        // Rotate admin to a fresh address.
+        let new_admin_addr = @0xCAFE;
+        confidential_asset::set_chain_auditor_admin(&aptos_fx, new_admin_addr);
+        assert!(confidential_asset::get_chain_auditor_admin() == option::some(new_admin_addr), 1);
+        confidential_asset::assert_last_chain_auditor_admin_changed_event(new_admin_addr);
+
+        let _ = ca_admin;
+    }
+
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        not_gov = @0x9999
+    )]
+    #[expected_failure(abort_code = 0x50003, location = aptos_framework::system_addresses)]
+    /// Negative: only governance can designate the chain-auditor admin. A non-governance
+    /// signer hits `assert_aptos_framework` and aborts with the framework's standard
+    /// permission_denied code (0x50003).
+    fun fail_set_chain_auditor_admin_by_non_governance(
+        confidential_asset: signer, aptos_fx: signer, not_gov: signer)
+    {
+        set_up_chain_admin_test(&confidential_asset, &aptos_fx);
+        confidential_asset::set_chain_auditor_admin(&not_gov, @0xCA);
+    }
+
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework
+    )]
+    #[expected_failure(abort_code = 0x30017, location = confidential_asset)]
+    /// Negative bootstrap: before governance has assigned an admin, no one — not even
+    /// governance itself — can set the chain auditor. Aborts with
+    /// `ECHAIN_AUDITOR_ADMIN_NOT_SET` (0x17) under invalid_state (category 3).
+    fun fail_set_chain_auditor_when_admin_not_set(
+        confidential_asset: signer, aptos_fx: signer)
+    {
+        set_up_chain_admin_test(&confidential_asset, &aptos_fx);
+
+        let (_, chain_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::set_chain_auditor(&aptos_fx, twisted_elgamal::pubkey_to_bytes(&chain_ek));
+    }
+
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        ca_admin = @0xCA
+    )]
+    #[expected_failure(abort_code = 0x50018, location = confidential_asset)]
+    /// The separation property: once governance has designated a separate admin,
+    /// governance itself can no longer rotate the chain auditor. Aborts with
+    /// `ENOT_CHAIN_AUDITOR_ADMIN` (0x18) under permission_denied.
+    fun fail_set_chain_auditor_by_governance_when_admin_is_separate(
+        confidential_asset: signer, aptos_fx: signer, ca_admin: signer)
+    {
+        set_up_chain_admin_test(&confidential_asset, &aptos_fx);
+        confidential_asset::set_chain_auditor_admin(&aptos_fx, signer::address_of(&ca_admin));
+
+        let (_, chain_ek) = generate_twisted_elgamal_keypair();
+        // aptos_fx (governance) is no longer the admin — must abort.
+        confidential_asset::set_chain_auditor(&aptos_fx, twisted_elgamal::pubkey_to_bytes(&chain_ek));
+
+        let _ = ca_admin;
+    }
+
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        ca_admin = @0xCA,
+        stranger = @0x1234
+    )]
+    #[expected_failure(abort_code = 0x50018, location = confidential_asset)]
+    /// Negative: an arbitrary third party who is neither governance nor the designated
+    /// admin cannot rotate the chain auditor.
+    fun fail_set_chain_auditor_by_stranger(
+        confidential_asset: signer, aptos_fx: signer, ca_admin: signer, stranger: signer)
+    {
+        set_up_chain_admin_test(&confidential_asset, &aptos_fx);
+        confidential_asset::set_chain_auditor_admin(&aptos_fx, signer::address_of(&ca_admin));
+
+        let (_, chain_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::set_chain_auditor(&stranger, twisted_elgamal::pubkey_to_bytes(&chain_ek));
+
+        let _ = ca_admin;
+    }
+
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        ca_admin1 = @0xCA1,
+        ca_admin2 = @0xCA2
+    )]
+    #[expected_failure(abort_code = 0x50018, location = confidential_asset)]
+    /// Rotation revokes the prior admin: after governance moves the role from ca_admin1
+    /// to ca_admin2, ca_admin1 loses authority.
+    fun fail_set_chain_auditor_by_revoked_admin(
+        confidential_asset: signer,
+        aptos_fx: signer,
+        ca_admin1: signer,
+        ca_admin2: signer)
+    {
+        set_up_chain_admin_test(&confidential_asset, &aptos_fx);
+        confidential_asset::set_chain_auditor_admin(&aptos_fx, signer::address_of(&ca_admin1));
+
+        // ca_admin1 sets a key successfully.
+        let (_, ek1) = generate_twisted_elgamal_keypair();
+        confidential_asset::set_chain_auditor(&ca_admin1, twisted_elgamal::pubkey_to_bytes(&ek1));
+
+        // Governance rotates the admin role away from ca_admin1.
+        confidential_asset::set_chain_auditor_admin(&aptos_fx, signer::address_of(&ca_admin2));
+
+        // The former admin tries to rotate again — must abort.
+        let (_, ek2) = generate_twisted_elgamal_keypair();
+        confidential_asset::set_chain_auditor(&ca_admin1, twisted_elgamal::pubkey_to_bytes(&ek2));
+
+        let _ = ca_admin2;
     }
 }

--- a/aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_asset_tests.move
+++ b/aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_asset_tests.move
@@ -1303,10 +1303,10 @@ module aptos_experimental::confidential_asset_tests {
 
     #[test(confidential_asset = @aptos_experimental, aptos_fx = @aptos_framework,
         fa = @0xfa, alice = @0xa1, bob = @0xb0)]
-    /// Rotation history: each rotation bumps the epoch, appends to history, and stamps
-    /// the new epoch on subsequent transfers. Past entries close their
-    /// `deactivated_at_epoch` to the successor's `activated_at_epoch`.
-    fun success_chain_auditor_rotation_tracks_history(
+    /// Rotation: each rotation bumps the epoch and stamps the new epoch on subsequent
+    /// transfers. Off-chain auditors / gateways resolve epoch → key by indexing
+    /// `ChainAuditorChanged` / `AssetAuditorChanged` events.
+    fun success_auditor_rotation_bumps_epoch(
         confidential_asset: signer, aptos_fx: signer, fa: signer,
         alice: signer, bob: signer)
     {
@@ -1330,11 +1330,6 @@ module aptos_experimental::confidential_asset_tests {
         confidential_asset::set_chain_auditor(&aptos_fx, twisted_elgamal::pubkey_to_bytes(&ek3));
         assert!(confidential_asset::get_chain_auditor_epoch() == 3, 3);
 
-        // History has 3 entries; the first two are deactivated at the successor's epoch,
-        // and the active key has deactivated_at_epoch == 0.
-        let history = confidential_asset::get_chain_auditor_history();
-        assert!(history.length() == 3, 4);
-
         // Transfer stamps the *current* epoch (3) on the event.
         transfer(&alice, &alice_dk, token, bob_addr, 100, 200, vector[]);
         confidential_asset::assert_last_transferred_event_matches_state(
@@ -1349,9 +1344,7 @@ module aptos_experimental::confidential_asset_tests {
         assert!(confidential_asset::get_asset_auditor_epoch(token) == 2, 6);
         confidential_asset::set_asset_auditor(&fa, token, b"");
         assert!(confidential_asset::get_asset_auditor_epoch(token) == 3, 7);
-        // History contains both prior keys; after the clear there is no active asset auditor.
-        let asset_hist = confidential_asset::get_asset_auditor_history(token);
-        assert!(asset_hist.length() == 2, 8);
+        // After the clear there is no active asset auditor; the epoch keeps advancing.
         assert!(confidential_asset::get_asset_auditor(token).is_none(), 9);
     }
 

--- a/aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_asset_tests.move
+++ b/aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_asset_tests.move
@@ -487,7 +487,7 @@ module aptos_experimental::confidential_asset_tests {
         let (auditor2_dk, auditor2_ek) = generate_twisted_elgamal_keypair();
 
         confidential_asset::set_asset_auditor(
-            &aptos_fx,
+            &fa,
             token,
             twisted_elgamal::pubkey_to_bytes(&auditor1_ek));
 
@@ -540,7 +540,7 @@ module aptos_experimental::confidential_asset_tests {
         let (auditor2_dk, auditor2_ek) = generate_twisted_elgamal_keypair();
 
         confidential_asset::set_asset_auditor(
-            &aptos_fx,
+            &fa,
             token,
             twisted_elgamal::pubkey_to_bytes(&auditor1_ek));
 
@@ -604,7 +604,7 @@ module aptos_experimental::confidential_asset_tests {
         let (_, auditor2_ek) = generate_twisted_elgamal_keypair();
 
         confidential_asset::set_asset_auditor(
-            &aptos_fx,
+            &fa,
             token,
             twisted_elgamal::pubkey_to_bytes(&auditor1_ek));
 
@@ -856,13 +856,13 @@ module aptos_experimental::confidential_asset_tests {
         // --- set_asset_auditor emits AssetAuditorChanged with bumped epoch ---
         let (_, auditor_ek) = generate_twisted_elgamal_keypair();
         confidential_asset::set_asset_auditor(
-            &aptos_fx,
+            &fa,
             token,
             twisted_elgamal::pubkey_to_bytes(&auditor_ek));
         confidential_asset::assert_last_asset_auditor_changed_event(token, 1);
 
         // clear asset auditor — still bumps epoch and emits the event
-        confidential_asset::set_asset_auditor(&aptos_fx, token, b"");
+        confidential_asset::set_asset_auditor(&fa, token, b"");
         confidential_asset::assert_last_asset_auditor_changed_event(token, 2);
 
         // --- set_chain_auditor emits ChainAuditorChanged ---
@@ -1222,7 +1222,7 @@ module aptos_experimental::confidential_asset_tests {
         let (alice_dk, alice_ek) = generate_twisted_elgamal_keypair();
         let (_, bob_ek) = generate_twisted_elgamal_keypair();
         let (_, asset_aud_ek) = generate_twisted_elgamal_keypair();
-        confidential_asset::set_asset_auditor(&aptos_fx, token,
+        confidential_asset::set_asset_auditor(&fa, token,
             twisted_elgamal::pubkey_to_bytes(&asset_aud_ek));
         confidential_asset::register_for_testing(&alice, token, twisted_elgamal::pubkey_to_bytes(&alice_ek));
         confidential_asset::register_for_testing(&bob, token, twisted_elgamal::pubkey_to_bytes(&bob_ek));
@@ -1340,15 +1340,215 @@ module aptos_experimental::confidential_asset_tests {
         // Asset auditor history is independent. Set, rotate, clear.
         let (_, asset_ek1) = generate_twisted_elgamal_keypair();
         let (_, asset_ek2) = generate_twisted_elgamal_keypair();
-        confidential_asset::set_asset_auditor(&aptos_fx, token, twisted_elgamal::pubkey_to_bytes(&asset_ek1));
+        confidential_asset::set_asset_auditor(&fa, token, twisted_elgamal::pubkey_to_bytes(&asset_ek1));
         assert!(confidential_asset::get_asset_auditor_epoch(token) == 1, 5);
-        confidential_asset::set_asset_auditor(&aptos_fx, token, twisted_elgamal::pubkey_to_bytes(&asset_ek2));
+        confidential_asset::set_asset_auditor(&fa, token, twisted_elgamal::pubkey_to_bytes(&asset_ek2));
         assert!(confidential_asset::get_asset_auditor_epoch(token) == 2, 6);
-        confidential_asset::set_asset_auditor(&aptos_fx, token, b"");
+        confidential_asset::set_asset_auditor(&fa, token, b"");
         assert!(confidential_asset::get_asset_auditor_epoch(token) == 3, 7);
         // History contains both prior keys; after the clear there is no active asset auditor.
         let asset_hist = confidential_asset::get_asset_auditor_history(token);
         assert!(asset_hist.length() == 2, 8);
         assert!(confidential_asset::get_asset_auditor(token).is_none(), 9);
+    }
+
+    // ============================================================================
+    // Asset auditor authorization tests
+    //
+    // `set_asset_auditor` is gated by `object::root_owner(token) == signer::address_of(issuer)`.
+    // For framework-managed FAs (root = @0x1) only governance qualifies; for issuer-deployed
+    // FAs the account at the top of the metadata object's ownership chain qualifies — even
+    // if there are intermediate object owners (the USDCX-style "contract object owns FA,
+    // multisig owns contract" pattern).
+    // ============================================================================
+
+    /// Helper: chain auditor + module init + features, without minting or creating an FA.
+    /// Tests below create their own FA with custom ownership chains.
+    fun set_up_chain_only(confidential_asset: &signer, aptos_fx: &signer) {
+        chain_id::initialize_for_test(aptos_fx, 4);
+        confidential_asset::init_module_for_testing(confidential_asset);
+        features::change_feature_flags_for_testing(
+            aptos_fx, vector[features::get_bulletproofs_feature()], vector[]
+        );
+        let (_, chain_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::set_chain_auditor(aptos_fx, twisted_elgamal::pubkey_to_bytes(&chain_ek));
+    }
+
+    /// Helper: create a fresh FA owned directly by `creator_addr`.
+    fun create_fa_owned_by(creator_addr: address): Object<Metadata> {
+        let ctor_ref = &object::create_sticky_object(creator_addr);
+        primary_fungible_store::create_primary_store_enabled_fungible_asset(
+            ctor_ref,
+            option::none(),
+            utf8(b"MockToken"),
+            utf8(b"MT"),
+            18,
+            utf8(b"https://"),
+            utf8(b"https://"),
+        );
+        object::object_from_constructor_ref<Metadata>(ctor_ref)
+    }
+
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        fa = @0xfa,
+        alice = @0xa1
+    )]
+    /// Direct-ownership case: the FA creator is the root owner of the metadata object,
+    /// so they can rotate the asset auditor. Mirrors the issuer-deployed FA shape where
+    /// no intermediate object sits between the issuer account and the FA.
+    fun success_set_asset_auditor_by_direct_root_owner(
+        confidential_asset: signer, aptos_fx: signer, fa: signer, alice: signer)
+    {
+        set_up_chain_only(&confidential_asset, &aptos_fx);
+        let token = create_fa_owned_by(signer::address_of(&fa));
+
+        // Sanity: direct owner == root owner == fa.
+        assert!(object::owner(token) == signer::address_of(&fa), 1);
+        assert!(object::root_owner(token) == signer::address_of(&fa), 2);
+
+        let (_, ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::set_asset_auditor(&fa, token, twisted_elgamal::pubkey_to_bytes(&ek));
+        assert!(confidential_asset::get_asset_auditor_epoch(token) == 1, 3);
+        assert!(confidential_asset::get_asset_auditor(token).is_some(), 4);
+
+        // Silence unused-binding warning for `alice` (kept in the test signature so the
+        // address space matches sibling tests).
+        let _ = alice;
+    }
+
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        fa = @0xfa,
+        alice = @0xa1
+    )]
+    #[expected_failure(abort_code = 0x50016, location = confidential_asset)]
+    /// Negative: a non-owner signer is rejected. `alice` did not create the FA and is not
+    /// in the ownership chain, so root_owner != alice and the call aborts with
+    /// `ENOT_ASSET_ISSUER` (0x16) under permission_denied (category 5).
+    fun fail_set_asset_auditor_if_not_root_owner(
+        confidential_asset: signer, aptos_fx: signer, fa: signer, alice: signer)
+    {
+        set_up_chain_only(&confidential_asset, &aptos_fx);
+        let token = create_fa_owned_by(signer::address_of(&fa));
+
+        let (_, ek) = generate_twisted_elgamal_keypair();
+        // Alice is not the root owner — must abort.
+        confidential_asset::set_asset_auditor(&alice, token, twisted_elgamal::pubkey_to_bytes(&ek));
+    }
+
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        fa = @0xfa,
+        alice = @0xa1
+    )]
+    #[expected_failure(abort_code = 0x50016, location = confidential_asset)]
+    /// Negative: governance cannot rotate the auditor of an issuer-deployed FA. This is
+    /// the intended authorization shift — `aptos_framework` no longer has implicit
+    /// authority over per-asset auditors; only the FA's root owner does.
+    fun fail_set_asset_auditor_by_aptos_framework_for_issuer_fa(
+        confidential_asset: signer, aptos_fx: signer, fa: signer, alice: signer)
+    {
+        set_up_chain_only(&confidential_asset, &aptos_fx);
+        let token = create_fa_owned_by(signer::address_of(&fa));
+
+        let (_, ek) = generate_twisted_elgamal_keypair();
+        // root_owner(token) == @0xfa, signer::address_of(&aptos_fx) == @0x1 — mismatch.
+        confidential_asset::set_asset_auditor(&aptos_fx, token, twisted_elgamal::pubkey_to_bytes(&ek));
+
+        let _ = (fa, alice);
+    }
+
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        alice = @0xa1
+    )]
+    /// Framework-managed FA: when the FA is created with `@aptos_framework` (= @0x1) as
+    /// the creator, root_owner returns @0x1 and only governance — via the
+    /// `aptos_framework` signer — can rotate the auditor. Models a canonical framework
+    /// FA like APT at @0xa.
+    fun success_set_asset_auditor_for_framework_fa(
+        confidential_asset: signer, aptos_fx: signer, alice: signer)
+    {
+        set_up_chain_only(&confidential_asset, &aptos_fx);
+        // Framework FA: creator is @aptos_framework, so root_owner == @0x1.
+        let token = create_fa_owned_by(@aptos_framework);
+
+        assert!(object::root_owner(token) == @aptos_framework, 1);
+
+        let (_, ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::set_asset_auditor(&aptos_fx, token, twisted_elgamal::pubkey_to_bytes(&ek));
+        assert!(confidential_asset::get_asset_auditor_epoch(token) == 1, 2);
+
+        let _ = alice;
+    }
+
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        multisig = @0x9001,
+        alice = @0xa1
+    )]
+    /// Nested-ownership case (USDCX shape): a "contract object" sits between the multisig
+    /// issuer and the FA metadata object. `object::root_owner` walks the chain through
+    /// the contract object to the multisig at the top, so the multisig can call
+    /// `set_asset_auditor` directly without needing the contract's ExtendRef wrapper.
+    fun success_set_asset_auditor_via_nested_object_chain(
+        confidential_asset: signer, aptos_fx: signer, multisig: signer, alice: signer)
+    {
+        set_up_chain_only(&confidential_asset, &aptos_fx);
+
+        // Build the chain: multisig -> contract_obj -> fa_metadata_obj.
+        let contract_ctor = object::create_sticky_object(signer::address_of(&multisig));
+        let contract_signer = object::generate_signer(&contract_ctor);
+        let contract_addr = signer::address_of(&contract_signer);
+
+        let token = create_fa_owned_by(contract_addr);
+
+        // Direct owner is the contract object; root walks past it to the multisig.
+        assert!(object::owner(token) == contract_addr, 1);
+        assert!(object::root_owner(token) == signer::address_of(&multisig), 2);
+
+        // Multisig (root) can rotate directly.
+        let (_, ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::set_asset_auditor(&multisig, token, twisted_elgamal::pubkey_to_bytes(&ek));
+        assert!(confidential_asset::get_asset_auditor_epoch(token) == 1, 3);
+
+        let _ = alice;
+    }
+
+    #[test(
+        confidential_asset = @aptos_experimental,
+        aptos_fx = @aptos_framework,
+        multisig = @0x9001,
+        alice = @0xa1
+    )]
+    #[expected_failure(abort_code = 0x50016, location = confidential_asset)]
+    /// Nested-ownership negative: the *intermediate* object signer (the contract object
+    /// directly above the FA) is not the root owner and is rejected. Only the account at
+    /// the top of the chain has authority.
+    fun fail_set_asset_auditor_by_intermediate_object_in_chain(
+        confidential_asset: signer, aptos_fx: signer, multisig: signer, alice: signer)
+    {
+        set_up_chain_only(&confidential_asset, &aptos_fx);
+
+        let contract_ctor = object::create_sticky_object(signer::address_of(&multisig));
+        let contract_signer = object::generate_signer(&contract_ctor);
+        let contract_addr = signer::address_of(&contract_signer);
+
+        let token = create_fa_owned_by(contract_addr);
+
+        // The contract-object signer is the *direct* owner but not the *root* owner —
+        // root_owner walks past it to the multisig — so this must abort.
+        let (_, ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::set_asset_auditor(
+            &contract_signer, token, twisted_elgamal::pubkey_to_bytes(&ek)
+        );
+
+        let _ = alice;
     }
 }

--- a/aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_asset_tests.move
+++ b/aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_asset_tests.move
@@ -66,64 +66,11 @@ module aptos_experimental::confidential_asset_tests {
         new_amount: u128,
         sender_auditor_hint: vector<u8>)
     {
-        let from = signer::address_of(sender);
-        let sender_ek = confidential_asset::encryption_key(from, token);
-        let recipient_ek = confidential_asset::encryption_key(to, token);
-        let current_balance = confidential_balance::decompress_balance(
-            &confidential_asset::actual_balance(from, token)
-        );
+        // Every confidential transfer must include the chain-level auditor at slot 0; helper
+        // fetches it from on-chain state so individual tests don't have to thread it through.
+        let chain_auditor_ek = confidential_asset::get_chain_auditor().extract();
+        let auditor_eks = vector[chain_auditor_ek];
 
-        let (
-            proof,
-            new_balance,
-            sender_amount,
-            recipient_amount,
-            _
-        ) = confidential_proof::prove_transfer(
-            4u8, // test chain ID
-            from,
-            @aptos_experimental,
-            object::object_address(&token),
-            sender_dk,
-            &sender_ek,
-            &recipient_ek,
-            amount,
-            new_amount,
-            &current_balance,
-            &vector[],
-            sender_auditor_hint,
-        );
-
-        let (sigma_proof, zkrp_new_balance, zkrp_transfer_amount) = confidential_proof::serialize_transfer_proof(
-            &proof
-        );
-
-        confidential_asset::confidential_transfer(
-            sender,
-            token,
-            to,
-            confidential_balance::balance_to_bytes(&new_balance),
-            confidential_balance::balance_to_bytes(&sender_amount),
-            confidential_balance::balance_to_bytes(&recipient_amount),
-            b"",
-            b"",
-            zkrp_new_balance,
-            zkrp_transfer_amount,
-            sigma_proof,
-            sender_auditor_hint
-        );
-    }
-
-    fun audit_transfer(
-        sender: &signer,
-        sender_dk: &Scalar,
-        token: Object<Metadata>,
-        to: address,
-        amount: u64,
-        new_amount: u128,
-        auditor_eks: &vector<twisted_elgamal::CompressedPubkey>,
-        sender_auditor_hint: vector<u8>): vector<confidential_balance::ConfidentialBalance>
-    {
         let from = signer::address_of(sender);
         let sender_ek = confidential_asset::encryption_key(from, token);
         let recipient_ek = confidential_asset::encryption_key(to, token);
@@ -148,7 +95,7 @@ module aptos_experimental::confidential_asset_tests {
             amount,
             new_amount,
             &current_balance,
-            auditor_eks,
+            &auditor_eks,
             sender_auditor_hint,
         );
 
@@ -163,7 +110,74 @@ module aptos_experimental::confidential_asset_tests {
             confidential_balance::balance_to_bytes(&new_balance),
             confidential_balance::balance_to_bytes(&sender_amount),
             confidential_balance::balance_to_bytes(&recipient_amount),
-            confidential_asset::serialize_auditor_eks(auditor_eks),
+            confidential_asset::serialize_auditor_eks(&auditor_eks),
+            confidential_asset::serialize_auditor_amounts(&auditor_amounts),
+            zkrp_new_balance,
+            zkrp_transfer_amount,
+            sigma_proof,
+            sender_auditor_hint
+        );
+    }
+
+    /// Like `transfer`, but lets the caller append additional auditor keys (asset-level
+    /// and/or voluntary). The chain-level auditor is fetched from on-chain state and
+    /// automatically placed at slot 0; the caller's `extra_auditor_eks` are appended in
+    /// order, so an asset-auditor test should pass `[asset_auditor_ek, vol1, vol2, ...]`
+    /// and a pure-voluntary test should pass `[vol1, vol2, ...]`.
+    fun audit_transfer(
+        sender: &signer,
+        sender_dk: &Scalar,
+        token: Object<Metadata>,
+        to: address,
+        amount: u64,
+        new_amount: u128,
+        extra_auditor_eks: &vector<twisted_elgamal::CompressedPubkey>,
+        sender_auditor_hint: vector<u8>): vector<confidential_balance::ConfidentialBalance>
+    {
+        let chain_auditor_ek = confidential_asset::get_chain_auditor().extract();
+        let auditor_eks = vector[chain_auditor_ek];
+        extra_auditor_eks.for_each_ref(|ek| auditor_eks.push_back(*ek));
+
+        let from = signer::address_of(sender);
+        let sender_ek = confidential_asset::encryption_key(from, token);
+        let recipient_ek = confidential_asset::encryption_key(to, token);
+        let current_balance = confidential_balance::decompress_balance(
+            &confidential_asset::actual_balance(from, token)
+        );
+
+        let (
+            proof,
+            new_balance,
+            sender_amount,
+            recipient_amount,
+            auditor_amounts
+        ) = confidential_proof::prove_transfer(
+            4u8, // test chain ID
+            from,
+            @aptos_experimental,
+            object::object_address(&token),
+            sender_dk,
+            &sender_ek,
+            &recipient_ek,
+            amount,
+            new_amount,
+            &current_balance,
+            &auditor_eks,
+            sender_auditor_hint,
+        );
+
+        let (sigma_proof, zkrp_new_balance, zkrp_transfer_amount) = confidential_proof::serialize_transfer_proof(
+            &proof
+        );
+
+        confidential_asset::confidential_transfer(
+            sender,
+            token,
+            to,
+            confidential_balance::balance_to_bytes(&new_balance),
+            confidential_balance::balance_to_bytes(&sender_amount),
+            confidential_balance::balance_to_bytes(&recipient_amount),
+            confidential_asset::serialize_auditor_eks(&auditor_eks),
             confidential_asset::serialize_auditor_amounts(&auditor_amounts),
             zkrp_new_balance,
             zkrp_transfer_amount,
@@ -277,6 +291,13 @@ module aptos_experimental::confidential_asset_tests {
         confidential_asset::init_module_for_testing(confidential_asset);
 
         features::change_feature_flags_for_testing(aptos_fx, vector[features::get_bulletproofs_feature()], vector[]);
+
+        // Every confidential transfer requires the chain-level auditor to be set, so the
+        // shared setup configures it with a deterministic-but-fresh keypair. Tests that
+        // need direct access to the chain auditor's keys can call
+        // `set_chain_auditor_for_test` themselves to override.
+        let (_chain_dk, chain_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::set_chain_auditor(aptos_fx, twisted_elgamal::pubkey_to_bytes(&chain_ek));
 
         let token = object::object_from_constructor_ref<Metadata>(ctor_ref);
 
@@ -428,12 +449,16 @@ module aptos_experimental::confidential_asset_tests {
 
         let hint = vector[0x01u8, 0x77u8, 0x61u8]; // arbitrary opaque bytes ("wa" with prefix)
         transfer(&alice, &alice_dk, token, bob_addr, 100, 100, hint);
+        // setup set the chain auditor exactly once (epoch 1); no asset auditor (epoch 0).
+        // ek_volun_auds covers ALL auditors including chain — so 1 row, not 0.
         confidential_asset::assert_last_transferred_event_matches_state(
             token,
             alice_addr,
             bob_addr,
+            1,
+            hint,
+            1,
             0,
-            hint
         );
     }
 
@@ -461,7 +486,7 @@ module aptos_experimental::confidential_asset_tests {
         let (auditor1_dk, auditor1_ek) = generate_twisted_elgamal_keypair();
         let (auditor2_dk, auditor2_ek) = generate_twisted_elgamal_keypair();
 
-        confidential_asset::set_auditor(
+        confidential_asset::set_asset_auditor(
             &aptos_fx,
             token,
             twisted_elgamal::pubkey_to_bytes(&auditor1_ek));
@@ -485,8 +510,9 @@ module aptos_experimental::confidential_asset_tests {
         assert!(confidential_asset::verify_actual_balance(alice_addr, token, &alice_dk, 100), 1);
         assert!(confidential_asset::verify_pending_balance(bob_addr, token, &bob_dk, 100), 1);
 
-        assert!(confidential_balance::verify_pending_balance(&auditor_amounts[0], &auditor1_dk, 100), 1);
-        assert!(confidential_balance::verify_pending_balance(&auditor_amounts[1], &auditor2_dk, 100), 1);
+        // auditor_amounts[0] is the chain auditor's row; the asset & voluntary rows shift to [1]/[2].
+        assert!(confidential_balance::verify_pending_balance(&auditor_amounts[1], &auditor1_dk, 100), 1);
+        assert!(confidential_balance::verify_pending_balance(&auditor_amounts[2], &auditor2_dk, 100), 1);
     }
 
     #[test(
@@ -513,7 +539,7 @@ module aptos_experimental::confidential_asset_tests {
         let (auditor1_dk, auditor1_ek) = generate_twisted_elgamal_keypair();
         let (auditor2_dk, auditor2_ek) = generate_twisted_elgamal_keypair();
 
-        confidential_asset::set_auditor(
+        confidential_asset::set_asset_auditor(
             &aptos_fx,
             token,
             twisted_elgamal::pubkey_to_bytes(&auditor1_ek));
@@ -537,15 +563,19 @@ module aptos_experimental::confidential_asset_tests {
 
         assert!(confidential_asset::verify_actual_balance(alice_addr, token, &alice_dk, 100), 1);
         assert!(confidential_asset::verify_pending_balance(bob_addr, token, &bob_dk, 100), 1);
-        assert!(confidential_balance::verify_pending_balance(&auditor_amounts[0], &auditor1_dk, 100), 2);
-        assert!(confidential_balance::verify_pending_balance(&auditor_amounts[1], &auditor2_dk, 100), 3);
+        // auditor_amounts[0] is the chain auditor's row; the asset & voluntary rows shift to [1]/[2].
+        assert!(confidential_balance::verify_pending_balance(&auditor_amounts[1], &auditor1_dk, 100), 2);
+        assert!(confidential_balance::verify_pending_balance(&auditor_amounts[2], &auditor2_dk, 100), 3);
 
+        // chain auditor + asset auditor + 1 voluntary = 3 auditor rows in ek_volun_auds.
         confidential_asset::assert_last_transferred_event_matches_state(
             token,
             alice_addr,
             bob_addr,
-            2,
-            hint
+            3,
+            hint,
+            1,
+            1,
         );
     }
 
@@ -573,7 +603,7 @@ module aptos_experimental::confidential_asset_tests {
         let (_, auditor1_ek) = generate_twisted_elgamal_keypair();
         let (_, auditor2_ek) = generate_twisted_elgamal_keypair();
 
-        confidential_asset::set_auditor(
+        confidential_asset::set_asset_auditor(
             &aptos_fx,
             token,
             twisted_elgamal::pubkey_to_bytes(&auditor1_ek));
@@ -584,9 +614,10 @@ module aptos_experimental::confidential_asset_tests {
         confidential_asset::deposit(&alice, token, 200);
         confidential_asset::rollover_pending_balance(&alice, token);
 
-        // This fails because the `auditor1` is set for `token`,
-        // so each transfer must include `auditor1` in the auditor list as the FIRST element.
-        // Please, see `confidential_asset::validate_auditors` for more details.
+        // Asset auditor for `token` is `auditor1`, so the first slot in `extra_auditor_eks`
+        // (which becomes `auditor_eks[1]` after the helper prepends the chain auditor at slot 0)
+        // must equal `auditor1`. Passing `auditor2` there is a slot-1 mismatch and is rejected.
+        // See `confidential_asset::validate_auditors`.
         audit_transfer(
             &alice,
             &alice_dk,
@@ -822,17 +853,25 @@ module aptos_experimental::confidential_asset_tests {
         confidential_asset::disable_allow_list(&aptos_fx);
         confidential_asset::assert_last_allow_list_changed_event(false);
 
-        // --- set_auditor emits AuditorChanged ---
+        // --- set_asset_auditor emits AssetAuditorChanged with bumped epoch ---
         let (_, auditor_ek) = generate_twisted_elgamal_keypair();
-        confidential_asset::set_auditor(
+        confidential_asset::set_asset_auditor(
             &aptos_fx,
             token,
             twisted_elgamal::pubkey_to_bytes(&auditor_ek));
-        confidential_asset::assert_last_auditor_changed_event(token);
+        confidential_asset::assert_last_asset_auditor_changed_event(token, 1);
 
-        // remove auditor
-        confidential_asset::set_auditor(&aptos_fx, token, b"");
-        confidential_asset::assert_last_auditor_changed_event(token);
+        // clear asset auditor — still bumps epoch and emits the event
+        confidential_asset::set_asset_auditor(&aptos_fx, token, b"");
+        confidential_asset::assert_last_asset_auditor_changed_event(token, 2);
+
+        // --- set_chain_auditor emits ChainAuditorChanged ---
+        // Setup already set the chain auditor once (epoch 1); rotate to a new key (epoch 2).
+        let (_, new_chain_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::set_chain_auditor(
+            &aptos_fx,
+            twisted_elgamal::pubkey_to_bytes(&new_chain_ek));
+        confidential_asset::assert_last_chain_auditor_changed_event(2);
     }
 
     #[test(
@@ -1046,5 +1085,270 @@ module aptos_experimental::confidential_asset_tests {
         let (_, alice_ek) = generate_twisted_elgamal_keypair();
         confidential_asset::register_for_testing(&alice, token, twisted_elgamal::pubkey_to_bytes(&alice_ek));
         confidential_asset::deposit(&alice, token, 100);
+    }
+
+    //
+    // Auditor layering: chain-level + per-asset + voluntary auditors.
+    //
+
+    /// Setup variant that does NOT install a chain-level auditor. Used to exercise the
+    /// `ECHAIN_AUDITOR_NOT_SET` precondition on transfers.
+    fun set_up_without_chain_auditor(
+        confidential_asset: &signer,
+        aptos_fx: &signer,
+        fa: &signer,
+        sender: &signer,
+        recipient: &signer,
+        sender_amount: u64,
+        recipient_amount: u64): Object<Metadata>
+    {
+        chain_id::initialize_for_test(aptos_fx, 4);
+        let ctor_ref = &object::create_sticky_object(signer::address_of(fa));
+        primary_fungible_store::create_primary_store_enabled_fungible_asset(
+            ctor_ref, option::none(), utf8(b"NoChainAuditor"), utf8(b"NCA"), 18,
+            utf8(b"https://"), utf8(b"https://"));
+        let mint_ref = fungible_asset::generate_mint_ref(ctor_ref);
+        confidential_asset::init_module_for_testing(confidential_asset);
+        features::change_feature_flags_for_testing(
+            aptos_fx, vector[features::get_bulletproofs_feature()], vector[]);
+        let token = object::object_from_constructor_ref<Metadata>(ctor_ref);
+        let sender_store = primary_fungible_store::ensure_primary_store_exists(
+            signer::address_of(sender), token);
+        fungible_asset::mint_to(&mint_ref, sender_store, sender_amount);
+        let recipient_store = primary_fungible_store::ensure_primary_store_exists(
+            signer::address_of(recipient), token);
+        fungible_asset::mint_to(&mint_ref, recipient_store, recipient_amount);
+        token
+    }
+
+    /// Builds and submits a transfer using the supplied `auditor_eks` *verbatim* — without
+    /// the chain-key prepend that `audit_transfer` performs. Used by tests that need to
+    /// exercise rejection paths (wrong slot 0, missing prefix, post-rotation old proof).
+    fun audit_transfer_raw(
+        sender: &signer,
+        sender_dk: &Scalar,
+        token: Object<Metadata>,
+        to: address,
+        amount: u64,
+        new_amount: u128,
+        auditor_eks: &vector<twisted_elgamal::CompressedPubkey>,
+        sender_auditor_hint: vector<u8>)
+    {
+        let from = signer::address_of(sender);
+        let sender_ek = confidential_asset::encryption_key(from, token);
+        let recipient_ek = confidential_asset::encryption_key(to, token);
+        let current_balance = confidential_balance::decompress_balance(
+            &confidential_asset::actual_balance(from, token));
+        let (proof, new_balance, sender_amount, recipient_amount, auditor_amounts) =
+            confidential_proof::prove_transfer(
+                4u8, from, @aptos_experimental, object::object_address(&token),
+                sender_dk, &sender_ek, &recipient_ek, amount, new_amount,
+                &current_balance, auditor_eks, sender_auditor_hint);
+        let (sigma_proof, zkrp_new_balance, zkrp_transfer_amount) =
+            confidential_proof::serialize_transfer_proof(&proof);
+        confidential_asset::confidential_transfer(
+            sender, token, to,
+            confidential_balance::balance_to_bytes(&new_balance),
+            confidential_balance::balance_to_bytes(&sender_amount),
+            confidential_balance::balance_to_bytes(&recipient_amount),
+            confidential_asset::serialize_auditor_eks(auditor_eks),
+            confidential_asset::serialize_auditor_amounts(&auditor_amounts),
+            zkrp_new_balance, zkrp_transfer_amount, sigma_proof, sender_auditor_hint);
+    }
+
+    #[test(confidential_asset = @aptos_experimental, aptos_fx = @aptos_framework,
+        fa = @0xfa, alice = @0xa1, bob = @0xb0)]
+    #[expected_failure(abort_code = 0x030015, location = confidential_asset)]
+    /// Confidential transfers cannot run before the chain-level auditor has been
+    /// configured. Aborts with `ECHAIN_AUDITOR_NOT_SET`.
+    fun fail_transfer_if_chain_auditor_unset(
+        confidential_asset: signer, aptos_fx: signer, fa: signer,
+        alice: signer, bob: signer)
+    {
+        let token = set_up_without_chain_auditor(
+            &confidential_asset, &aptos_fx, &fa, &alice, &bob, 500, 500);
+        let bob_addr = signer::address_of(&bob);
+        let (alice_dk, alice_ek) = generate_twisted_elgamal_keypair();
+        let (_, bob_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::register_for_testing(&alice, token, twisted_elgamal::pubkey_to_bytes(&alice_ek));
+        confidential_asset::register_for_testing(&bob, token, twisted_elgamal::pubkey_to_bytes(&bob_ek));
+        confidential_asset::deposit(&alice, token, 200);
+        confidential_asset::rollover_pending_balance(&alice, token);
+
+        // Even an empty auditor list is rejected — chain auditor is mandatory.
+        audit_transfer_raw(&alice, &alice_dk, token, bob_addr, 100, 100, &vector[], vector[]);
+    }
+
+    #[test(confidential_asset = @aptos_experimental, aptos_fx = @aptos_framework,
+        fa = @0xfa, alice = @0xa1, bob = @0xb0)]
+    #[expected_failure(abort_code = 0x010006, location = confidential_asset)]
+    /// Slot 0 of `auditor_eks` must equal the active chain auditor key — a sender cannot
+    /// substitute their own key in that position even if they encrypt a valid auditor
+    /// amount under it.
+    fun fail_transfer_if_slot0_not_chain_auditor(
+        confidential_asset: signer, aptos_fx: signer, fa: signer,
+        alice: signer, bob: signer)
+    {
+        let token = set_up_for_confidential_asset_test(
+            &confidential_asset, &aptos_fx, &fa, &alice, &bob, 500, 500);
+        let bob_addr = signer::address_of(&bob);
+        let (alice_dk, alice_ek) = generate_twisted_elgamal_keypair();
+        let (_, bob_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::register_for_testing(&alice, token, twisted_elgamal::pubkey_to_bytes(&alice_ek));
+        confidential_asset::register_for_testing(&bob, token, twisted_elgamal::pubkey_to_bytes(&bob_ek));
+        confidential_asset::deposit(&alice, token, 200);
+        confidential_asset::rollover_pending_balance(&alice, token);
+
+        // Use a fresh keypair as slot 0 — proof verifies (consistent transcript) but
+        // `validate_auditors` rejects because slot 0 ≠ on-chain chain auditor.
+        let (_, wrong_ek) = generate_twisted_elgamal_keypair();
+        audit_transfer_raw(&alice, &alice_dk, token, bob_addr, 100, 100,
+            &vector[wrong_ek], vector[]);
+    }
+
+    #[test(confidential_asset = @aptos_experimental, aptos_fx = @aptos_framework,
+        fa = @0xfa, alice = @0xa1, bob = @0xb0)]
+    #[expected_failure(abort_code = 0x010006, location = confidential_asset)]
+    /// When an asset auditor is set, `auditor_eks` must include both the chain auditor
+    /// (slot 0) and the asset auditor (slot 1). Submitting only the chain auditor is
+    /// rejected — the prefix length check in `validate_auditors` catches it.
+    fun fail_transfer_if_asset_auditor_required_but_missing(
+        confidential_asset: signer, aptos_fx: signer, fa: signer,
+        alice: signer, bob: signer)
+    {
+        let token = set_up_for_confidential_asset_test(
+            &confidential_asset, &aptos_fx, &fa, &alice, &bob, 500, 500);
+        let bob_addr = signer::address_of(&bob);
+        let (alice_dk, alice_ek) = generate_twisted_elgamal_keypair();
+        let (_, bob_ek) = generate_twisted_elgamal_keypair();
+        let (_, asset_aud_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::set_asset_auditor(&aptos_fx, token,
+            twisted_elgamal::pubkey_to_bytes(&asset_aud_ek));
+        confidential_asset::register_for_testing(&alice, token, twisted_elgamal::pubkey_to_bytes(&alice_ek));
+        confidential_asset::register_for_testing(&bob, token, twisted_elgamal::pubkey_to_bytes(&bob_ek));
+        confidential_asset::deposit(&alice, token, 200);
+        confidential_asset::rollover_pending_balance(&alice, token);
+
+        // Helper auto-prepends the chain auditor ⇒ auditor_eks = [chain]. Slot 1 is missing
+        // even though asset auditor is set ⇒ rejected.
+        audit_transfer(&alice, &alice_dk, token, bob_addr, 100, 100, &vector[], vector[]);
+    }
+
+    #[test(confidential_asset = @aptos_experimental, aptos_fx = @aptos_framework,
+        fa = @0xfa, alice = @0xa1, bob = @0xb0)]
+    /// Voluntary auditors at slot 2+ are accepted when no asset auditor is configured —
+    /// the prefix is just `[chain]`, anything after is the sender's choice.
+    fun success_voluntary_auditors_without_asset_auditor(
+        confidential_asset: signer, aptos_fx: signer, fa: signer,
+        alice: signer, bob: signer)
+    {
+        let token = set_up_for_confidential_asset_test(
+            &confidential_asset, &aptos_fx, &fa, &alice, &bob, 500, 500);
+        let alice_addr = signer::address_of(&alice);
+        let bob_addr = signer::address_of(&bob);
+        let (alice_dk, alice_ek) = generate_twisted_elgamal_keypair();
+        let (bob_dk, bob_ek) = generate_twisted_elgamal_keypair();
+        let (vol1_dk, vol1_ek) = generate_twisted_elgamal_keypair();
+        let (vol2_dk, vol2_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::register_for_testing(&alice, token, twisted_elgamal::pubkey_to_bytes(&alice_ek));
+        confidential_asset::register_for_testing(&bob, token, twisted_elgamal::pubkey_to_bytes(&bob_ek));
+        confidential_asset::deposit(&alice, token, 200);
+        confidential_asset::rollover_pending_balance(&alice, token);
+
+        let auditor_amounts = audit_transfer(&alice, &alice_dk, token, bob_addr, 100, 100,
+            &vector[vol1_ek, vol2_ek], vector[]);
+
+        assert!(confidential_asset::verify_actual_balance(alice_addr, token, &alice_dk, 100), 1);
+        assert!(confidential_asset::verify_pending_balance(bob_addr, token, &bob_dk, 100), 1);
+        // [0] = chain auditor (helper-prepended); [1] = vol1; [2] = vol2.
+        assert!(confidential_balance::verify_pending_balance(&auditor_amounts[1], &vol1_dk, 100), 2);
+        assert!(confidential_balance::verify_pending_balance(&auditor_amounts[2], &vol2_dk, 100), 3);
+    }
+
+    #[test(confidential_asset = @aptos_experimental, aptos_fx = @aptos_framework,
+        fa = @0xfa, alice = @0xa1, bob = @0xb0)]
+    #[expected_failure(abort_code = 0x010006, location = confidential_asset)]
+    /// A proof generated under the previous chain auditor key becomes unsubmittable after
+    /// governance rotates the chain auditor — slot 0 no longer equals the on-chain key.
+    /// This is the explicit "rotation invalidates in-flight proofs" property documented
+    /// on `set_chain_auditor`.
+    fun fail_transfer_after_chain_auditor_rotation(
+        confidential_asset: signer, aptos_fx: signer, fa: signer,
+        alice: signer, bob: signer)
+    {
+        let token = set_up_for_confidential_asset_test(
+            &confidential_asset, &aptos_fx, &fa, &alice, &bob, 500, 500);
+        let bob_addr = signer::address_of(&bob);
+        let (alice_dk, alice_ek) = generate_twisted_elgamal_keypair();
+        let (_, bob_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::register_for_testing(&alice, token, twisted_elgamal::pubkey_to_bytes(&alice_ek));
+        confidential_asset::register_for_testing(&bob, token, twisted_elgamal::pubkey_to_bytes(&bob_ek));
+        confidential_asset::deposit(&alice, token, 200);
+        confidential_asset::rollover_pending_balance(&alice, token);
+
+        // Capture the chain auditor key in force at proof-generation time, then rotate
+        // before submission to simulate a governance proposal landing mid-flight.
+        let old_chain_ek = confidential_asset::get_chain_auditor().extract();
+        let (_, new_chain_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::set_chain_auditor(&aptos_fx, twisted_elgamal::pubkey_to_bytes(&new_chain_ek));
+
+        // `audit_transfer_raw` uses the supplied list verbatim — slot 0 is the *old* key,
+        // which no longer matches the on-chain chain auditor.
+        audit_transfer_raw(&alice, &alice_dk, token, bob_addr, 100, 100,
+            &vector[old_chain_ek], vector[]);
+    }
+
+    #[test(confidential_asset = @aptos_experimental, aptos_fx = @aptos_framework,
+        fa = @0xfa, alice = @0xa1, bob = @0xb0)]
+    /// Rotation history: each rotation bumps the epoch, appends to history, and stamps
+    /// the new epoch on subsequent transfers. Past entries close their
+    /// `deactivated_at_epoch` to the successor's `activated_at_epoch`.
+    fun success_chain_auditor_rotation_tracks_history(
+        confidential_asset: signer, aptos_fx: signer, fa: signer,
+        alice: signer, bob: signer)
+    {
+        let token = set_up_for_confidential_asset_test(
+            &confidential_asset, &aptos_fx, &fa, &alice, &bob, 500, 500);
+        let alice_addr = signer::address_of(&alice);
+        let bob_addr = signer::address_of(&bob);
+        let (alice_dk, alice_ek) = generate_twisted_elgamal_keypair();
+        let (_, bob_ek) = generate_twisted_elgamal_keypair();
+        confidential_asset::register_for_testing(&alice, token, twisted_elgamal::pubkey_to_bytes(&alice_ek));
+        confidential_asset::register_for_testing(&bob, token, twisted_elgamal::pubkey_to_bytes(&bob_ek));
+        confidential_asset::deposit(&alice, token, 300);
+        confidential_asset::rollover_pending_balance(&alice, token);
+
+        // Setup installed epoch 1; rotate twice → epochs 2, 3.
+        assert!(confidential_asset::get_chain_auditor_epoch() == 1, 1);
+        let (_, ek2) = generate_twisted_elgamal_keypair();
+        confidential_asset::set_chain_auditor(&aptos_fx, twisted_elgamal::pubkey_to_bytes(&ek2));
+        assert!(confidential_asset::get_chain_auditor_epoch() == 2, 2);
+        let (_, ek3) = generate_twisted_elgamal_keypair();
+        confidential_asset::set_chain_auditor(&aptos_fx, twisted_elgamal::pubkey_to_bytes(&ek3));
+        assert!(confidential_asset::get_chain_auditor_epoch() == 3, 3);
+
+        // History has 3 entries; the first two are deactivated at the successor's epoch,
+        // and the active key has deactivated_at_epoch == 0.
+        let history = confidential_asset::get_chain_auditor_history();
+        assert!(history.length() == 3, 4);
+
+        // Transfer stamps the *current* epoch (3) on the event.
+        transfer(&alice, &alice_dk, token, bob_addr, 100, 200, vector[]);
+        confidential_asset::assert_last_transferred_event_matches_state(
+            token, alice_addr, bob_addr, 1, vector[], 3, 0);
+
+        // Asset auditor history is independent. Set, rotate, clear.
+        let (_, asset_ek1) = generate_twisted_elgamal_keypair();
+        let (_, asset_ek2) = generate_twisted_elgamal_keypair();
+        confidential_asset::set_asset_auditor(&aptos_fx, token, twisted_elgamal::pubkey_to_bytes(&asset_ek1));
+        assert!(confidential_asset::get_asset_auditor_epoch(token) == 1, 5);
+        confidential_asset::set_asset_auditor(&aptos_fx, token, twisted_elgamal::pubkey_to_bytes(&asset_ek2));
+        assert!(confidential_asset::get_asset_auditor_epoch(token) == 2, 6);
+        confidential_asset::set_asset_auditor(&aptos_fx, token, b"");
+        assert!(confidential_asset::get_asset_auditor_epoch(token) == 3, 7);
+        // History contains both prior keys; after the clear there is no active asset auditor.
+        let asset_hist = confidential_asset::get_asset_auditor_history(token);
+        assert!(asset_hist.length() == 2, 8);
+        assert!(confidential_asset::get_asset_auditor(token).is_none(), 9);
     }
 }

--- a/scripts/chain-auditor-bootstrap/Move.toml
+++ b/scripts/chain-auditor-bootstrap/Move.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ChainAuditorBootstrap"
+version = "1.0.0"
+
+[addresses]
+# Resolved at compile-time via --named-addresses to the publish-profile account
+# that AptosExperimental was published from. This script only references
+# aptos_experimental::confidential_asset symbols; it does not deploy here.
+aptos_experimental = "_"
+
+[dependencies]
+AptosExperimental = { local = "../../aptos-move/framework/aptos-experimental" }

--- a/scripts/chain-auditor-bootstrap/sources/set_chain_auditor_admin.move
+++ b/scripts/chain-auditor-bootstrap/sources/set_chain_auditor_admin.move
@@ -1,0 +1,14 @@
+// Designates the chain-auditor admin via governance. Sender must be the core
+// resources account (localnet: key in <test-dir>/mint.key). Pairs with the
+// subsequent `confidential_asset::set_chain_auditor` entry call signed by the
+// admin itself.
+script {
+    use aptos_experimental::confidential_asset;
+    use aptos_framework::aptos_governance;
+
+    fun main(core_resources: &signer, new_admin: address) {
+        let core_signer = aptos_governance::get_signer_testnet_only(core_resources, @0x1);
+        let framework_signer = &core_signer;
+        confidential_asset::set_chain_auditor_admin(framework_signer, new_admin);
+    }
+}

--- a/scripts/start-localnet-confidential-assets.sh
+++ b/scripts/start-localnet-confidential-assets.sh
@@ -519,7 +519,8 @@ publish_experimental_from_profile() {
     --named-addresses "aptos_experimental=${named_addr}" \
     --max-gas "$MOVE_PUBLISH_MAX_GAS" \
     --skip-fetch-latest-git-deps \
-    --included-artifacts none
+    --included-artifacts none \
+    --override-size-check
 }
 
 wait_for_mint_key() {
@@ -624,6 +625,57 @@ echo "Enabling feature flag 87 (BULLETPROOFS_BATCH_NATIVES) ..."
   --script-path "$FEATURE_SCRIPT"
 
 publish_experimental_from_profile
+
+# Bootstrap the chain-auditor: governance (mint.key) designates the publish-profile
+# account as `chain_auditor_admin`, then that admin sets a known TwistedElGamal
+# pubkey as the chain auditor. Without this, every `confidential_transfer` aborts
+# with ECHAIN_AUDITOR_NOT_SET because the GlobalConfig.chain_auditor_ek defaults
+# to None at publish.
+#
+# CHAIN_AUDITOR_EK is a fixed test-only key. Re-running the script bumps the
+# on-chain `chain_auditor_epoch` (harmless for tests; localnet state is wiped on
+# fresh starts). Private key for this pubkey (only needed if a test ever wants
+# to actually decrypt as the chain auditor):
+#   priv: 0xb17fdd9dd18e25a3c5f7b2004142b76c3998eab4f91372ea543830ece670b5cb
+CHAIN_AUDITOR_BOOTSTRAP_DIR="$SCRIPT_DIR/chain-auditor-bootstrap"
+CHAIN_AUDITOR_EK="${CHAIN_AUDITOR_EK:-0x5e7cbfdf6b100216d7541b0439704748225a90005cd4908a1ee3c90d1ab1ea00}"
+
+if [[ "${SKIP_EXPERIMENTAL_PUBLISH:-0}" != "1" ]]; then
+  if [[ ! -d "$CHAIN_AUDITOR_BOOTSTRAP_DIR" ]]; then
+    echo "error: missing $CHAIN_AUDITOR_BOOTSTRAP_DIR" >&2
+    exit 1
+  fi
+  admin_addr=$(profile_account_hex) || exit 1
+
+  # `move run-script` does not accept --named-addresses, so compile the bootstrap
+  # script package separately and feed the resulting bytecode in via
+  # --compiled-script-path.
+  echo "Compiling chain-auditor bootstrap script (aptos_experimental=$admin_addr) ..."
+  "$MOVEMENT" move compile-script \
+    --package-dir "$CHAIN_AUDITOR_BOOTSTRAP_DIR" \
+    --named-addresses "aptos_experimental=$admin_addr" \
+    --output-file "$CHAIN_AUDITOR_BOOTSTRAP_DIR/build/set_chain_auditor_admin.mv"
+
+  echo "Designating $admin_addr (profile \"$MOVEMENT_PROFILE\") as chain_auditor_admin ..."
+  "$MOVEMENT" move run-script \
+    --assume-yes \
+    --url "$NODE_URL" \
+    --private-key-file "$TEST_DIR/mint.key" \
+    --encoding bcs \
+    --sender-account "$CORE_RESOURCES_ADDRESS" \
+    --max-gas "$MOVE_RUN_SCRIPT_MAX_GAS" \
+    --compiled-script-path "$CHAIN_AUDITOR_BOOTSTRAP_DIR/build/set_chain_auditor_admin.mv" \
+    --args "address:$admin_addr"
+
+  echo "Setting chain auditor encryption key to $CHAIN_AUDITOR_EK ..."
+  "$MOVEMENT" move run \
+    --assume-yes \
+    --url "$NODE_URL" \
+    --profile "$MOVEMENT_PROFILE" \
+    --max-gas "$MOVE_RUN_SCRIPT_MAX_GAS" \
+    --function-id "${admin_addr}::confidential_asset::set_chain_auditor" \
+    --args "hex:$CHAIN_AUDITOR_EK"
+fi
 
 echo "Done — feature flag and (if enabled) publish finished."
 echo "REST: $NODE_URL/v1  (ready probe: $READY_URL — set WAIT_STRATEGY=node to wait only on REST)"


### PR DESCRIPTION
# Two-tier auditor model + epoch tracking for confidential assets

## Summary

The Confidential Asset module previously supported a single optional per-asset auditor. This PR introduces a **chain-level auditor** (always required, governed at the framework address) layered alongside the existing per-asset auditor, plus **monotonic epoch tracking and append-only history** for both layers. Every confidential transfer now stamps the active chain and asset auditor epochs onto its `Transferred` event, enabling reconstruction of which historical key covered which transfer years after a rotation.

## Behavior changes

### Auditor slot layout

`auditor_eks` (and the matching `auditor_amounts`) now have a fixed prefix:

```
[0]   chain-level auditor       (always required)
[1]   asset-specific auditor    (required iff get_asset_auditor(token).is_some())
[2..] voluntary auditors        (sender's choice; ordered)
```

Slot identity is bound into the transfer's Fiat–Shamir transcript via the order of `auditor_eks` (existing mechanism in `confidential_proof::fiat_shamir_transfer_sigma_proof_challenge`), so a sender cannot substitute one slot for another.

### Validation

`validate_auditors` now:

- Aborts with new error `ECHAIN_AUDITOR_NOT_SET` if no chain auditor is configured.
- Rejects the transfer if `auditor_eks[0]` ≠ active chain auditor.
- Rejects the transfer if an asset auditor is set and `auditor_eks[1]` ≠ it.
- Otherwise behaves as before (length checks, ciphertext consistency).

### Epoch + history

`FAController` and `FAConfig` each gain:

- `*_auditor_epoch: u64` — bumped on every set/rotate/clear (including clears).
- `*_auditor_history: vector<AuditorEntry>` — append-only; each entry carries `[activated_at_epoch, deactivated_at_epoch)` (`0` while still active).

`Transferred` event gains `chain_auditor_epoch` and `asset_auditor_epoch` (`0` when the asset has no auditor).

### Renamed / new module API

| Before                              | After                                       |
| ----------------------------------- | ------------------------------------------- |
| `set_auditor`                       | `set_asset_auditor`                         |
| `get_auditor`                       | `get_asset_auditor`                         |
| `AuditorChanged`                    | `AssetAuditorChanged` (+`new_epoch` field)  |
| `FAConfig.auditor_ek`               | `FAConfig.asset_auditor_ek`                 |
| —                                   | `set_chain_auditor`                         |
| —                                   | `get_chain_auditor` / `*_epoch` / `*_history` |
| —                                   | `get_asset_auditor_epoch` / `*_history`     |
| —                                   | `ChainAuditorChanged`                       |
| —                                   | `AuditorEntry` struct                       |
| —                                   | `ECHAIN_AUDITOR_NOT_SET`                    |

### In-flight proof invalidation on rotation

Auditor identity is bound into the proof's Fiat–Shamir transcript, so rotating either layer invalidates any user transactions signed against the old key but not yet executed. Documented inline on `set_chain_auditor` / `set_asset_auditor`.

## Tests

### Move unit tests (`confidential_asset_tests.move`) — 64/64 passing

New coverage:

- `fail_transfer_if_chain_auditor_unset` — abort when chain auditor missing.
- `fail_transfer_if_slot0_not_chain_auditor` — slot 0 mismatch rejected.
- `fail_transfer_if_asset_auditor_required_but_missing` — slot 1 absent when required.
- `success_voluntary_auditors_without_asset_auditor` — slot 2+ accepted with no asset auditor.
- `fail_transfer_after_chain_auditor_rotation` — pre-rotation old-key proof rejected.
- `success_chain_auditor_rotation_tracks_history` — rotations bump epochs, history records prior keys, `Transferred` stamps current epoch.

Existing transfer tests updated for the new slot layout (chain auditor auto-prepended via `get_chain_auditor()` in shared helpers).

### Rust e2e tests (`confidential_asset_e2e.rs`) — 7/7 passing

New coverage:

- `confidential_transfer_rejects_when_chain_auditor_unset`
- `confidential_transfer_rejects_when_slot0_not_chain_auditor`
- `confidential_transfer_rejects_after_chain_auditor_rotation`

`fresh_harness` now installs a default chain auditor; existing tests pass through unchanged because the test-only `pack_confidential_transfer_proof_*` helpers auto-prepend the chain auditor. A `fresh_harness_no_chain_auditor` variant and `pack_transfer_audited_verbatim` helper support the rejection-path tests.

> Note: `cargo test -p e2e-move-tests confidential_asset` requires `RUST_MIN_STACK=33554432` (or higher) — pre-existing requirement, documented in this module's file header.

## Follow-ups / out of scope

- **Chain-level key custody.** The contract enforces that the chain-level auditor *exists* and is bound into every transfer, but it can't enforce *who* holds the private key or *how*. A separate decision is needed before launch on whether the key sits with a qualified third-party custodian and whether custody is single-party or threshold/MPC. Strictly an off-chain operational call.
- **History sizing.** `chain_auditor_history` and `asset_auditor_history` are unbounded `vector<AuditorEntry>` on `FAController` / `FAConfig`. Fine pre-launch; if rotation cadence ends up high in production, follow up with a paginated view or periodic archival. Not a correctness or compliance gap — just a storage-growth concern.
- **Per-user auditor epoch tracking on `ConfidentialAssetStore`.** Not needed in this codebase — auditors only receive ciphertexts at transfer time, not on the balance, so rollover-staleness (the issue addressed in zkSecurity finding #01 upstream) does not apply here.
- **Documentation regeneration.** `aptos-experimental/doc/confidential_asset.md` is left untouched in this PR; regenerate via `movement move document` against a locally-built `movement` binary so the markup style stays consistent.

## Files changed

- `aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move`
- `aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_gas_e2e_helpers.move`
- `aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_asset_tests.move`
- `aptos-move/e2e-move-tests/src/tests/confidential_asset_e2e.rs`
