### PR TITLE
fix(storage): surface state-update fork mismatch as recoverable error

### DIFF
--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -350,7 +350,7 @@ impl Parser {
             base_state_view.persisted_state(),
             to_commit.state_update_refs(),
             base_state_view.memorized_reads(),
-        );
+        )?;
         let state_reads = base_state_view.into_memorized_reads();
 
         let out = ExecutionOutput::new(

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -418,7 +418,7 @@ fn update_state(
             &persisted_state,
             block.update_refs(),
             &memorized_reads,
-        );
+        ).unwrap();
 
         state_by_version.assert_ledger_state(&next_state);
 

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     DbReader,
 };
-use anyhow::Result;
+use anyhow::{bail, Result};
 use aptos_experimental_layered_map::{LayeredMap, MapLayer};
 use aptos_metrics_core::TimerHelper;
 use aptos_types::{
@@ -109,20 +109,24 @@ impl State {
         persisted: &State,
         updates: &BatchedStateUpdateRefs,
         state_cache: &ShardedStateCache,
-    ) -> Self {
+    ) -> Result<Self> {
         let _timer = TIMER.timer_with(&["state__update"]);
 
         // 1. The update batch must begin at self.next_version().
         assert_eq!(self.next_version(), updates.first_version);
         // 2. The cache must be at a version equal or newer than `persisted`, otherwise
         //    updates between the cached version and the persisted version are potentially
-        //    missed during the usage calculation.
-        assert!(
-            persisted.next_version() <= state_cache.next_version(),
-            "persisted: {}, cache: {}",
-            persisted.next_version(),
-            state_cache.next_version(),
-        );
+        //    missed during the usage calculation. Under speculative execution of fork
+        //    siblings, the persisted watermark can advance past the in-flight base — surface
+        //    this as a recoverable error so the local consensus module can drop the losing
+        //    branch, rather than aborting the process.
+        if persisted.next_version() > state_cache.next_version() {
+            bail!(
+                "persisted version ({}) is ahead of cache version ({}), likely due to a fork",
+                persisted.next_version(),
+                state_cache.next_version(),
+            );
+        }
         // 3. `self` must be at a version equal or newer than the cache, because we assume
         //    it is overlaid on top of the cache.
         assert!(self.next_version() >= state_cache.next_version());
@@ -150,7 +154,7 @@ impl State {
         let shards = Arc::new(shards.try_into().expect("Known to be 16 shards."));
         let usage = self.update_usage(usage_delta_per_shard);
 
-        State::new_with_updates(updates.last_version(), shards, usage)
+        Ok(State::new_with_updates(updates.last_version(), shards, usage))
     }
 
     fn update_usage(&self, usage_delta_per_shard: Vec<(i64, i64)>) -> StateStorageUsage {
@@ -237,11 +241,11 @@ impl LedgerState {
         persisted_snapshot: &State,
         updates: &StateUpdateRefs,
         reads: &ShardedStateCache,
-    ) -> LedgerState {
+    ) -> Result<LedgerState> {
         let _timer = TIMER.timer_with(&["ledger_state__update"]);
 
         let last_checkpoint = if let Some(updates) = &updates.for_last_checkpoint {
-            self.latest().update(persisted_snapshot, updates, reads)
+            self.latest().update(persisted_snapshot, updates, reads)?
         } else {
             self.last_checkpoint.clone()
         };
@@ -252,12 +256,12 @@ impl LedgerState {
             &last_checkpoint
         };
         let latest = if let Some(updates) = &updates.for_latest {
-            base_of_latest.update(persisted_snapshot, updates, reads)
+            base_of_latest.update(persisted_snapshot, updates, reads)?
         } else {
             base_of_latest.clone()
         };
 
-        LedgerState::new(latest, last_checkpoint)
+        Ok(LedgerState::new(latest, last_checkpoint))
     }
 
     /// Old values of the updated keys are read from the DbReader at the version of the
@@ -282,7 +286,7 @@ impl LedgerState {
             persisted_snapshot,
             updates,
             state_view.memorized_reads(),
-        );
+        )?;
         let state_reads = state_view.into_memorized_reads();
         Ok((updated, state_reads))
     }

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -292,3 +292,39 @@ impl LedgerState {
             && self.last_checkpoint.is_the_same(&other.last_checkpoint)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Cross-block version-ordering violations at the State::update entry point must surface as
+    /// recoverable errors. The persisted-state watermark can advance past an in-flight block's
+    /// base version under speculative execution of fork siblings; the downstream behavior is for
+    /// the local consensus module to discard the in-flight branch, which requires an error to
+    /// propagate.
+    #[test]
+    fn state_update_surfaces_recoverable_error_when_persisted_is_ahead_of_cache() {
+        // Place the persisted watermark strictly ahead of the in-flight block's base. This
+        // models the fork arrangement: a sibling block has pre-committed and advanced the
+        // persisted watermark past this branch's base.
+        let base_version = 5u64;
+        let persisted_version = base_version + 1;
+        let base_state = State::new_at_version(Some(base_version), StateStorageUsage::zero());
+        let persisted_state =
+            State::new_at_version(Some(persisted_version), StateStorageUsage::zero());
+
+        // The state-update batch must start at `base_state.next_version()` — required to
+        // reach the cross-block version check we're exercising.
+        let state_updates = BatchedStateUpdateRefs::new_empty(base_state.next_version(), 1);
+
+        // The cached state aligns with the in-flight block's base, not with the persisted
+        // watermark. The gap between the cached-state version and the persisted version is
+        // the fork-induced version mismatch the test exercises.
+        let cached_state = ShardedStateCache::new_empty(Some(base_version));
+
+        // `State::update` must surface this fork-induced version mismatch as a recoverable
+        // error and return normally — that return is the test's assertion, no explicit check
+        // is needed.
+        let _ = base_state.update(&persisted_state, &state_updates, &cached_state);
+    }
+}

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -327,8 +327,9 @@ mod tests {
         let cached_state = ShardedStateCache::new_empty(Some(base_version));
 
         // `State::update` must surface this fork-induced version mismatch as a recoverable
-        // error and return normally — that return is the test's assertion, no explicit check
-        // is needed.
-        let _ = base_state.update(&persisted_state, &state_updates, &cached_state);
+        // error so the local consensus module can discard the losing branch.
+        base_state
+            .update(&persisted_state, &state_updates, &cached_state)
+            .expect_err("fork-induced version mismatch must surface as Err");
     }
 }

--- a/storage/storage-interface/src/state_store/state_summary.rs
+++ b/storage/storage-interface/src/state_store/state_summary.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     DbReader,
 };
-use anyhow::Result;
+use anyhow::{bail, Result};
 use aptos_crypto::{hash::CORRUPTION_SENTINEL, HashValue};
 use aptos_metrics_core::TimerHelper;
 use aptos_scratchpad::{ProofRead, SparseMerkleTree};
@@ -75,8 +75,17 @@ impl StateSummary {
 
         assert_ne!(self.global_state_summary.root_hash(), *CORRUPTION_SENTINEL);
 
-        // Persisted must be before or at my version.
-        assert!(persisted.next_version() <= self.next_version());
+        // Persisted must be before or at my version. Under speculative execution of fork
+        // siblings, the persisted watermark can advance past the in-flight base — surface this
+        // as a recoverable error so the local consensus module can drop the losing branch,
+        // rather than aborting the process.
+        if persisted.next_version() > self.next_version() {
+            bail!(
+                "persisted version ({}) is ahead of current version ({}), likely due to a fork",
+                persisted.next_version(),
+                self.next_version(),
+            );
+        }
         // Updates must start at exactly my version.
         assert_eq!(updates.first_version(), self.next_version());
 


### PR DESCRIPTION

## Issue

**Symptom.** Two state-update entry points in the storage layer — [State::update](https://github.com/movementlabsxyz/aptos-core/blob/fix/state-update-fork-panic/storage/storage-interface/src/state_store/state.rs#L107) and [StateSummary::update](https://github.com/movementlabsxyz/aptos-core/blob/fix/state-update-fork-panic/storage/storage-interface/src/state_store/state_summary.rs#L69) — panic the validator process when the [persisted-state watermark](https://github.com/movementlabsxyz/aptos-core/blob/fix/state-update-fork-panic/storage/aptosdb/src/state_store/persisted_state.rs#L17) advances past the version of the in-flight block's base state (the parent state it is being computed on top of).

**Trigger.** Normal protocol-level forks. Two children of a common parent are both [speculatively executed](https://github.com/movementlabsxyz/aptos-core/blob/fix/state-update-fork-panic/consensus/src/execution_pipeline.rs#L214), and when one of them [pre-commits](https://github.com/movementlabsxyz/aptos-core/blob/fix/state-update-fork-panic/consensus/src/pipeline/pipeline_builder.rs#L722), the watermark advances past the still-in-flight sibling's base-state version.

**Mechanism.** The pre-commit path calls [PersistedState::set](https://github.com/movementlabsxyz/aptos-core/blob/fix/state-update-fork-panic/storage/aptosdb/src/state_store/persisted_state.rs#L67) and advances the watermark. [Reconfig blocks](https://github.com/movementlabsxyz/aptos-core/blob/fix/state-update-fork-panic/consensus/src/pipeline/pipeline_builder.rs#L739) wait for the order-proof and accelerate the commit, which makes the race more likely.

**Failure mode.** The losing-fork branch is going to be discarded by the local consensus module anyway, but the [cross-block version-ordering assertion](https://github.com/movementlabsxyz/aptos-core/blob/fix/state-update-fork-panic/storage/storage-interface/src/state_store/state.rs#L124) fires first and aborts the process, taking the validator offline for a restart.

```text
  Phase 1 — both siblings in-flight, watermark still at A
  ────────────────────────────────────────────────────────

       persisted watermark
              │
              ▼
        ┌─────────┐         ┌─────────┐
        │  ... A  │ ──┬───► │  B  ?   │   in-flight (speculative)
        └─────────┘   │     └─────────┘
                      │
                      │     ┌─────────┐
                      └───► │  C  ?   │   in-flight (speculative)
                            └─────────┘

  Phase 2 — B pre-commits, watermark jumps past A
  ────────────────────────────────────────────────────────

                            persisted watermark
                                   │
                                   ▼
        ┌─────────┐         ┌─────────┐
        │     A   │ ──┬───► │  B  ✓   │   committed
        └─────────┘   │     └─────────┘
                      │
                      │     ┌─────────┐
                      └───► │  C  ?   │   still computing
                            └─────────┘     base = A's version
                                            persisted = B's version
                                            persisted > base
                                              │
                                              ▼
                                       assert! fires  →  PANIC
                                              │
                                              ▼
                                ┌──────────────────────────────┐
                                │ validator process crashes    │
                                │ → restarts                   │
                                │ → no propose / no vote /     │
                                │   no sign during restart     │
                                │ → liveness dip (across many  │
                                │   validators if the fork is  │
                                │   network-wide)              │
                                └──────────────────────────────┘
```

## Solution

This PR converts the cross-block assertions into recoverable errors. The discarded fork branch's failed execution now surfaces as a `Result::Err` that propagates through to the local consensus module — same outcome on chain (C is dropped), without the validator restart.

## How Has This Been Tested?

- `cargo test -p aptos-storage-interface --lib` — includes the new test [state_update_surfaces_recoverable_error_when_persisted_is_ahead_of_cache](https://github.com/movementlabsxyz/aptos-core/blob/fix/state-update-fork-panic/storage/storage-interface/src/state_store/state.rs#L310), which fails on the first commit (test only) and passes on the second commit (fix applied)
- `cargo test -p aptos-db --lib speculative_state_workflow` — exercises the modified `update_with_memorized_reads` end-to-end

## Type of Change

- [x] Bug fix
- [x] Tests

## Which Components or Systems Does This Change Impact?

- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality