### PR TITLE
fix: Security nits for MoveVM

### DIFF
--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -971,7 +971,7 @@ impl InterpreterImpl<'_> {
                 // in the end to determine which function to jump to. The native function shouldn't switch ordering of arguments.
                 //
                 // Runtime will use such convention to reconstruct the type stack required to perform paranoid mode checks.
-                if function.ty_param_abilities() != target_func.ty_param_abilities()
+                if function.param_tys().is_empty() || function.ty_param_abilities() != target_func.ty_param_abilities()
                     || function.return_tys() != target_func.return_tys()
                     || &function.param_tys()[0..function.param_tys().len() - 1]
                         != target_func.param_tys()
@@ -1660,11 +1660,11 @@ impl Stack {
     }
 
     /// Pop n types off the stack.
-    pub(crate) fn popn_tys(&mut self, n: u16) -> PartialVMResult<Vec<Type>> {
+    pub(crate) fn popn_tys(&mut self, n: usize) -> PartialVMResult<Vec<Type>> {
         let remaining_stack_size = self
             .types
             .len()
-            .checked_sub(n as usize)
+            .checked_sub(n)
             .ok_or_else(|| PartialVMError::new(StatusCode::EMPTY_VALUE_STACK))?;
         let args = self.types.split_off(remaining_stack_size);
         Ok(args)
@@ -2374,6 +2374,14 @@ impl Frame {
                                 ty_args,
                             )
                             .map(Rc::new)?;
+                        if RTTCheck::should_perform_checks() {
+                            verify_pack_closure(
+                                self.ty_builder(),
+                                &mut interpreter.operand_stack,
+                                &function,
+                                *mask,
+                            )?;
+                        }
                         let captured = interpreter.operand_stack.popn(mask.captured_count())?;
                         let lazy_function = LazyLoadedFunction::new_resolved(
                             module_storage.runtime_environment(),
@@ -2383,15 +2391,6 @@ impl Frame {
                         interpreter
                             .operand_stack
                             .push(Value::closure(Box::new(lazy_function), captured))?;
-
-                        if RTTCheck::should_perform_checks() {
-                            verify_pack_closure(
-                                self.ty_builder(),
-                                &mut interpreter.operand_stack,
-                                &function,
-                                *mask,
-                            )?;
-                        }
                     },
                     Bytecode::ReadRef => {
                         let reference = interpreter.operand_stack.pop_as::<Reference>()?;

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
@@ -36,7 +36,7 @@ pub(crate) trait RuntimeTypeCheck {
 
 fn verify_pack<'a>(
     operand_stack: &mut Stack,
-    field_count: u16,
+    field_count: usize,
     field_tys: impl Iterator<Item = &'a Type>,
     output_ty: Type,
 ) -> PartialVMResult<()> {
@@ -86,7 +86,7 @@ pub fn verify_pack_closure(
     // signature.
     let expected_capture_tys = mask.extract(func.param_tys(), true);
 
-    let given_capture_tys = operand_stack.popn_tys(expected_capture_tys.len() as u16)?;
+    let given_capture_tys = operand_stack.popn_tys(expected_capture_tys.len())?;
     for (expected, given) in expected_capture_tys
         .into_iter()
         .zip(given_capture_tys.into_iter())
@@ -452,7 +452,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
                 let args_ty = frame.get_struct(*idx);
                 let field_tys = args_ty.fields(None)?.iter().map(|(_, ty)| ty);
                 let output_ty = frame.get_struct_ty(*idx);
-                verify_pack(operand_stack, field_count, field_tys, output_ty)?;
+                verify_pack(operand_stack, field_count.into(), field_tys, output_ty)?;
             },
             Bytecode::PackGeneric(idx) => {
                 let field_count = frame.field_instantiation_count(*idx);
@@ -472,7 +472,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
 
                 verify_pack(
                     operand_stack,
-                    field_count,
+                    field_count.into(),
                     args_ty.iter().map(|(ty, _)| ty),
                     output_ty,
                 )?;
@@ -503,7 +503,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
                     .iter()
                     .map(|(_, ty)| ty);
                 let output_ty = frame.create_struct_ty(&info.definition_struct_type);
-                verify_pack(operand_stack, info.field_count, field_tys, output_ty)?;
+                verify_pack(operand_stack, info.field_count.into(), field_tys, output_ty)?;
             },
             Bytecode::PackVariantGeneric(idx) => {
                 let info = frame.get_struct_variant_instantiation_at(*idx);
@@ -511,7 +511,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
                 let args_ty = ty_cache.get_struct_variant_fields_types(*idx, frame)?;
                 verify_pack(
                     operand_stack,
-                    info.field_count,
+                    info.field_count.into(),
                     args_ty.iter().map(|(ty, _)| ty),
                     output_ty,
                 )?;
@@ -706,7 +706,10 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             },
             Bytecode::VecPack(si, num) => {
                 let (ty, _) = ty_cache.get_signature_index_type(*si, frame)?;
-                let elem_tys = operand_stack.popn_tys(*num as u16)?;
+                let num: usize = (*num).try_into().map_err(|_| {
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                })?;
+                let elem_tys = operand_stack.popn_tys(num)?;
                 for elem_ty in elem_tys.iter() {
                     // For vector element types, use assignability
                     elem_ty.paranoid_check_assignable(ty)?;

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
@@ -706,10 +706,10 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             },
             Bytecode::VecPack(si, num) => {
                 let (ty, _) = ty_cache.get_signature_index_type(*si, frame)?;
-                let num: usize = (*num).try_into().map_err(|_| {
+                let num: u16 = (*num).try_into().map_err(|_| {
                     PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
                 })?;
-                let elem_tys = operand_stack.popn_tys(num)?;
+                let elem_tys = operand_stack.popn_tys(num.into())?;
                 for elem_ty in elem_tys.iter() {
                     // For vector element types, use assignability
                     elem_ty.paranoid_check_assignable(ty)?;


### PR DESCRIPTION
## Summary 
 - PackClosureGeneric stack order: verification was running after the operand stack was already mutated (captured values popped, closure pushed). If verification failed the stacks were inconsistent. Fixed to mirror PackClosure — verify first, then mutate.
  - Native dynamic dispatch: param_tys().len() - 1 would panic/wrap if the function had no parameters. Added an explicit guard.
  
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?

- `cargo test -p move-vm-runtime`
- `cargo test -p move-vm-types`

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
