### PR TITLE
[db-tool] serialize tests to avoid VM logging race

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,6 +1213,7 @@ dependencies = [
  "itertools 0.13.0",
  "rayon",
  "serde_json",
+ "serial_test",
  "tokio",
 ]
 
@@ -16076,6 +16077,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16136,6 +16146,12 @@ dependencies = [
  "ring 0.17.7",
  "untrusted 0.9.0",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "seahash"
@@ -16485,6 +16501,32 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -763,6 +763,7 @@ serde-generate = { git = "https://github.com/aptos-labs/serde-reflection", rev =
 serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "73b6bbf748334b71ff6d7d09d06a29e3062ca075" }
 serde_with = "3.4.0"
 serde_yaml = "0.8.24"
+serial_test = "3.1.1"
 set_env = "1.3.4"
 shadow-rs = "0.16.2"
 simplelog = "0.9.0"

--- a/storage/db-tool/Cargo.toml
+++ b/storage/db-tool/Cargo.toml
@@ -37,3 +37,4 @@ aptos-backup-cli = { workspace = true, features = ["testing"] }
 aptos-backup-service = { workspace = true }
 aptos-executor-test-helpers = { workspace = true }
 aptos-indexer-grpc-table-info = { workspace = true }
+serial_test = { workspace = true }

--- a/storage/db-tool/src/tests.rs
+++ b/storage/db-tool/src/tests.rs
@@ -95,6 +95,7 @@ mod dbtool_tests {
         waypoint::Waypoint,
     };
     use clap::Parser;
+    use serial_test::serial;
     use std::{
         default::Default,
         fs,
@@ -119,6 +120,7 @@ mod dbtool_tests {
     }
 
     #[test]
+    #[serial]
     fn test_backup_compaction() {
         let db = test_execution_with_storage_impl();
         let backup_dir = TempPath::new();
@@ -657,6 +659,7 @@ mod dbtool_tests {
     }
 
     #[test]
+    #[serial]
     fn test_restore_db_with_trusted_waypoint_smoke() {
         let backup_dir = TempPath::new();
         backup_dir.create_as_dir().unwrap();
@@ -777,6 +780,7 @@ mod dbtool_tests {
     }
 
     #[test]
+    #[serial]
     fn test_restore_db_with_replay() {
         let backup_dir = TempPath::new();
         backup_dir.create_as_dir().unwrap();
@@ -802,6 +806,7 @@ mod dbtool_tests {
         rt.shutdown_timeout(Duration::from_secs(1));
     }
     #[test]
+    #[serial]
     fn test_restore_archive_db() {
         let backup_dir = TempPath::new();
         backup_dir.create_as_dir().unwrap();
@@ -820,6 +825,7 @@ mod dbtool_tests {
     }
 
     #[test]
+    #[serial]
     fn test_resume_db_from_kv_replay() {
         let backup_dir = TempPath::new();
         backup_dir.create_as_dir().unwrap();
@@ -859,6 +865,7 @@ mod dbtool_tests {
     }
 
     #[test]
+    #[serial]
     fn test_restore_with_sharded_db() {
         let backup_dir = TempPath::new();
         backup_dir.create_as_dir().unwrap();


### PR DESCRIPTION

## Description

The 6 tests in `dbtool_tests` (in [storage/db-tool/src/tests.rs](storage/db-tool/src/tests.rs)) drive `execute_block`, which uses the global `BUFFERED_LOG_EVENTS` static in `aptos-vm-logging`. When `cargo test` runs them in parallel, one test's `init_speculative_logs(N)` replaces the storage between another test's init and flush. The latter then panics in `SpeculativeEvents::flush` with `range end index N out of range for slice of length M` (in [crates/aptos-speculative-state-helper/src/lib.rs](crates/aptos-speculative-state-helper/src/lib.rs)).

Production block execution is single-threaded so the race doesn't occur there. This PR addresses only the parallel-test artifact, with no changes to production code: `#[serial]` (via the `serial_test` crate) is added to the affected tests so they run one at a time within the test binary.

The race is timing-dependent: on some parallel runs it hits one or several tests, on others it does not fire at all. The fix prevents it from firing regardless of scheduling.

## How Has This Been Tested?

Before fix, parallel run on `m1`:

```bash
cargo test --no-fail-fast -p aptos-db-tool --lib -- tests::dbtool_tests
```

→ result varies run-to-run. Typical outcome: at least one test panics with `range end index N out of range for slice of length M` in `SpeculativeEvents::flush`. The specific test that loses the race differs between invocations (`test_restore_with_sharded_db`, `test_backup_compaction`, `test_restore_db_with_trusted_waypoint_smoke` have all been observed). On scheduling where the race does not fire, no `range end` panic occurs.

Same set forced serial (no fix), to confirm the `range end` panic is purely a parallelism artifact:

```bash
cargo test --no-fail-fast -p aptos-db-tool --lib -- --test-threads=1 tests::dbtool_tests
```

→ no `range end` panic.

After fix, parallel run:

```bash
cargo test --no-fail-fast -p aptos-db-tool --lib -- tests::dbtool_tests
```

→ no `range end` panic, regardless of scheduling.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?

- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation