### PR TITLE
feat: add per-peer inbound throttle for message and byte rate limiting

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -118,6 +118,9 @@ pub struct NetworkConfig {
     pub inbound_rate_limit_config: Option<RateLimitConfig>,
     /// Outbound rate limiting configuration, if not specified, no rate limiting
     pub outbound_rate_limit_config: Option<RateLimitConfig>,
+    /// Per-peer inbound rate limiting for messages and bytes.
+    /// If None, per-peer inbound rate limiting is disabled.
+    pub inbound_peer_rate_limit_config: Option<InboundPeerRateLimitConfig>,
     /// The maximum size of an inbound or outbound message (it may be divided into multiple frame)
     pub max_message_size: usize,
     /// The maximum number of parallel message deserialization tasks that can run (per application)
@@ -158,6 +161,7 @@ impl NetworkConfig {
             max_inbound_connections: MAX_INBOUND_CONNECTIONS,
             inbound_rate_limit_config: None,
             outbound_rate_limit_config: None,
+            inbound_peer_rate_limit_config: None,
             max_message_size: MAX_MESSAGE_SIZE,
             inbound_rx_buffer_size_bytes: None,
             inbound_tx_buffer_size_bytes: None,
@@ -386,6 +390,16 @@ impl Default for RateLimitConfig {
             enabled: true,
         }
     }
+}
+
+/// Per-peer inbound rate limiting configuration
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct InboundPeerRateLimitConfig {
+    /// Max inbound bytes/sec per peer. None = unlimited.
+    pub inbound_bytes_per_second: Option<u64>,
+    /// Max inbound messages/sec per peer. None = unlimited.
+    pub inbound_messages_per_second: Option<u64>,
 }
 
 pub type PeerSet = HashMap<PeerId, Peer>;

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -85,6 +85,7 @@ impl NetworkBuilder {
         network_channel_size: usize,
         inbound_connection_limit: usize,
         tcp_buffer_cfg: TCPBufferCfg,
+        inbound_peer_rate_limit_config: Option<aptos_config::config::InboundPeerRateLimitConfig>,
     ) -> Self {
         // A network cannot exist without a PeerManager
         // TODO:  construct this in create and pass it to new() as a parameter. The complication is manual construction of NetworkBuilder in various tests.
@@ -101,6 +102,7 @@ impl NetworkBuilder {
             enable_proxy_protocol,
             inbound_connection_limit,
             tcp_buffer_cfg,
+            inbound_peer_rate_limit_config,
         );
 
         NetworkBuilder {
@@ -140,6 +142,7 @@ impl NetworkBuilder {
             NETWORK_CHANNEL_SIZE,
             MAX_INBOUND_CONNECTIONS,
             TCPBufferCfg::default(),
+            None, /* inbound_peer_rate_limit_config */
         );
 
         builder.add_connectivity_manager(
@@ -195,6 +198,7 @@ impl NetworkBuilder {
                 config.outbound_rx_buffer_size_bytes,
                 config.outbound_tx_buffer_size_bytes,
             ),
+            config.inbound_peer_rate_limit_config.clone(),
         );
 
         network_builder.add_connection_monitoring(

--- a/network/framework/src/counters.rs
+++ b/network/framework/src/counters.rs
@@ -681,3 +681,37 @@ pub fn inbound_queue_delay_observe(protocol_id: ProtocolId, seconds: f64) {
         .with_label_values(&[protocol_id.as_str()])
         .observe(seconds)
 }
+
+/// Number of inbound messages delayed by the per-peer throttle
+pub static APTOS_NETWORK_PEER_THROTTLE_DELAYED_TOTAL: Lazy<IntCounterVec> =
+    Lazy::new(|| {
+        register_int_counter_vec!(
+            "aptos_network_peer_throttle_delayed_total",
+            "Inbound messages delayed by per-peer throttle, by bucket kind",
+            &["bucket"]
+        )
+        .unwrap()
+    });
+
+pub fn inc_peer_throttle_delayed(bucket_label: &str) {
+    APTOS_NETWORK_PEER_THROTTLE_DELAYED_TOTAL
+        .with_label_values(&[bucket_label])
+        .inc();
+}
+
+/// Number of inbound messages dropped because they exceed the per-peer throttle capacity
+pub static APTOS_NETWORK_PEER_THROTTLE_REJECTED_TOTAL: Lazy<IntCounterVec> =
+    Lazy::new(|| {
+        register_int_counter_vec!(
+            "aptos_network_peer_throttle_rejected_total",
+            "Inbound messages dropped because they exceed per-peer throttle capacity",
+            &["bucket"]
+        )
+        .unwrap()
+    });
+
+pub fn inc_peer_throttle_rejected(bucket_label: &str) {
+    APTOS_NETWORK_PEER_THROTTLE_REJECTED_TOTAL
+        .with_label_values(&[bucket_label])
+        .inc();
+}

--- a/network/framework/src/peer/fuzzing.rs
+++ b/network/framework/src/peer/fuzzing.rs
@@ -108,6 +108,7 @@ pub fn fuzz(data: &[u8]) {
         constants::MAX_CONCURRENT_OUTBOUND_RPCS,
         constants::MAX_FRAME_SIZE,
         constants::MAX_MESSAGE_SIZE,
+        None, /* inbound_throttle */
     );
     executor.spawn(peer.start());
 

--- a/network/framework/src/peer/inbound_throttle.rs
+++ b/network/framework/src/peer/inbound_throttle.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Aptos Foundation
+// Copyright (c) Movement Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
@@ -126,25 +126,16 @@ impl PeerInboundThrottle {
 /// Stream fragments do not count as a new message (only headers do) but their
 /// bytes are still accounted for.
 fn compute_message_cost(message: &Result<MultiplexMessage, ReadError>) -> (u64, u64) {
-    let msg_cost: u64 = match message {
-        Ok(MultiplexMessage::Message(_)) => 1,
-        Ok(MultiplexMessage::Stream(StreamMessage::Header(_))) => 1,
-        Ok(MultiplexMessage::Stream(StreamMessage::Fragment(_))) => 0,
-        Err(_) => 0,
-    };
-
-    let byte_cost: u64 = match message {
-        Ok(MultiplexMessage::Message(msg)) => msg.data_len() as u64,
+    match message {
+        Ok(MultiplexMessage::Message(msg)) => (1, msg.data_len() as u64),
         Ok(MultiplexMessage::Stream(StreamMessage::Header(h))) => {
-            h.message.data_len() as u64
+            (1, h.message.data_len() as u64)
         },
         Ok(MultiplexMessage::Stream(StreamMessage::Fragment(f))) => {
-            f.raw_data.len() as u64
+            (0, f.raw_data.len() as u64)
         },
-        Err(_) => 0,
-    };
-
-    (msg_cost, byte_cost)
+        Err(_) => (0, 0),
+    }
 }
 
 /// Spin on the bucket until `cost` tokens are available, sleeping in between.

--- a/network/framework/src/peer/inbound_throttle.rs
+++ b/network/framework/src/peer/inbound_throttle.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use aptos_logger::debug;
 use aptos_time_service::{TimeService, TimeServiceTrait};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 const MSG_RATE_LABEL: &str = "msg_rate";
 const BYTE_RATE_LABEL: &str = "byte_rate";
@@ -22,22 +22,21 @@ struct LeakyBucket {
     available: f64,
     max_capacity: u64,
     per_second: u64,
-    last_update: Instant,
+    last_update: std::time::Instant,
 }
 
 impl LeakyBucket {
-    fn new(max_capacity: u64, per_second: u64) -> Self {
+    fn new(max_capacity: u64, per_second: u64, now: std::time::Instant) -> Self {
         Self {
             available: max_capacity as f64,
             max_capacity,
             per_second,
-            last_update: Instant::now(),
+            last_update: now,
         }
     }
 
-    /// Replenish tokens based on wall-clock time since last call.
-    fn replenish(&mut self) {
-        let now = Instant::now();
+    /// Replenish tokens based on elapsed time since last call.
+    fn replenish(&mut self, now: std::time::Instant) {
         let delta = now.duration_since(self.last_update);
         let added = delta.as_secs_f64() * self.per_second as f64;
         self.available = (self.available + added).min(self.max_capacity as f64);
@@ -49,12 +48,12 @@ impl LeakyBucket {
     /// - `Ok(())` — cost was deducted successfully.
     /// - `Err(Some(d))` — not enough capacity right now; caller should wait `d`.
     /// - `Err(None)` — cost exceeds the bucket's max capacity and can never be satisfied.
-    fn try_spend(&mut self, cost: u64) -> Result<(), Option<Duration>> {
+    fn try_spend(&mut self, cost: u64, now: std::time::Instant) -> Result<(), Option<Duration>> {
         if cost > self.max_capacity {
             return Err(None);
         }
 
-        self.replenish();
+        self.replenish(now);
 
         if self.available >= cost as f64 {
             self.available -= cost as f64;
@@ -88,8 +87,9 @@ impl PeerInboundThrottle {
             return None;
         }
 
-        let msg_bucket = msg_per_sec.map(|r| LeakyBucket::new(r, r));
-        let byte_bucket = bytes_per_sec.map(|r| LeakyBucket::new(r, r));
+        let now = time_service.now();
+        let msg_bucket = msg_per_sec.map(|r| LeakyBucket::new(r, r, now));
+        let byte_bucket = bytes_per_sec.map(|r| LeakyBucket::new(r, r, now));
 
         Some(Self {
             byte_bucket,
@@ -108,12 +108,14 @@ impl PeerInboundThrottle {
 
         if let Some(bucket) = &mut self.msg_bucket {
             if msg_cost > 0 {
-                acquire_or_wait(bucket, msg_cost, &self.time_service, MSG_RATE_LABEL).await?;
+                acquire_or_wait(bucket, msg_cost, &self.time_service, MSG_RATE_LABEL)
+                    .await?;
             }
         }
         if let Some(bucket) = &mut self.byte_bucket {
             if byte_cost > 0 {
-                acquire_or_wait(bucket, byte_cost, &self.time_service, BYTE_RATE_LABEL).await?;
+                acquire_or_wait(bucket, byte_cost, &self.time_service, BYTE_RATE_LABEL)
+                    .await?;
             }
         }
 
@@ -146,7 +148,7 @@ async fn acquire_or_wait(
     label: &'static str,
 ) -> Result<(), PeerManagerError> {
     loop {
-        match bucket.try_spend(cost) {
+        match bucket.try_spend(cost, time_service.now()) {
             Ok(()) => return Ok(()),
             Err(Some(delay)) => {
                 debug!(

--- a/network/framework/src/peer/inbound_throttle.rs
+++ b/network/framework/src/peer/inbound_throttle.rs
@@ -1,0 +1,366 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    counters,
+    peer_manager::PeerManagerError,
+    protocols::{
+        stream::StreamMessage,
+        wire::messaging::v1::{MultiplexMessage, ReadError},
+    },
+};
+use aptos_logger::debug;
+use aptos_time_service::{TimeService, TimeServiceTrait};
+use std::time::{Duration, Instant};
+
+const MSG_RATE_LABEL: &str = "msg_rate";
+const BYTE_RATE_LABEL: &str = "byte_rate";
+
+/// A leaky-bucket style rate controller that tracks available capacity and
+/// replenishes it over time.
+struct LeakyBucket {
+    available: f64,
+    max_capacity: u64,
+    per_second: u64,
+    last_update: Instant,
+}
+
+impl LeakyBucket {
+    fn new(max_capacity: u64, per_second: u64) -> Self {
+        Self {
+            available: max_capacity as f64,
+            max_capacity,
+            per_second,
+            last_update: Instant::now(),
+        }
+    }
+
+    /// Replenish tokens based on wall-clock time since last call.
+    fn replenish(&mut self) {
+        let now = Instant::now();
+        let delta = now.duration_since(self.last_update);
+        let added = delta.as_secs_f64() * self.per_second as f64;
+        self.available = (self.available + added).min(self.max_capacity as f64);
+        self.last_update = now;
+    }
+
+    /// Attempt to spend `cost` units from the bucket.
+    ///
+    /// - `Ok(())` — cost was deducted successfully.
+    /// - `Err(Some(d))` — not enough capacity right now; caller should wait `d`.
+    /// - `Err(None)` — cost exceeds the bucket's max capacity and can never be satisfied.
+    fn try_spend(&mut self, cost: u64) -> Result<(), Option<Duration>> {
+        if cost > self.max_capacity {
+            return Err(None);
+        }
+
+        self.replenish();
+
+        if self.available >= cost as f64 {
+            self.available -= cost as f64;
+            Ok(())
+        } else {
+            let shortfall = cost as f64 - self.available;
+            let wait = shortfall / self.per_second as f64;
+            Err(Some(Duration::from_secs_f64(wait)))
+        }
+    }
+}
+
+/// Per-peer inbound throttle that limits message rate and byte rate using
+/// leaky buckets. Constructed once per accepted connection and owned by the
+/// [`Peer`](super::Peer) actor.
+pub struct PeerInboundThrottle {
+    byte_bucket: Option<LeakyBucket>,
+    msg_bucket: Option<LeakyBucket>,
+    time_service: TimeService,
+}
+
+impl PeerInboundThrottle {
+    /// Build a throttle from the given per-second limits.
+    /// Returns `None` when both limits are `None` (throttling disabled).
+    pub fn new(
+        msg_per_sec: Option<u64>,
+        bytes_per_sec: Option<u64>,
+        time_service: TimeService,
+    ) -> Option<Self> {
+        if msg_per_sec.is_none() && bytes_per_sec.is_none() {
+            return None;
+        }
+
+        let msg_bucket = msg_per_sec.map(|r| LeakyBucket::new(r, r));
+        let byte_bucket = bytes_per_sec.map(|r| LeakyBucket::new(r, r));
+
+        Some(Self {
+            byte_bucket,
+            msg_bucket,
+            time_service,
+        })
+    }
+
+    /// Block until both buckets can accommodate the given message, or return
+    /// an error if the message exceeds a bucket's maximum capacity.
+    pub async fn check_and_wait(
+        &mut self,
+        message: &Result<MultiplexMessage, ReadError>,
+    ) -> Result<(), PeerManagerError> {
+        let (msg_cost, byte_cost) = compute_message_cost(message);
+
+        if let Some(bucket) = &mut self.msg_bucket {
+            if msg_cost > 0 {
+                acquire_or_wait(bucket, msg_cost, &self.time_service, MSG_RATE_LABEL).await?;
+            }
+        }
+        if let Some(bucket) = &mut self.byte_bucket {
+            if byte_cost > 0 {
+                acquire_or_wait(bucket, byte_cost, &self.time_service, BYTE_RATE_LABEL).await?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Determine how many message-units and bytes a [`MultiplexMessage`] costs.
+///
+/// Stream fragments do not count as a new message (only headers do) but their
+/// bytes are still accounted for.
+fn compute_message_cost(message: &Result<MultiplexMessage, ReadError>) -> (u64, u64) {
+    let msg_cost: u64 = match message {
+        Ok(MultiplexMessage::Message(_)) => 1,
+        Ok(MultiplexMessage::Stream(StreamMessage::Header(_))) => 1,
+        Ok(MultiplexMessage::Stream(StreamMessage::Fragment(_))) => 0,
+        Err(_) => 0,
+    };
+
+    let byte_cost: u64 = match message {
+        Ok(MultiplexMessage::Message(msg)) => msg.data_len() as u64,
+        Ok(MultiplexMessage::Stream(StreamMessage::Header(h))) => {
+            h.message.data_len() as u64
+        },
+        Ok(MultiplexMessage::Stream(StreamMessage::Fragment(f))) => {
+            f.raw_data.len() as u64
+        },
+        Err(_) => 0,
+    };
+
+    (msg_cost, byte_cost)
+}
+
+/// Spin on the bucket until `cost` tokens are available, sleeping in between.
+async fn acquire_or_wait(
+    bucket: &mut LeakyBucket,
+    cost: u64,
+    time_service: &TimeService,
+    label: &'static str,
+) -> Result<(), PeerManagerError> {
+    loop {
+        match bucket.try_spend(cost) {
+            Ok(()) => return Ok(()),
+            Err(Some(delay)) => {
+                debug!(
+                    "Peer throttle: {} bucket short {} tokens, backing off {:?}",
+                    label, cost, delay
+                );
+                counters::inc_peer_throttle_delayed(label);
+                time_service.sleep(delay).await;
+            },
+            Err(None) => {
+                counters::inc_peer_throttle_rejected(label);
+                return Err(PeerManagerError::InboundThrottleCapacityExceeded);
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        protocols::{
+            stream::{StreamFragment, StreamHeader},
+            wire::messaging::v1::{DirectSendMsg, NetworkMessage},
+        },
+        ProtocolId,
+    };
+    use aptos_time_service::MockTimeService;
+    use std::io;
+
+    #[test]
+    fn cost_of_direct_send() {
+        let msg = make_direct_send(42);
+        let (msgs, bytes) = compute_message_cost(&msg);
+        assert_eq!(msgs, 1);
+        assert_eq!(bytes, 42);
+    }
+
+    #[test]
+    fn cost_of_stream_header() {
+        let msg = make_stream_header(20);
+        let (msgs, bytes) = compute_message_cost(&msg);
+        assert_eq!(msgs, 1);
+        assert_eq!(bytes, 20);
+    }
+
+    #[test]
+    fn cost_of_stream_fragment() {
+        let msg = make_stream_fragment(15);
+        let (msgs, bytes) = compute_message_cost(&msg);
+        assert_eq!(msgs, 0);
+        assert_eq!(bytes, 15);
+    }
+
+    #[test]
+    fn cost_of_error_is_zero() {
+        let io_err = io::Error::other("test error");
+        let (msgs, bytes) = compute_message_cost(&Err(ReadError::IoError(io_err)));
+        assert_eq!(msgs, 0);
+        assert_eq!(bytes, 0);
+    }
+
+    #[test]
+    fn disabled_when_no_limits() {
+        let ts = TimeService::mock();
+        assert!(PeerInboundThrottle::new(None, None, ts).is_none());
+    }
+
+    #[test]
+    fn enabled_with_byte_limit_only() {
+        let ts = TimeService::mock();
+        assert!(PeerInboundThrottle::new(None, Some(100), ts).is_some());
+    }
+
+    #[test]
+    fn enabled_with_msg_limit_only() {
+        let ts = TimeService::mock();
+        assert!(PeerInboundThrottle::new(Some(10), None, ts).is_some());
+    }
+
+    #[tokio::test]
+    async fn within_budget_passes_immediately() {
+        let (mut t, _) = build_throttle(10, 1000);
+        let msg = make_direct_send(100);
+        t.check_and_wait(&msg).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn rejects_when_bytes_exceed_capacity() {
+        let (mut t, _) = build_throttle(50, 1);
+        let msg = make_direct_send(100);
+        let res = t.check_and_wait(&msg).await;
+        assert!(matches!(res, Err(PeerManagerError::InboundThrottleCapacityExceeded)));
+    }
+
+    #[tokio::test]
+    async fn rejects_when_msg_limit_is_zero() {
+        let (mut t, _) = build_throttle(0, 1000);
+        let msg = make_direct_send(100);
+        let res = t.check_and_wait(&msg).await;
+        assert!(matches!(res, Err(PeerManagerError::InboundThrottleCapacityExceeded)));
+    }
+
+    #[tokio::test]
+    async fn blocks_then_resumes_after_refill() {
+        let (mut t, mock_time) = build_throttle(100, 100);
+
+        let task = tokio::spawn(async move {
+            t.check_and_wait(&make_direct_send(100)).await.unwrap();
+            t.check_and_wait(&make_direct_send(100)).await
+        });
+
+        tokio::task::yield_now().await;
+        mock_time.advance_secs_async(1).await;
+
+        task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn msg_token_refill_unblocks() {
+        let (mut t, mock_time) = build_throttle(1, 1000);
+
+        let task = tokio::spawn(async move {
+            t.check_and_wait(&make_direct_send(1)).await.unwrap();
+            t.check_and_wait(&make_direct_send(1)).await
+        });
+
+        tokio::task::yield_now().await;
+        mock_time.advance_secs_async(1).await;
+
+        task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn fragments_skip_msg_accounting() {
+        let (mut t, _) = build_throttle(0, 1000);
+        for _ in 0..10 {
+            t.check_and_wait(&make_stream_fragment(0)).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn fragment_bytes_still_counted() {
+        let (mut t, mock_time) = build_throttle(1000, 50);
+
+        let task = tokio::spawn(async move {
+            t.check_and_wait(&make_stream_fragment(50)).await.unwrap();
+            t.check_and_wait(&make_stream_fragment(50)).await
+        });
+
+        tokio::task::yield_now().await;
+        mock_time.advance_secs_async(1).await;
+
+        task.await.unwrap().unwrap();
+    }
+
+    // -- helpers --
+
+    fn make_direct_send(n: usize) -> Result<MultiplexMessage, ReadError> {
+        Ok(MultiplexMessage::Message(NetworkMessage::DirectSendMsg(
+            DirectSendMsg {
+                protocol_id: ProtocolId::ConsensusDirectSendJson,
+                priority: 0,
+                raw_msg: vec![0u8; n],
+            },
+        )))
+    }
+
+    fn make_stream_header(n: usize) -> Result<MultiplexMessage, ReadError> {
+        let message = NetworkMessage::DirectSendMsg(DirectSendMsg {
+            protocol_id: ProtocolId::ConsensusDirectSendJson,
+            priority: 0,
+            raw_msg: vec![0u8; n],
+        });
+        Ok(MultiplexMessage::Stream(StreamMessage::Header(
+            StreamHeader {
+                request_id: 0,
+                num_fragments: 1,
+                message,
+            },
+        )))
+    }
+
+    fn make_stream_fragment(n: usize) -> Result<MultiplexMessage, ReadError> {
+        Ok(MultiplexMessage::Stream(StreamMessage::Fragment(
+            StreamFragment {
+                request_id: 0,
+                fragment_id: 0,
+                raw_data: vec![0u8; n],
+            },
+        )))
+    }
+
+    fn build_throttle(
+        msg_per_sec: u64,
+        bytes_per_sec: u64,
+    ) -> (PeerInboundThrottle, MockTimeService) {
+        let mock = MockTimeService::new();
+        let ts = TimeService::from_mock(mock.clone());
+        let throttle = PeerInboundThrottle::new(
+            Some(msg_per_sec),
+            Some(bytes_per_sec),
+            ts,
+        )
+        .unwrap();
+        (throttle, mock)
+    }
+}

--- a/network/framework/src/peer/mod.rs
+++ b/network/framework/src/peer/mod.rs
@@ -21,6 +21,7 @@ use crate::{
         DECLINED_LABEL, FAILED_LABEL, RECEIVED_LABEL, SENT_LABEL, UNKNOWN_LABEL,
     },
     logging::NetworkSchema,
+    peer::inbound_throttle::PeerInboundThrottle,
     peer_manager::{PeerManagerError, TransportNotification},
     protocols::{
         direct_send::Message,
@@ -61,6 +62,8 @@ mod test;
 
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod fuzzing;
+
+pub(crate) mod inbound_throttle;
 
 /// Requests [`Peer`] receives from the [`PeerManager`](crate::peer_manager::PeerManager).
 #[derive(Debug)]
@@ -138,6 +141,8 @@ pub struct Peer<TSocket> {
     max_message_size: usize,
     /// Inbound stream buffer
     inbound_stream: InboundStreamBuffer,
+    /// Optional per-peer inbound rate limiter
+    inbound_throttle: Option<PeerInboundThrottle>,
 }
 
 impl<TSocket> Peer<TSocket>
@@ -160,6 +165,7 @@ where
         max_concurrent_outbound_rpcs: u32,
         max_frame_size: usize,
         max_message_size: usize,
+        inbound_throttle: Option<PeerInboundThrottle>,
     ) -> Self {
         let Connection {
             metadata: connection_metadata,
@@ -193,6 +199,7 @@ where
             max_frame_size,
             max_message_size,
             inbound_stream: InboundStreamBuffer::new(max_fragments),
+            inbound_throttle,
         }
     }
 
@@ -253,6 +260,22 @@ where
                 maybe_message = reader.next() => {
                     match maybe_message {
                         Some(message) =>  {
+                            // Enforce per-peer inbound throttle (if configured)
+                            if let Some(throttle) = &mut self.inbound_throttle {
+                                if let Err(err) = throttle.check_and_wait(&message).await {
+                                    warn!(
+                                        NetworkSchema::new(&self.network_context)
+                                            .connection_metadata(&self.connection_metadata),
+                                        error = %err,
+                                        "{} Inbound message from peer {} rejected by throttle, dropping.",
+                                        self.network_context,
+                                        remote_peer_id.short_str(),
+                                    );
+                                    continue;
+                                }
+                            }
+
+                            // Handle the inbound message
                             if let Err(err) = self.handle_inbound_message(message, &mut write_reqs_tx) {
                                 warn!(
                                     NetworkSchema::new(&self.network_context)

--- a/network/framework/src/peer/test.rs
+++ b/network/framework/src/peer/test.rs
@@ -97,6 +97,7 @@ fn build_test_peer(
         MAX_CONCURRENT_OUTBOUND_RPCS,
         MAX_FRAME_SIZE,
         MAX_MESSAGE_SIZE,
+        None, /* inbound_throttle */
     );
     let peer_handle = PeerHandle(peer_reqs_tx);
 

--- a/network/framework/src/peer_manager/builder.rs
+++ b/network/framework/src/peer_manager/builder.rs
@@ -18,7 +18,10 @@ use crate::{
     ProtocolId,
 };
 use aptos_channels::{self, aptos_channel, message_queues::QueueStyle};
-use aptos_config::{config::HANDSHAKE_VERSION, network_id::NetworkContext};
+use aptos_config::{
+    config::{InboundPeerRateLimitConfig, HANDSHAKE_VERSION},
+    network_id::NetworkContext,
+};
 use aptos_crypto::x25519;
 use aptos_logger::prelude::*;
 #[cfg(any(test, feature = "testing", feature = "fuzzing"))]
@@ -78,6 +81,7 @@ struct PeerManagerContext {
     max_message_size: usize,
     inbound_connection_limit: usize,
     tcp_buffer_cfg: TCPBufferCfg,
+    inbound_rate_limit_config: Option<InboundPeerRateLimitConfig>,
 }
 
 impl PeerManagerContext {
@@ -100,6 +104,7 @@ impl PeerManagerContext {
         max_message_size: usize,
         inbound_connection_limit: usize,
         tcp_buffer_cfg: TCPBufferCfg,
+        inbound_rate_limit_config: Option<InboundPeerRateLimitConfig>,
     ) -> Self {
         Self {
             pm_reqs_tx,
@@ -116,6 +121,7 @@ impl PeerManagerContext {
             max_message_size,
             inbound_connection_limit,
             tcp_buffer_cfg,
+            inbound_rate_limit_config,
         }
     }
 
@@ -173,6 +179,7 @@ impl PeerManagerBuilder {
         enable_proxy_protocol: bool,
         inbound_connection_limit: usize,
         tcp_buffer_cfg: TCPBufferCfg,
+        inbound_rate_limit_config: Option<InboundPeerRateLimitConfig>,
     ) -> Self {
         // Setup channel to send requests to peer manager.
         let (pm_reqs_tx, pm_reqs_rx) = aptos_channel::new(
@@ -207,6 +214,7 @@ impl PeerManagerBuilder {
                 max_message_size,
                 inbound_connection_limit,
                 tcp_buffer_cfg,
+                inbound_rate_limit_config,
             )),
             peer_manager: None,
             listen_address,
@@ -340,6 +348,7 @@ impl PeerManagerBuilder {
             pm_context.max_frame_size,
             pm_context.max_message_size,
             pm_context.inbound_connection_limit,
+            pm_context.inbound_rate_limit_config,
         );
 
         // PeerManager constructor appends a public key to the listen_address.

--- a/network/framework/src/peer_manager/error.rs
+++ b/network/framework/src/peer_manager/error.rs
@@ -43,6 +43,9 @@ pub enum PeerManagerError {
 
     #[error("Error writing to wire: {0}")]
     WireWriteError(#[from] wire::WriteError),
+
+    #[error("Inbound message exceeds per-peer throttle capacity")]
+    InboundThrottleCapacityExceeded,
 }
 
 impl PeerManagerError {

--- a/network/framework/src/peer_manager/mod.rs
+++ b/network/framework/src/peer_manager/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     constants,
     counters::{self},
     logging::*,
-    peer::{Peer, PeerRequest},
+    peer::{inbound_throttle::PeerInboundThrottle, Peer, PeerRequest},
     transport::{
         Connection, ConnectionId, ConnectionMetadata, TSocket as TransportTSocket,
         TRANSPORT_TIMEOUT,
@@ -23,7 +23,10 @@ use crate::{
     ProtocolId,
 };
 use aptos_channels::{self, aptos_channel, message_queues::QueueStyle};
-use aptos_config::network_id::{NetworkContext, PeerNetworkId};
+use aptos_config::{
+    config::InboundPeerRateLimitConfig,
+    network_id::{NetworkContext, PeerNetworkId},
+};
 use aptos_logger::prelude::*;
 use aptos_netcore::transport::{ConnectionOrigin, Transport};
 use aptos_short_hex_str::AsShortHexStr;
@@ -117,6 +120,8 @@ where
     max_message_size: usize,
     /// Inbound connection limit separate of outbound connections
     inbound_connection_limit: usize,
+    /// Rate limiting configuration for inbound network traffic per peer
+    inbound_rate_limit_config: Option<InboundPeerRateLimitConfig>,
 }
 
 impl<TTransport, TSocket> PeerManager<TTransport, TSocket>
@@ -144,6 +149,7 @@ where
         max_frame_size: usize,
         max_message_size: usize,
         inbound_connection_limit: usize,
+        inbound_rate_limit_config: Option<InboundPeerRateLimitConfig>,
     ) -> Self {
         let (transport_notifs_tx, transport_notifs_rx) = aptos_channels::new(
             channel_size,
@@ -185,6 +191,7 @@ where
             max_frame_size,
             max_message_size,
             inbound_connection_limit,
+            inbound_rate_limit_config,
         }
     }
 
@@ -662,6 +669,15 @@ where
             Some(&counters::PENDING_NETWORK_REQUESTS),
         );
 
+        // Build a per-peer inbound throttle if the config is present
+        let inbound_throttle = self.inbound_rate_limit_config.as_ref().and_then(|config| {
+            PeerInboundThrottle::new(
+                config.inbound_messages_per_second,
+                config.inbound_bytes_per_second,
+                self.time_service.clone(),
+            )
+        });
+
         // Initialize a new Peer actor for this connection.
         let peer = Peer::new(
             self.network_context,
@@ -676,6 +692,7 @@ where
             constants::MAX_CONCURRENT_OUTBOUND_RPCS,
             self.max_frame_size,
             self.max_message_size,
+            inbound_throttle,
         );
         self.executor.spawn(peer.start());
 

--- a/network/framework/src/peer_manager/tests.rs
+++ b/network/framework/src/peer_manager/tests.rs
@@ -116,6 +116,7 @@ fn build_test_peer_manager(
         constants::MAX_FRAME_SIZE,
         constants::MAX_MESSAGE_SIZE,
         MAX_INBOUND_CONNECTIONS,
+        None, /* inbound_rate_limit_config */
     );
 
     (


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
 Adds configurable per-peer inbound throttling to the network framework layer. Without this, a peer that floods a node with inbound messages can degrade performance across the entire network stack. The throttle uses leaky-bucket rate controllers to enforce independent message-rate and byte-rate limits on each accepted connection.
## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
Unit tests
## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
