### PR TITLE
[block-executor] fix keys_read returning writes instead of reads

### DIFF
--- a/aptos-move/aptos-transaction-simulation/src/state_store.rs
+++ b/aptos-move/aptos-transaction-simulation/src/state_store.rs
@@ -342,6 +342,11 @@ where
 {
     type Key = StateKey;
 
+    fn get_state_slot(&self, state_key: &Self::Key) -> StateViewResult<StateSlot> {
+        let value_opt = self.get_state_value(state_key)?.map(|value| (0, value));
+        Ok(StateSlot::from_db_get(value_opt))
+    }
+
     fn get_state_value(&self, state_key: &Self::Key) -> StateViewResult<Option<StateValue>> {
         if let Some(res) = self.states.read().get(state_key) {
             return Ok(res.clone());

--- a/aptos-move/block-executor/src/types.rs
+++ b/aptos-move/block-executor/src/types.rs
@@ -58,7 +58,7 @@ impl<T: Transaction> ReadWriteSummary<T> {
     }
 
     pub fn keys_read(&self) -> impl Iterator<Item = &T::Key> {
-        Self::keys_except_delayed_fields(self.writes.iter())
+        Self::keys_except_delayed_fields(self.reads.iter())
     }
 
     fn keys_except_delayed_fields<'a>(


### PR DESCRIPTION
## Description

Cherry-pick of upstream [aptos-labs/aptos-core@c4a91c36c7](https://github.com/aptos-labs/aptos-core/commit/c4a91c36c7), which bundles two unrelated fixes:

**1. `keys_read()` returned the write set instead of the read set** ([aptos-move/block-executor/src/types.rs:61](aptos-move/block-executor/src/types.rs#L61)). The VM under-reported its read set to `CachedStateView`, so the hot-state cache hit rate was artificially low. Correctness/performance regression — no DoS or fund-loss exposure.

**2. `DeltaStateStore` was missing a `get_state_slot` override** ([aptos-move/aptos-transaction-simulation/src/state_store.rs](aptos-move/aptos-transaction-simulation/src/state_store.rs)). The `TStateView` trait's default `get_state_slot` is `unimplemented!()`, so any caller would panic. Defensive addition; dormant on m1 since the simulation crate is currently unbuildable here for pre-existing reasons.

## How Has This Been Tested?

No direct test coverage — the bug only surfaces as hot-state cache hit-rate degradation, which is a production-metrics observable.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?

- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation