### PR TITLE
fix(consensus): bound batch-gen packing loop on oversized txns

### DIFF
--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -234,6 +234,11 @@ impl BatchGenerator {
                 batches.push(batch);
                 *total_batches_remaining = total_batches_remaining.saturating_sub(1);
                 txns_remaining -= num_batch_txns;
+            } else {
+                // The leading transaction alone exceeds `sender_max_batch_bytes`;
+                // drop it so the loop makes progress.
+                txns.remove(0);
+                txns_remaining -= 1;
             }
         }
     }

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -237,6 +237,7 @@ impl BatchGenerator {
             } else {
                 // The leading transaction alone exceeds `sender_max_batch_bytes`;
                 // drop it so the loop makes progress.
+                counters::BATCH_GENERATOR_DROPPED_OVERSIZED_TXNS.inc();
                 txns.remove(0);
                 txns_remaining -= 1;
             }

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -143,6 +143,18 @@ pub static BATCH_GENERATOR_MAIN_LOOP: Lazy<DurationHistogram> = Lazy::new(|| {
     )
 });
 
+/// Number of transactions the batch generator dropped because the
+/// transaction's serialized size alone exceeded `sender_max_batch_bytes`.
+/// A non-zero value indicates configuration drift between the per-transaction
+/// size cap enforced upstream of the batch generator and `sender_max_batch_bytes`.
+pub static BATCH_GENERATOR_DROPPED_OVERSIZED_TXNS: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "quorum_store_batch_generator_dropped_oversized_txns",
+        "Number of transactions the batch generator dropped because their size alone exceeded sender_max_batch_bytes."
+    )
+    .unwrap()
+});
+
 //////////////////////
 // NEW QUORUM STORE
 //////////////////////

--- a/consensus/src/quorum_store/tests/batch_generator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_generator_test.rs
@@ -785,3 +785,115 @@ async fn test_remote_batches_in_progress() {
         .unwrap()
         .unwrap();
 }
+
+// Ensures the batch-generator pull cycle terminates and produces no
+// batches when every queued transaction's serialized size exceeds
+// `sender_max_batch_bytes`. The pull is bounded by a wall-clock timeout
+// so any future regression that fails to make progress under this
+// configuration fails the test deterministically instead of hanging.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_oversized_txn_does_not_hang_batch_generator() {
+    let (quorum_store_to_mempool_tx, mut quorum_store_to_mempool_rx) = channel(1_024);
+    let (batch_coordinator_cmd_tx, mut batch_coordinator_cmd_rx) = TokioChannel(100);
+
+    // Set the per-sender batch byte cap strictly below the size of a single
+    // generated transaction so every queued transaction is, by itself, too
+    // large to fit into any batch.
+    let txn_bytes_len = create_vec_signed_transactions(1)[0].txn_bytes_len();
+    let config = QuorumStoreConfig {
+        sender_max_batch_bytes: txn_bytes_len - 1,
+        ..Default::default()
+    };
+
+    let author = AccountAddress::random();
+    let mut batch_generator = BatchGenerator::new(
+        0,
+        author,
+        config,
+        Arc::new(MockQuorumStoreDB::new()),
+        Arc::new(MockBatchWriter::new()),
+        quorum_store_to_mempool_tx,
+        1000,
+    );
+
+    // Mempool-side fixture: respond to the pull with a small set of
+    // transactions and then verify the resulting batch-coordinator command.
+    let join_handle = tokio::spawn(async move {
+        let signed_txns = create_vec_signed_transactions(3);
+        // The mempool helper applies its own cumulative-size cap before
+        // returning transactions to the batch generator. Pass a generous cap
+        // (well above the total payload) so the helper does not filter any
+        // transaction out — the per-sender batch byte cap inside the batch
+        // generator is what this test exercises.
+        queue_mempool_batch_response(
+            signed_txns,
+            txn_bytes_len * 10,
+            &mut quorum_store_to_mempool_rx,
+        )
+        .await;
+
+        // The pull must produce zero batches: every transaction's size
+        // exceeds the per-sender batch byte cap, so none can be packed.
+        let quorum_store_command = batch_coordinator_cmd_rx.recv().await.unwrap();
+        if let BatchCoordinatorCommand::NewBatches(_, result) = quorum_store_command {
+            assert_eq!(
+                result.len(),
+                0,
+                "transactions exceeding sender_max_batch_bytes must not be batched"
+            );
+        } else {
+            panic!("Unexpected variant")
+        }
+    });
+
+    // Run the pull on a detached OS thread with its own runtime.
+    // `bucket_into_batches` is fully synchronous, so a non-yielding pull
+    // would block teardown of the test runtime if it lived on a tokio
+    // worker. The OS thread is independent of the test runtime; a
+    // regression that fails to make progress is reaped by the OS on test
+    // process exit instead of hanging libtest's harness.
+    let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(batch_generator.handle_scheduled_pull(300));
+        let _ = done_tx.send(result);
+    });
+
+    // A 5s budget is far above the expected runtime of a single pull cycle
+    // over a handful of transactions; tripping it indicates the pull failed
+    // to make progress.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let result = loop {
+        match done_rx.try_recv() {
+            Ok(v) => break v,
+            Err(std::sync::mpsc::TryRecvError::Empty) => {
+                if std::time::Instant::now() >= deadline {
+                    panic!(
+                        "handle_scheduled_pull must terminate when every queued txn exceeds the per-sender batch byte cap"
+                    );
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            },
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                panic!("pull thread terminated without delivering a result");
+            },
+        }
+    };
+
+    // Forward the (empty) result to the mempool-side fixture so it can run
+    // its assertion on the batch-coordinator command.
+    batch_coordinator_cmd_tx
+        .send(BatchCoordinatorCommand::NewBatches(author, result))
+        .await
+        .unwrap();
+
+    // Give the mempool-side fixture a generous deadline to drain its
+    // assertion before tearing down the test runtime.
+    timeout(Duration::from_millis(10_000), join_handle)
+        .await
+        .unwrap()
+        .unwrap();
+}

--- a/consensus/src/quorum_store/tests/batch_generator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_generator_test.rs
@@ -794,7 +794,6 @@ async fn test_remote_batches_in_progress() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_oversized_txn_does_not_hang_batch_generator() {
     let (quorum_store_to_mempool_tx, mut quorum_store_to_mempool_rx) = channel(1_024);
-    let (batch_coordinator_cmd_tx, mut batch_coordinator_cmd_rx) = TokioChannel(100);
 
     // Set the per-sender batch byte cap strictly below the size of a single
     // generated transaction so every queued transaction is, by itself, too
@@ -817,82 +816,53 @@ async fn test_oversized_txn_does_not_hang_batch_generator() {
     );
 
     // Mempool-side fixture: respond to the pull with a small set of
-    // transactions and then verify the resulting batch-coordinator command.
-    let join_handle = tokio::spawn(async move {
-        let signed_txns = create_vec_signed_transactions(3);
-        // The mempool helper applies its own cumulative-size cap before
-        // returning transactions to the batch generator. Pass a generous cap
-        // (well above the total payload) so the helper does not filter any
-        // transaction out — the per-sender batch byte cap inside the batch
-        // generator is what this test exercises.
+    // transactions. The mempool helper applies its own cumulative-size cap
+    // before returning transactions to the batch generator. Pass a generous
+    // cap (well above the total payload) so the helper does not filter any
+    // transaction out — the per-sender batch byte cap inside the batch
+    // generator is what this test exercises.
+    let fixture = tokio::spawn(async move {
         queue_mempool_batch_response(
-            signed_txns,
+            create_vec_signed_transactions(3),
             txn_bytes_len * 10,
             &mut quorum_store_to_mempool_rx,
         )
         .await;
-
-        // The pull must produce zero batches: every transaction's size
-        // exceeds the per-sender batch byte cap, so none can be packed.
-        let quorum_store_command = batch_coordinator_cmd_rx.recv().await.unwrap();
-        if let BatchCoordinatorCommand::NewBatches(_, result) = quorum_store_command {
-            assert_eq!(
-                result.len(),
-                0,
-                "transactions exceeding sender_max_batch_bytes must not be batched"
-            );
-        } else {
-            panic!("Unexpected variant")
-        }
     });
 
-    // Run the pull on a detached OS thread with its own runtime.
-    // `bucket_into_batches` is fully synchronous, so a non-yielding pull
-    // would block teardown of the test runtime if it lived on a tokio
-    // worker. The OS thread is independent of the test runtime; a
-    // regression that fails to make progress is reaped by the OS on test
-    // process exit instead of hanging libtest's harness.
+    // Run the pull on a detached OS thread, not `tokio::spawn`. The regression
+    // is a synchronous infinite loop in `bucket_into_batches`; tokio cannot
+    // preempt a task that doesn't `.await`, so `tokio::spawn` + `timeout`
+    // would record the failure but the runtime drop would then block forever
+    // waiting on the wedged worker. A detached OS thread is reaped by the OS
+    // at process exit instead. The numeric arg is `max_count` forwarded to
+    // mempool — sized so this cap does not gate the test.
     let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
     std::thread::spawn(move || {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();
-        let result = rt.block_on(batch_generator.handle_scheduled_pull(300));
-        let _ = done_tx.send(result);
+        let _ = done_tx.send(rt.block_on(batch_generator.handle_scheduled_pull(300)));
     });
 
-    // A 5s budget is far above the expected runtime of a single pull cycle
-    // over a handful of transactions; tripping it indicates the pull failed
-    // to make progress.
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    let result = loop {
-        match done_rx.try_recv() {
-            Ok(v) => break v,
-            Err(std::sync::mpsc::TryRecvError::Empty) => {
-                if std::time::Instant::now() >= deadline {
-                    panic!(
-                        "handle_scheduled_pull must terminate when every queued txn exceeds the per-sender batch byte cap"
-                    );
-                }
-                tokio::time::sleep(Duration::from_millis(50)).await;
-            },
-            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                panic!("pull thread terminated without delivering a result");
-            },
-        }
-    };
-
-    // Forward the (empty) result to the mempool-side fixture so it can run
-    // its assertion on the batch-coordinator command.
-    batch_coordinator_cmd_tx
-        .send(BatchCoordinatorCommand::NewBatches(author, result))
+    // 5s is far above the expected runtime over a handful of transactions.
+    // `recv_timeout` runs on the blocking pool so the mempool fixture can
+    // still progress on a tokio worker.
+    let result = tokio::task::spawn_blocking(move || done_rx.recv_timeout(Duration::from_secs(5)))
         .await
-        .unwrap();
+        .unwrap()
+        .expect(
+            "handle_scheduled_pull must terminate when every queued txn exceeds the per-sender batch byte cap",
+        );
 
-    // Give the mempool-side fixture a generous deadline to drain its
-    // assertion before tearing down the test runtime.
-    timeout(Duration::from_millis(10_000), join_handle)
+    assert_eq!(
+        result.len(),
+        0,
+        "transactions exceeding sender_max_batch_bytes must not be batched"
+    );
+
+    timeout(Duration::from_millis(10_000), fixture)
         .await
         .unwrap()
         .unwrap();


### PR DESCRIPTION

## Description

The QuorumStore batch generator's [packing loop](https://github.com/movementlabsxyz/aptos-core/blob/fix/batch-generator-oversized-tx-loop/consensus/src/quorum_store/batch_generator.rs#L202) iterates while `txns_remaining > 0` and decrements the counter only when at least one transaction fits under [sender_max_batch_bytes](https://github.com/movementlabsxyz/aptos-core/blob/fix/batch-generator-oversized-tx-loop/config/src/config/quorum_store_config.rs#L60). If the leading queued transaction alone exceeds that cap, the loop never makes progress and the pull cycle never returns.

This PR adds the missing `else` branch: drop the leading transaction so the loop preserves its progress invariant. A new counter [quorum_store_batch_generator_dropped_oversized_txns](https://github.com/movementlabsxyz/aptos-core/blob/fix/batch-generator-oversized-tx-loop/consensus/src/quorum_store/counters.rs#L152) surfaces drift to operators.

The hazard is latent under the VM-level per-transaction size cap and becomes live on configuration drift.

## How Has This Been Tested?

- New unit test [test_oversized_txn_does_not_hang_batch_generator](https://github.com/movementlabsxyz/aptos-core/blob/fix/batch-generator-oversized-tx-loop/consensus/src/quorum_store/tests/batch_generator_test.rs#L795): configures `sender_max_batch_bytes` below a single transaction's size, drives one pull cycle, asserts return within 5 s and zero batches. Fails on unfixed code, passes after.
- All 11 tests in [quorum_store::tests::batch_generator_test](https://github.com/movementlabsxyz/aptos-core/blob/fix/batch-generator-oversized-tx-loop/consensus/src/quorum_store/tests/batch_generator_test.rs) pass.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?

- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation