### PR TITLE
[vm] include verifier config digest in verified-module cache key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12539,6 +12539,7 @@ version = "0.1.0"
 dependencies = [
  "ambassador",
  "anyhow",
+ "bcs 0.1.4",
  "better_any",
  "bytes",
  "claims",
@@ -12559,6 +12560,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "proptest",
  "serde",
+ "sha3 0.9.1",
  "smallbitvec",
  "triomphe",
  "typed-arena",

--- a/third_party/move/move-vm/runtime/Cargo.toml
+++ b/third_party/move/move-vm/runtime/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 
 [dependencies]
 ambassador = { workspace = true }
+bcs = { workspace = true }
 better_any = { workspace = true }
 bytes = { workspace = true }
 claims = { workspace = true }
@@ -27,6 +28,7 @@ move-vm-types = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
+sha3 = { workspace = true }
 triomphe = { workspace = true }
 typed-arena = { workspace = true }
 

--- a/third_party/move/move-vm/runtime/src/storage/environment.rs
+++ b/third_party/move/move-vm/runtime/src/storage/environment.rs
@@ -31,6 +31,7 @@ use move_vm_types::loaded_data::{
     runtime_types::StructIdentifier, struct_name_indexing::StructNameIndex,
 };
 use move_vm_types::loaded_data::{runtime_types::Type, struct_name_indexing::StructNameIndexMap};
+use sha3::{Digest, Sha3_256};
 use std::sync::Arc;
 
 /// [MoveVM] runtime environment encapsulating different configurations. Shared between the VM and
@@ -58,6 +59,17 @@ pub struct RuntimeEnvironment {
     /// Caches struct tags for instantiated types. This cache can be used concurrently and
     /// speculatively because type tag information does not change with module publishes.
     ty_tag_cache: Arc<TypeTagCache>,
+
+    /// SHA3-256 digest of the BCS-serialized [VerifierConfig] from `vm_config`. Precomputed at
+    /// construction time so it can be combined with the module hash to form the
+    /// [VERIFIED_MODULES_V2] cache key without re-hashing the config on every lookup.
+    ///
+    /// Why this exists: the verified-module cache is a process-global LRU shared across all
+    /// runtime environments. Without a per-config component in the key, two threads using
+    /// different verifier configurations (e.g. straddling an epoch boundary where the config
+    /// changed) would treat each other's cached entries as their own — a module accepted under
+    /// a more permissive config could be skipped under a stricter one.
+    verifier_config_digest: [u8; 32],
 }
 
 impl RuntimeEnvironment {
@@ -82,11 +94,13 @@ impl RuntimeEnvironment {
     ) -> Self {
         let natives = NativeFunctions::new(natives)
             .unwrap_or_else(|e| panic!("Failed to create native functions: {}", e));
+        let verifier_config_digest = digest_verifier_config(&vm_config);
         Self {
             vm_config,
             natives,
             struct_name_index_map: Arc::new(StructNameIndexMap::empty()),
             ty_tag_cache: Arc::new(TypeTagCache::empty()),
+            verifier_config_digest,
         }
     }
 
@@ -96,6 +110,9 @@ impl RuntimeEnvironment {
     }
 
     /// Enables delayed field optimization for this environment.
+    ///
+    /// Note: this does not change the verifier config, so [Self::verifier_config_digest] is
+    /// preserved.
     pub fn enable_delayed_field_optimization(&mut self) {
         self.vm_config.delayed_field_optimization_enabled = true;
     }
@@ -140,21 +157,22 @@ impl RuntimeEnvironment {
         module_size: usize,
         module_hash: &[u8; 32],
     ) -> VMResult<LocallyVerifiedModule> {
-        if !VERIFIED_MODULES_V2.contains(module_hash) {
+        if !VERIFIED_MODULES_V2.contains(module_hash, &self.verifier_config_digest) {
             let _timer = VM_TIMER.timer_with_label(
                 "LoaderV2::build_locally_verified_module [verification cache miss]",
             );
 
             // For regular execution, we cache already verified modules. Note that this even caches
-            // verification for the published modules. This should be ok because as long as the
-            // hash is the same, the deployed bytecode and any dependencies are the same, and so
-            // the cached verification result can be used.
+            // verification for the published modules. This should be ok because as long as both
+            // the module hash and the verifier-config digest match, the deployed bytecode, its
+            // dependencies, and the rules used to verify them are the same, and so the cached
+            // verification result can be reused.
             move_bytecode_verifier::verify_module_with_config(
                 &self.vm_config().verifier_config,
                 compiled_module.as_ref(),
             )?;
             check_natives(compiled_module.as_ref())?;
-            VERIFIED_MODULES_V2.put(*module_hash);
+            VERIFIED_MODULES_V2.put(*module_hash, self.verifier_config_digest);
         }
 
         Ok(LocallyVerifiedModule(compiled_module, module_size))
@@ -327,8 +345,21 @@ impl Clone for RuntimeEnvironment {
             natives: self.natives.clone(),
             struct_name_index_map: Arc::clone(&self.struct_name_index_map),
             ty_tag_cache: Arc::clone(&self.ty_tag_cache),
+            verifier_config_digest: self.verifier_config_digest,
         }
     }
+}
+
+/// Hashes the BCS-serialized verifier configuration of `vm_config` with SHA3-256.
+///
+/// Used as the per-environment component of the verified-module cache key (see
+/// [RuntimeEnvironment::verifier_config_digest] for the reasoning).
+fn digest_verifier_config(vm_config: &VMConfig) -> [u8; 32] {
+    let serialized = bcs::to_bytes(&vm_config.verifier_config)
+        .expect("VerifierConfig must be BCS-serializable");
+    let mut hasher = Sha3_256::new();
+    hasher.update(&serialized);
+    hasher.finalize().into()
 }
 
 /// Represents any type that contains a [RuntimeEnvironment].
@@ -380,4 +411,59 @@ fn check_natives(module: &CompiledModule) -> VMResult<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use move_bytecode_verifier::VerifierConfig;
+
+    fn config_with_loop_depth(max_loop_depth: Option<usize>) -> VMConfig {
+        VMConfig {
+            verifier_config: VerifierConfig {
+                max_loop_depth,
+                ..VerifierConfig::default()
+            },
+            ..VMConfig::default()
+        }
+    }
+
+    #[test]
+    fn verifier_config_digest_is_stable_for_equal_configs() {
+        let env_a = RuntimeEnvironment::new_with_config(vec![], VMConfig::default());
+        let env_b = RuntimeEnvironment::new_with_config(vec![], VMConfig::default());
+        assert_eq!(env_a.verifier_config_digest, env_b.verifier_config_digest);
+    }
+
+    #[test]
+    fn verifier_config_digest_changes_with_config() {
+        let env_a =
+            RuntimeEnvironment::new_with_config(vec![], config_with_loop_depth(Some(8)));
+        let env_b =
+            RuntimeEnvironment::new_with_config(vec![], config_with_loop_depth(Some(16)));
+        assert_ne!(
+            env_a.verifier_config_digest, env_b.verifier_config_digest,
+            "different verifier configs must yield different cache-key digests, otherwise a \
+             module verified under one config could be reused under another"
+        );
+    }
+
+    #[test]
+    fn verifier_config_digest_preserved_across_clone() {
+        let env = RuntimeEnvironment::new_with_config(vec![], config_with_loop_depth(Some(4)));
+        let clone = env.clone();
+        assert_eq!(env.verifier_config_digest, clone.verifier_config_digest);
+    }
+
+    #[test]
+    fn verifier_config_digest_preserved_when_enabling_delayed_fields() {
+        let mut env =
+            RuntimeEnvironment::new_with_config(vec![], config_with_loop_depth(Some(4)));
+        let before = env.verifier_config_digest;
+        env.enable_delayed_field_optimization();
+        assert_eq!(
+            before, env.verifier_config_digest,
+            "delayed-field toggle must not affect the verifier-config digest"
+        );
+    }
 }

--- a/third_party/move/move-vm/runtime/src/storage/environment.rs
+++ b/third_party/move/move-vm/runtime/src/storage/environment.rs
@@ -69,6 +69,9 @@ pub struct RuntimeEnvironment {
     /// different verifier configurations (e.g. straddling an epoch boundary where the config
     /// changed) would treat each other's cached entries as their own — a module accepted under
     /// a more permissive config could be skipped under a stricter one.
+    /// 
+    /// Invariant: must stay in line with `vm_config.verifier_config`. Any mutation of `vm_config.verifier_config` must
+    /// recompute this digest.
     verifier_config_digest: [u8; 32],
 }
 

--- a/third_party/move/move-vm/runtime/src/storage/verified_module_cache.rs
+++ b/third_party/move/move-vm/runtime/src/storage/verified_module_cache.rs
@@ -19,6 +19,12 @@ type Key = ([u8; 32], [u8; 32]);
 /// and V2 implementations.
 pub(crate) struct VerifiedModuleCache(Mutex<lru::LruCache<Key, ()>>);
 
+/// In test builds the cache is treated as empty: lookups always miss and inserts are no-ops.
+/// This keeps unit tests deterministic regardless of the process-global LRU's accumulated state.
+const fn cache_active() -> bool {
+    !cfg!(test) && !cfg!(feature = "testing")
+}
+
 impl VerifiedModuleCache {
     /// Maximum size of the cache. When modules are cached, they can skip re-verification.
     const VERIFIED_CACHE_SIZE: usize = 100_000;
@@ -29,22 +35,18 @@ impl VerifiedModuleCache {
     }
 
     /// Returns true if the (module hash, verifier config digest) pair is contained in the cache.
-    /// For tests, the cache is treated as empty at all times.
     pub(crate) fn contains(
         &self,
         module_hash: &[u8; 32],
         verifier_config_digest: &[u8; 32],
     ) -> bool {
-        !cfg!(test)
-            && !cfg!(feature = "testing")
-            && self.0.lock().contains(&(*module_hash, *verifier_config_digest))
+        cache_active() && self.0.lock().contains(&(*module_hash, *verifier_config_digest))
     }
 
     /// Inserts the (module hash, verifier config digest) pair into the cache, marking the
-    /// corresponding module as locally verified under that configuration. For tests, entries are
-    /// not added to the cache.
+    /// corresponding module as locally verified under that configuration.
     pub(crate) fn put(&self, module_hash: [u8; 32], verifier_config_digest: [u8; 32]) {
-        if !cfg!(test) && !cfg!(feature = "testing") {
+        if cache_active() {
             self.0
                 .lock()
                 .put((module_hash, verifier_config_digest), ());

--- a/third_party/move/move-vm/runtime/src/storage/verified_module_cache.rs
+++ b/third_party/move/move-vm/runtime/src/storage/verified_module_cache.rs
@@ -4,11 +4,20 @@
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
 
+/// Cache key for verified modules.
+///
+/// The key has two components: the module hash, and a digest of the verifier
+/// configuration that produced the verification result. Reusing a verified
+/// entry under a different verifier configuration is unsound — a module
+/// admitted under a permissive config may not be admitted under a stricter
+/// one — so the configuration digest must participate in the key.
+type Key = ([u8; 32], [u8; 32]);
+
 /// Cache for already verified modules. Since loader V1 uses such a cache to not perform repeated
 /// verifications, possibly even across blocks, for comparative performance we need to have it as
 /// well. For now, we keep it as a separate cache to make sure there is no interference between V1
 /// and V2 implementations.
-pub(crate) struct VerifiedModuleCache(Mutex<lru::LruCache<[u8; 32], ()>>);
+pub(crate) struct VerifiedModuleCache(Mutex<lru::LruCache<Key, ()>>);
 
 impl VerifiedModuleCache {
     /// Maximum size of the cache. When modules are cached, they can skip re-verification.
@@ -19,17 +28,26 @@ impl VerifiedModuleCache {
         Self(Mutex::new(lru::LruCache::new(Self::VERIFIED_CACHE_SIZE)))
     }
 
-    /// Returns true if the module hash is contained in the cache. For tests, the cache is treated
-    /// as empty at all times.
-    pub(crate) fn contains(&self, module_hash: &[u8; 32]) -> bool {
-        !cfg!(test) && !cfg!(feature = "testing") && self.0.lock().contains(module_hash)
+    /// Returns true if the (module hash, verifier config digest) pair is contained in the cache.
+    /// For tests, the cache is treated as empty at all times.
+    pub(crate) fn contains(
+        &self,
+        module_hash: &[u8; 32],
+        verifier_config_digest: &[u8; 32],
+    ) -> bool {
+        !cfg!(test)
+            && !cfg!(feature = "testing")
+            && self.0.lock().contains(&(*module_hash, *verifier_config_digest))
     }
 
-    /// Inserts the hash into the cache, marking the corresponding as locally verified. For tests,
-    /// entries are not added to the cache.
-    pub(crate) fn put(&self, module_hash: [u8; 32]) {
+    /// Inserts the (module hash, verifier config digest) pair into the cache, marking the
+    /// corresponding module as locally verified under that configuration. For tests, entries are
+    /// not added to the cache.
+    pub(crate) fn put(&self, module_hash: [u8; 32], verifier_config_digest: [u8; 32]) {
         if !cfg!(test) && !cfg!(feature = "testing") {
-            self.0.lock().put(module_hash, ());
+            self.0
+                .lock()
+                .put((module_hash, verifier_config_digest), ());
         }
     }
 }


### PR DESCRIPTION
## Description

Tighten the `VERIFIED_MODULES_V2` cache key in the Move VM runtime so that modules verified under one `VerifierConfig` are not treated as verified under a different one.

 The cache was previously keyed by module hash alone. The `RuntimeEnvironment` is process-global and the verifier config can change across an epoch boundary, so during concurrent replay two threads using different verifier configs could read each other's cached verifications. A module that was admitted under a more permissive config could then be skipped (rather than re-verified) under a stricter config — undermining the
stricter config's invariants.

This addresses the issue described in upstream `aptos-labs/aptos-core` PR
#19160. 

## How Has This Been Tested?

- `cargo check -p move-vm-runtime` — clean.
- `cargo check -p aptos-vm -p aptos-block-executor -p aptos-vm-environment`
  — clean (downstream callers unaffected).
- `cargo test -p move-vm-runtime --lib` — 11 tests pass, including 4 new
  tests in `storage::environment::tests`:
  - `verifier_config_digest_is_stable_for_equal_configs`
  - `verifier_config_digest_changes_with_config`
  - `verifier_config_digest_preserved_across_clone`
  - `verifier_config_digest_preserved_when_enabling_delayed_fields`
- `cargo test -p aptos-vm-environment --lib` — 4 tests pass.

The cache itself is no-op under `cfg(test)` / `feature = "testing"`, so the
direct cache-hit/miss behavior is exercised at the `RuntimeEnvironment` level
via the digest invariants above (different configs ⇒ different digests ⇒
different cache entries).



## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

