### PR TITLE
add .movement to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ docker/compose/indexer-grpc/data-service-grpc-server.key
 
 # Aptos CLI / local testnet files
 .aptos
+.movement
 **/*.rdb
 
 # VSCode settings


### PR DESCRIPTION
## Description
- add .movement to .gitignore to avoid private keys being pushed to the repo.

## How Has This Been Tested?
- No test required, trivial change
