### PR TITLE
[aptos-dkg] WVUF verify_proof accepts full-participation boundary

### DIFF
--- a/crates/aptos-dkg/src/weighted_vuf/pinkas/mod.rs
+++ b/crates/aptos-dkg/src/weighted_vuf/pinkas/mod.rs
@@ -217,7 +217,7 @@ impl WeightedVUF for PinkasWUF {
         msg: &[u8],
         proof: &Self::Proof,
     ) -> anyhow::Result<()> {
-        if proof.len() >= apks.len() {
+        if proof.len() > apks.len() {
             bail!("Number of proof shares ({}) exceeds number of APKs ({}) when verifying aggregated WVUF proof", proof.len(), apks.len());
         }
 

--- a/crates/aptos-dkg/tests/weighted_vuf.rs
+++ b/crates/aptos-dkg/tests/weighted_vuf.rs
@@ -28,6 +28,10 @@ fn test_wvuf_basic_viability() {
 /// Boundary case: when every player in the APK vector contributes a share, the
 /// aggregated proof has one entry per APK (`proof.len() == apks.len()`). The
 /// bounds-check preflight in `verify_proof` must accept this configuration.
+///
+/// The crate has two WVUF impls: PinkasWUF (src/weighted_vuf/pinkas/mod.rs) and
+/// BlsWUF (src/weighted_vuf/bls/mod.rs). The bounds check this test exercises
+/// only exists in PinkasWUF — BlsWUF::verify_proof doesn't have one.
 #[test]
 fn test_wvuf_verify_proof_accepts_full_participation() {
     type T = pvss::das::WeightedTranscript;
@@ -42,6 +46,9 @@ fn test_wvuf_verify_proof_accepts_full_participation() {
     let vuf_pp = <WVUF as WeightedVUF>::PublicParameters::from(&d.pp);
     let msg = b"some msg";
 
+    // Decrypt each player's `(sk_share, pk_share)` from the PVSS transcript.
+    // Reverse `sks` so the next loop can `pop()` them in player order — moving
+    // out of a `Vec` by index isn't allowed.
     let (mut sks, pks): (
         Vec<<WVUF as WeightedVUF>::SecretKeyShare>,
         Vec<<WVUF as WeightedVUF>::PubKeyShare>,
@@ -52,6 +59,8 @@ fn test_wvuf_verify_proof_accepts_full_participation() {
         .unzip();
     sks.reverse();
 
+    // Augment each PVSS key pair with the WVUF randomization delta, producing
+    // per-player augmented secret/public key shares (`ASK` / `APK`).
     let augmented_key_pairs = (0..wc.get_total_num_players())
         .map(|p| {
             let sk = sks.pop().unwrap();
@@ -60,11 +69,13 @@ fn test_wvuf_verify_proof_accepts_full_participation() {
         })
         .collect::<Vec<_>>();
 
+    // The APK vector that `verify_proof` consumes — one entry per player.
     let apks = augmented_key_pairs
         .iter()
         .map(|(_, apk)| Some(apk.clone()))
         .collect::<Vec<Option<<WVUF as WeightedVUF>::AugmentedPubKeyShare>>>();
 
+    // Full participation: every player produces a share.
     let apks_and_proofs = (0..wc.get_total_num_players())
         .map(|p| {
             let player = wc.get_player(p);
@@ -77,7 +88,13 @@ fn test_wvuf_verify_proof_accepts_full_participation() {
         })
         .collect::<Vec<_>>();
 
+    // `aggregate_shares` produces one `(Player, ProofShare)` per input, so
+    // `proof.len() == apks_and_proofs.len() == apks.len()`.
     let proof = WVUF::aggregate_shares(&wc, &apks_and_proofs);
+
+    // Load-bearing for future maintainers: if `aggregate_shares` ever changes
+    // shape so this no longer holds, the test stops probing the boundary it
+    // was written for, and this assert fires first.
     assert_eq!(
         proof.len(),
         apks.len(),

--- a/crates/aptos-dkg/tests/weighted_vuf.rs
+++ b/crates/aptos-dkg/tests/weighted_vuf.rs
@@ -25,6 +25,69 @@ fn test_wvuf_basic_viability() {
     weighted_wvuf_bvt::<pvss::das::WeightedTranscript, PinkasWUF>();
 }
 
+/// Boundary case: when every player in the APK vector contributes a share, the
+/// aggregated proof has one entry per APK (`proof.len() == apks.len()`). The
+/// bounds-check preflight in `verify_proof` must accept this configuration.
+#[test]
+fn test_wvuf_verify_proof_accepts_full_participation() {
+    type T = pvss::das::WeightedTranscript;
+    type WVUF = PinkasWUF;
+
+    let mut rng = thread_rng();
+    let seed = random_scalar(&mut rng);
+    let mut rng = StdRng::from_seed(seed.to_bytes_le());
+
+    let (wc, d, trx) = weighted_pvss::<T>(&mut rng);
+
+    let vuf_pp = <WVUF as WeightedVUF>::PublicParameters::from(&d.pp);
+    let msg = b"some msg";
+
+    let (mut sks, pks): (
+        Vec<<WVUF as WeightedVUF>::SecretKeyShare>,
+        Vec<<WVUF as WeightedVUF>::PubKeyShare>,
+    ) = (0..wc.get_total_num_players())
+        .map(|p| trx.decrypt_own_share(&wc, &wc.get_player(p), &d.dks[p]))
+        .collect::<Vec<_>>()
+        .into_iter()
+        .unzip();
+    sks.reverse();
+
+    let augmented_key_pairs = (0..wc.get_total_num_players())
+        .map(|p| {
+            let sk = sks.pop().unwrap();
+            let pk = pks[p].clone();
+            WVUF::augment_key_pair(&vuf_pp, sk, pk, &mut rng)
+        })
+        .collect::<Vec<_>>();
+
+    let apks = augmented_key_pairs
+        .iter()
+        .map(|(_, apk)| Some(apk.clone()))
+        .collect::<Vec<Option<<WVUF as WeightedVUF>::AugmentedPubKeyShare>>>();
+
+    let apks_and_proofs = (0..wc.get_total_num_players())
+        .map(|p| {
+            let player = wc.get_player(p);
+            let ask = &augmented_key_pairs[p].0;
+            let apk = augmented_key_pairs[p].1.clone();
+            let proof_share = WVUF::create_share(ask, msg);
+            WVUF::verify_share(&vuf_pp, &apk, msg, &proof_share)
+                .expect("per-share verification should succeed");
+            (player, apk, proof_share)
+        })
+        .collect::<Vec<_>>();
+
+    let proof = WVUF::aggregate_shares(&wc, &apks_and_proofs);
+    assert_eq!(
+        proof.len(),
+        apks.len(),
+        "boundary precondition: proof must have one entry per APK"
+    );
+
+    WVUF::verify_proof(&vuf_pp, &d.dpk, &apks[..], msg, &proof)
+        .expect("verify_proof must accept the full-participation aggregated proof");
+}
+
 fn weighted_wvuf_bvt<
     T: Transcript<SecretSharingConfig = WeightedConfig>,
     WVUF: WeightedVUF<


### PR DESCRIPTION

## Description

[`pinkas::verify_proof`](https://github.com/movementlabsxyz/aptos-core/blob/fix/wvuf-verify-proof-bounds/crates/aptos-dkg/src/weighted_vuf/pinkas/mod.rs#L213) rejected valid aggregated proofs at the boundary `proof.len() == apks.len()` (every player contributed). [Predicate](https://github.com/movementlabsxyz/aptos-core/blob/fix/wvuf-verify-proof-bounds/crates/aptos-dkg/src/weighted_vuf/pinkas/mod.rs#L220) should be `>`, not `>=`.

## How Has This Been Tested?

- New deterministic boundary test [`test_wvuf_verify_proof_accepts_full_participation`](https://github.com/movementlabsxyz/aptos-core/blob/fix/wvuf-verify-proof-bounds/crates/aptos-dkg/tests/weighted_vuf.rs#L32) — fails before the fix, passes after.
- `cargo test -p aptos-dkg` — no regressions.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?

- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/movementlabsxyz/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation