### PR TITLE
[vm] fix extract_abort_info for compiler-generated abort codes

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -546,12 +546,21 @@ impl AptosVM {
             ..
         } = status
         {
+            let use_exact_match = self
+                .features()
+                .is_enabled(FeatureFlag::EXTRACT_ABORT_INFO_EXACT_MATCH);
             let info = module_storage
                 .fetch_module_metadata(module_id.address(), module_id.name())
                 .ok()
                 .flatten()
                 .and_then(|metadata| get_metadata(&metadata))
-                .and_then(|m| m.extract_abort_info(code));
+                .and_then(|m| {
+                    if use_exact_match {
+                        m.extract_abort_info(code)
+                    } else {
+                        m.extract_abort_info_legacy(code)
+                    }
+                });
             ExecutionStatus::MoveAbort {
                 location: AbortLocation::Module(module_id),
                 code,

--- a/aptos-move/e2e-move-tests/src/tests/error_map.data/pack_unspecified_abort/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/error_map.data/pack_unspecified_abort/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "test_unspecified_abort"
+version = "0.0.0"
+upgrade_policy = "compatible"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }

--- a/aptos-move/e2e-move-tests/src/tests/error_map.data/pack_unspecified_abort/sources/test.move
+++ b/aptos-move/e2e-move-tests/src/tests/error_map.data/pack_unspecified_abort/sources/test.move
@@ -1,0 +1,34 @@
+module 0xcafe::test_unspecified_abort {
+    use std::error;
+
+    /// User-defined error that happens to use code 0.
+    const E_ZERO: u64 = 0;
+
+    /// User-defined error with a non-zero code.
+    const E_NONZERO: u64 = 7;
+
+    /// Triggers `UNSPECIFIED_ABORT_CODE` via single-argument `assert!`.
+    public entry fun unspecified_abort(_s: &signer) {
+        assert!(false);
+    }
+
+    /// Aborts directly with the user-defined error code zero.
+    public entry fun abort_with_user_zero(_s: &signer) {
+        abort E_ZERO
+    }
+
+    /// Aborts with a canonical `std::error` code whose reason is 0.
+    public entry fun abort_with_canonical_zero(_s: &signer) {
+        abort error::not_found(E_ZERO)
+    }
+
+    /// Aborts directly with a non-zero user-defined error code.
+    public entry fun abort_with_user_nonzero(_s: &signer) {
+        abort E_NONZERO
+    }
+
+    /// Aborts with a canonical `std::error` code whose reason is non-zero.
+    public entry fun abort_with_canonical_nonzero(_s: &signer) {
+        abort error::not_found(E_NONZERO)
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/error_map.rs
+++ b/aptos-move/e2e-move-tests/src/tests/error_map.rs
@@ -7,6 +7,7 @@ use crate::{assert_success, tests::common, MoveHarness};
 use aptos_framework::BuildOptions;
 use aptos_types::{
     account_address::AccountAddress,
+    on_chain_config::FeatureFlag,
     transaction::{ExecutionStatus, TransactionStatus},
 };
 use move_core_types::value::MoveValue;
@@ -57,6 +58,115 @@ fn error_map() {
         "ESOME_OTHER_ERROR",
         "This error is often raised as well.",
     );
+}
+
+/// Exercises the fix for compiler-generated abort codes (e.g. from a single-argument
+/// `assert!`) being incorrectly resolved to a user-defined error constant whose lower
+/// 12 bits happen to be zero.
+#[test]
+fn unspecified_abort_does_not_match_user_zero() {
+    let mut h = MoveHarness::new();
+    h.enable_features(
+        vec![FeatureFlag::EXTRACT_ABORT_INFO_EXACT_MATCH],
+        vec![],
+    );
+
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+    assert_success!(h.publish_package_with_options(
+        &acc,
+        &common::test_dir_path("error_map.data/pack_unspecified_abort"),
+        BuildOptions {
+            with_error_map: true,
+            ..BuildOptions::default()
+        }
+    ));
+
+    // 1. `assert!(false)` aborts with UNSPECIFIED_ABORT_CODE; even though E_ZERO = 0
+    //    exists in the module, no AbortInfo should be returned.
+    let status = h.run_entry_function(
+        &acc,
+        str::parse("0xcafe::test_unspecified_abort::unspecified_abort").unwrap(),
+        vec![],
+        vec![],
+    );
+    match status {
+        TransactionStatus::Keep(ExecutionStatus::MoveAbort { info, .. }) => {
+            assert!(
+                info.is_none(),
+                "UNSPECIFIED_ABORT_CODE must not resolve to user error code 0",
+            );
+        },
+        other => panic!("expected MoveAbort, got {:?}", other),
+    }
+
+    // 2. Aborting directly with E_ZERO must still produce AbortInfo.
+    let status = h.run_entry_function(
+        &acc,
+        str::parse("0xcafe::test_unspecified_abort::abort_with_user_zero").unwrap(),
+        vec![],
+        vec![],
+    );
+    check_error(status, "E_ZERO", "User-defined error that happens to use code 0.");
+
+    // 3. A canonical std::error code with reason 0 still resolves via the reason
+    //    fallback (upper 5 bytes are zero).
+    let status = h.run_entry_function(
+        &acc,
+        str::parse("0xcafe::test_unspecified_abort::abort_with_canonical_zero").unwrap(),
+        vec![],
+        vec![],
+    );
+    check_error(status, "E_ZERO", "User-defined error that happens to use code 0.");
+
+    // 4. Direct abort with a non-zero user error constant must resolve via the
+    //    exact-match path.
+    let status = h.run_entry_function(
+        &acc,
+        str::parse("0xcafe::test_unspecified_abort::abort_with_user_nonzero").unwrap(),
+        vec![],
+        vec![],
+    );
+    check_error(status, "E_NONZERO", "User-defined error with a non-zero code.");
+
+    // 5. A canonical std::error code with a non-zero reason resolves via the
+    //    reason fallback (upper 5 bytes are zero).
+    let status = h.run_entry_function(
+        &acc,
+        str::parse("0xcafe::test_unspecified_abort::abort_with_canonical_nonzero").unwrap(),
+        vec![],
+        vec![],
+    );
+    check_error(status, "E_NONZERO", "User-defined error with a non-zero code.");
+}
+
+/// Without the feature flag we keep the legacy (buggy) lookup, so that historical
+/// transactions replay with their original outputs.
+#[test]
+fn unspecified_abort_legacy_still_matches_user_zero() {
+    let mut h = MoveHarness::new();
+    h.enable_features(
+        vec![],
+        vec![FeatureFlag::EXTRACT_ABORT_INFO_EXACT_MATCH],
+    );
+
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+    assert_success!(h.publish_package_with_options(
+        &acc,
+        &common::test_dir_path("error_map.data/pack_unspecified_abort"),
+        BuildOptions {
+            with_error_map: true,
+            ..BuildOptions::default()
+        }
+    ));
+
+    let status = h.run_entry_function(
+        &acc,
+        str::parse("0xcafe::test_unspecified_abort::unspecified_abort").unwrap(),
+        vec![],
+        vec![],
+    );
+    // Legacy behaviour: spurious match against E_ZERO.
+    check_error(status, "E_ZERO", "User-defined error that happens to use code 0.");
 }
 
 fn check_error(status: TransactionStatus, reason_name: &str, description: &str) {

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -145,6 +145,10 @@ pub enum FeatureFlag {
     DISTRIBUTE_TRANSACTION_FEE = 97,
     GOVERNED_GAS_POOL = 223,
     STAKE_REWARD_USING_TREASURY = 224,
+    /// Use the fixed `extract_abort_info` lookup that does not spuriously match
+    /// compiler-generated abort codes (e.g. `UNSPECIFIED_ABORT_CODE`) against
+    /// user-defined error constants whose lower bits happen to coincide.
+    EXTRACT_ABORT_INFO_EXACT_MATCH = 225,
 }
 
 impl FeatureFlag {

--- a/types/src/vm/module_metadata.rs
+++ b/types/src/vm/module_metadata.rs
@@ -545,7 +545,13 @@ impl RuntimeModuleMetadataV1 {
             && self.struct_attributes.is_empty()
     }
 
-    pub fn extract_abort_info(&self, code: u64) -> Option<AbortInfo> {
+    /// Legacy abort-info lookup. Masks `code` with `0xFFF` before searching the error
+    /// map, which lets compiler-generated abort codes (e.g. `UNSPECIFIED_ABORT_CODE`
+    /// from a single-argument `assert!`) collide with a user-defined error constant
+    /// whose lower 12 bits happen to be zero. Retained verbatim so transactions
+    /// executed before [`FeatureFlag::EXTRACT_ABORT_INFO_EXACT_MATCH`] was activated
+    /// can be replayed deterministically; new code must use [`Self::extract_abort_info`].
+    pub fn extract_abort_info_legacy(&self, code: u64) -> Option<AbortInfo> {
         self.error_map
             .get(&(code & 0xFFF))
             .or_else(|| self.error_map.get(&code))
@@ -553,6 +559,35 @@ impl RuntimeModuleMetadataV1 {
                 reason_name: descr.code_name.clone(),
                 description: descr.code_description.clone(),
             })
+    }
+
+    /// Extract abort info for a Move abort `code`.
+    ///
+    /// Looks `code` up exactly first. On a miss, retries with just the reason (the
+    /// low 16 bits) but only if `code` matches the canonical `std::error` layout —
+    /// upper 5 bytes zero, leaving at most one category byte and two reason bytes.
+    /// Compiler-generated codes such as `UNSPECIFIED_ABORT_CODE` set bits beyond bit
+    /// 23 and so do not fall through to the reason lookup, which would otherwise let
+    /// them match an unrelated user error constant.
+    pub fn extract_abort_info(&self, code: u64) -> Option<AbortInfo> {
+        let to_info = |descr: &ErrorDescription| AbortInfo {
+            reason_name: descr.code_name.clone(),
+            description: descr.code_description.clone(),
+        };
+
+        if let Some(descr) = self.error_map.get(&code) {
+            return Some(to_info(descr));
+        }
+
+        // Bits 24-63 are zero only for canonical `std::error` codes; bail out for
+        // anything else (compiler-generated codes, opaque user codes) so the reason
+        // fallback can't pull in an unrelated user constant.
+        if code >> 24 != 0 {
+            return None;
+        }
+
+        let reason = code & 0xFFFF;
+        self.error_map.get(&reason).map(to_info)
     }
 }
 
@@ -795,5 +830,78 @@ mod test {
         assert!(!module_scope.are_equal_module_ids(&id("0x1::foo"), &id("0x1::bar")));
         assert!(!module_scope.are_equal_module_ids(&id("0x1::foo"), &id("0x2::foo")));
         assert!(!module_scope.are_equal_module_ids(&id("0x1::foo"), &id("0x2::bar")));
+    }
+
+    fn metadata_with_user_error_zero() -> RuntimeModuleMetadataV1 {
+        let mut error_map = BTreeMap::new();
+        error_map.insert(0, ErrorDescription {
+            code_name: "E_ZERO".to_string(),
+            code_description: "user error with code 0".to_string(),
+        });
+        RuntimeModuleMetadataV1 {
+            error_map,
+            ..Default::default()
+        }
+    }
+
+    // `assert!(false)` lowers to UNSPECIFIED_ABORT_CODE (0xCA26CD000000) — bits set
+    // far above bit 23, lower 12 bits zero.
+    const UNSPECIFIED_ABORT_CODE: u64 = 0xCA26CD000000;
+    // `error::not_found(0)` packs category 6 in bits 16-23 and reason 0 in bits 0-15.
+    const CANONICAL_NOT_FOUND_REASON_ZERO: u64 = 0x60000;
+
+    #[test]
+    fn extract_abort_info_legacy_matches_compiler_codes_to_user_zero() {
+        // Documents the bug the new lookup fixes: with the old `code & 0xFFF` mask,
+        // a compiler-generated abort whose lower 12 bits are zero collides with a
+        // user-defined error constant equal to zero.
+        let md = metadata_with_user_error_zero();
+        let info = md.extract_abort_info_legacy(UNSPECIFIED_ABORT_CODE);
+        assert!(info.is_some(), "legacy lookup is expected to spuriously match");
+        assert_eq!(info.unwrap().reason_name, "E_ZERO");
+    }
+
+    #[test]
+    fn extract_abort_info_does_not_match_compiler_generated_codes() {
+        let md = metadata_with_user_error_zero();
+        assert!(md.extract_abort_info(UNSPECIFIED_ABORT_CODE).is_none());
+    }
+
+    #[test]
+    fn extract_abort_info_matches_direct_user_code() {
+        let md = metadata_with_user_error_zero();
+        let info = md.extract_abort_info(0).expect("user code 0 must match");
+        assert_eq!(info.reason_name, "E_ZERO");
+    }
+
+    #[test]
+    fn extract_abort_info_falls_back_to_reason_for_canonical_codes() {
+        // A canonical std::error code with reason 0 should still resolve via the
+        // reason fallback because the upper 5 bytes are zero.
+        let md = metadata_with_user_error_zero();
+        let info = md
+            .extract_abort_info(CANONICAL_NOT_FOUND_REASON_ZERO)
+            .expect("canonical std::error reason 0 must fall back to user code 0");
+        assert_eq!(info.reason_name, "E_ZERO");
+    }
+
+    #[test]
+    fn extract_abort_info_prefers_exact_match_over_reason() {
+        // If the map has both an exact entry and a reason entry, the exact entry wins.
+        let mut error_map = BTreeMap::new();
+        error_map.insert(0, ErrorDescription {
+            code_name: "E_REASON".to_string(),
+            code_description: "via reason fallback".to_string(),
+        });
+        error_map.insert(CANONICAL_NOT_FOUND_REASON_ZERO, ErrorDescription {
+            code_name: "E_FULL".to_string(),
+            code_description: "via exact match".to_string(),
+        });
+        let md = RuntimeModuleMetadataV1 {
+            error_map,
+            ..Default::default()
+        };
+        let info = md.extract_abort_info(CANONICAL_NOT_FOUND_REASON_ZERO).unwrap();
+        assert_eq!(info.reason_name, "E_FULL");
     }
 }


### PR DESCRIPTION
## Description

Backport of upstream [aptos-core 162a5298291a](https://github.com/aptos-labs/aptos-core/commit/162a5298291a) ("[vm] Fix extract_abort_info for compiler-generated abort codes (#19090)").
 
Please check the commit message for the problem we fix.

## How Has This Been Tested?

New unit tests and e2e tests.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation
