### PR TITLE
fix: Type parameter issues for enums

### DIFF
--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -1837,6 +1837,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
 
                 let mut et = ExpTranslator::new_with_old(self, allows_old);
                 et.define_type_params(loc, &entry.type_params, false);
+                let self_type_args = entry.type_params.iter().enumerate().map(|(i, _) | Type::TypeParameter(i as u16)).collect();
                 if let StructLayout::Singleton(fields, _is_positional) = &entry.layout {
                     et.enter_scope();
                     let lang_ver_ge_2 =
@@ -1865,7 +1866,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                     if lang_ver_ge_2 {
                         let receiver_param_name =
                             et.symbol_pool().make(well_known::RECEIVER_PARAM_NAME);
-                        let struct_type = Type::Struct(entry.module_id, entry.struct_id, vec![]);
+                        let struct_type = Type::Struct(entry.module_id, entry.struct_id, self_type_args);
                         et.define_local(loc, receiver_param_name, struct_type, None, None);
                     }
                 } else if let StructLayout::Variants(_) = &entry.layout {
@@ -1873,7 +1874,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                     if et.env().language_version.is_at_least(LanguageVersion::V2_0) {
                         let receiver_param_name =
                             et.symbol_pool().make(well_known::RECEIVER_PARAM_NAME);
-                        let struct_type = Type::Struct(entry.module_id, entry.struct_id, vec![]);
+                        let struct_type = Type::Struct(entry.module_id, entry.struct_id, self_type_args);
                         et.define_local(loc, receiver_param_name, struct_type, None, None);
                     }
                 }

--- a/third_party/move/move-prover/tests/sources/functional/enum_19575.move
+++ b/third_party/move/move-prover/tests/sources/functional/enum_19575.move
@@ -1,0 +1,10 @@
+module 0x42::example {
+
+      enum Wrapper<T> has copy, drop {
+          One { value: T }
+      }
+
+      spec Wrapper {
+          invariant (self is Wrapper::One) ==> true;
+      }
+  }


### PR DESCRIPTION
## Description
Fixes problem described https://github.com/aptos-labs/aptos-core/issues/19575

A generic type arg has 0 type arguments which is not correct.

## How Has This Been Tested?

Added test case for this specifc problem.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

