### PR TITLE
docs(framework): regenerate fungible_asset doc

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/fungible_asset.md
@@ -68,6 +68,7 @@ metadata object can be any object that equipped with <code><a href="fungible_ass
 -  [Function `is_address_balance_at_least`](#0x1_fungible_asset_is_address_balance_at_least)
 -  [Function `is_frozen`](#0x1_fungible_asset_is_frozen)
 -  [Function `is_store_dispatchable`](#0x1_fungible_asset_is_store_dispatchable)
+-  [Function `is_asset_type_dispatchable`](#0x1_fungible_asset_is_asset_type_dispatchable)
 -  [Function `deposit_dispatch_function`](#0x1_fungible_asset_deposit_dispatch_function)
 -  [Function `has_deposit_dispatch_function`](#0x1_fungible_asset_has_deposit_dispatch_function)
 -  [Function `withdraw_dispatch_function`](#0x1_fungible_asset_withdraw_dispatch_function)
@@ -2527,6 +2528,33 @@ Return whether a fungible asset type is dispatchable.
     <b>let</b> fa_store = <a href="fungible_asset.md#0x1_fungible_asset_borrow_store_resource">borrow_store_resource</a>(&store);
     <b>let</b> metadata_addr = <a href="object.md#0x1_object_object_address">object::object_address</a>(&fa_store.metadata);
     <b>exists</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a>&gt;(metadata_addr)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_fungible_asset_is_asset_type_dispatchable"></a>
+
+## Function `is_asset_type_dispatchable`
+
+Return whether a fungible asset type has any dispatch or derived-supply hooks registered.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_is_asset_type_dispatchable">is_asset_type_dispatchable</a>(metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_is_asset_type_dispatchable">is_asset_type_dispatchable</a>(metadata: Object&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a>&gt;): bool {
+    <b>let</b> metadata_addr = <a href="object.md#0x1_object_object_address">object::object_address</a>(&metadata);
+    <b>exists</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a>&gt;(metadata_addr) || <b>exists</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_DeriveSupply">DeriveSupply</a>&gt;(metadata_addr)
 }
 </code></pre>
 


### PR DESCRIPTION

## Description

Regenerates [fungible_asset.md](https://github.com/movementlabsxyz/aptos-core/blob/docs/fungible-asset-regen/aptos-move/framework/aptos-framework/doc/fungible_asset.md) to include the entry for [is_asset_type_dispatchable](https://github.com/movementlabsxyz/aptos-core/blob/docs/fungible-asset-regen/aptos-move/framework/aptos-framework/sources/fungible_asset.move#L705). The function was added by [#333](https://github.com/movementlabsxyz/aptos-core/pull/333) but the auto-generated doc was not refreshed at that time, so the file has been showing as dirty in working trees on every `cargo build` of `aptos-cached-packages` (which re-runs the framework release-builder via [build.rs](https://github.com/movementlabsxyz/aptos-core/blob/docs/fungible-asset-regen/aptos-move/framework/cached-packages/build.rs#L94)). Landing the regen here clears that dirty state for everyone.

## How Has This Been Tested?

- This diff is the output of `cargo clean -p aptos-cached-packages && cargo build -p aptos-cached-packages` on `m1`.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [x] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?

- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation