### PR TITLE
[consensus] tighten block-validation invariants

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -378,7 +378,12 @@ impl Block {
             // but don't allow anything that shouldn't be there.
             //
             // we validate the full correctness of this field in round_manager.process_proposal()
-            let succ_round = self.round() + u64::from(self.is_nil_block());
+            let succ_round = self
+                .round()
+                .checked_add(u64::from(self.is_nil_block()))
+                .ok_or_else(|| {
+                    format_err!("Block round overflows when computing successor round")
+                })?;
             let skipped_rounds = succ_round.checked_sub(parent.round() + 1);
             ensure!(
                 skipped_rounds.is_some(),

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -268,14 +268,14 @@ impl BlockRetrievalResponse {
         self.blocks
             .iter()
             .try_fold(retrieval_request.block_id(), |expected_id, block| {
-                block.validate_signature(sig_verifier)?;
-                block.verify_well_formed()?;
                 ensure!(
                     block.id() == expected_id,
                     "blocks doesn't form a chain: expect {}, get {}",
                     expected_id,
                     block.id()
                 );
+                block.validate_signature(sig_verifier)?;
+                block.verify_well_formed()?;
                 Ok(block.parent_id())
             })
             .map(|_| ())

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -303,3 +303,50 @@ impl fmt::Display for BlockRetrievalResponse {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        block::{block_test_utils::certificate_for_genesis, Block},
+        common::Payload,
+    };
+    use aptos_types::{
+        validator_signer::ValidatorSigner, validator_verifier::random_validator_verifier,
+    };
+
+    /// The chain check (`block.id() == expected_id`, one hash compare) must run
+    /// before BLS signature verification (CPU-heavy). Otherwise a peer can stuff
+    /// unrelated blocks into a retrieval response and force the receiver to spend
+    /// BLS work on blocks that the cheap check would have rejected anyway.
+    #[test]
+    fn verify_rejects_chain_mismatch_before_signature_work() {
+        let outsider = ValidatorSigner::random(None);
+        let qc = certificate_for_genesis();
+        let block = Block::new_proposal(
+            Payload::empty(false, true),
+            1,
+            aptos_infallible::duration_since_epoch().as_micros() as u64,
+            qc,
+            &outsider,
+            Vec::new(),
+        )
+        .unwrap();
+
+        let expected_id = HashValue::zero();
+        assert_ne!(expected_id, block.id());
+
+        let (_signers, verifier) = random_validator_verifier(1, None, false);
+
+        let req = BlockRetrievalRequest::V1(BlockRetrievalRequestV1::new(expected_id, 1));
+        let response =
+            BlockRetrievalResponse::new(BlockRetrievalStatus::Succeeded, vec![block]);
+
+        let err = response.verify(req, &verifier).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("doesn't form a chain"),
+            "chain-mismatch must be detected before signature validation; got: {msg}"
+        );
+    }
+}

--- a/consensus/consensus-types/src/block_test.rs
+++ b/consensus/consensus-types/src/block_test.rs
@@ -314,3 +314,22 @@ fn test_failed_authors_well_formed() {
         .verify_well_formed()
         .is_err());
 }
+
+/// `verify_well_formed` must not panic on a nil block whose round is at u64::MAX:
+/// `self.round() + u64::from(self.is_nil_block())` would otherwise overflow.
+#[test]
+fn test_nil_block_at_max_round_does_not_panic() {
+    let qc = certificate_for_genesis();
+    let nil = Block::new_nil(u64::MAX, qc, vec![]);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        nil.verify_well_formed()
+    }));
+    assert!(
+        result.is_ok(),
+        "verify_well_formed must not panic on extreme rounds"
+    );
+    assert!(
+        result.unwrap().is_err(),
+        "verify_well_formed must reject a nil block at u64::MAX"
+    );
+}


### PR DESCRIPTION

## Description

Two fixes in `consensus/consensus-types/`:

1. `Block::verify_well_formed` panicked on a nil block at `round = u64::MAX` because `self.round() + u64::from(is_nil_block())` overflowed under overflow checks. Now uses `checked_add` and returns `Err`.
2. `BlockRetrievalResponse::verify` ran BLS signature verification before the chain-continuity check (`block.id() == expected_id`). A peer could stuff unrelated blocks into a response and burn the receiver's CPU on signature work. Order swapped — cheap check first, BLS after.

## How Has This Been Tested?

Two regression tests, red before the fix, green after:

- `block_test::test_nil_block_at_max_round_does_not_panic`
- `block_retrieval::tests::verify_rejects_chain_mismatch_before_signature_work`

```bash
cargo test -p aptos-consensus-types
```

14 / 14 pass.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?

- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation