### PR TITLE
feat: add txn rate limiting

### DIFF
--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -102,6 +102,15 @@ pub struct MempoolConfig {
     pub enable_max_load_balancing_at_any_load: bool,
     /// Maximum number of orderless transactions allowed in the Mempool per user
     pub orderless_txn_capacity_per_user: usize,
+    /// Per-peer inbound rate limit in transactions per second (token-bucket refill rate).
+    /// When set, each peer gets an independent token bucket. Transactions exceeding the
+    /// budget are dropped before validation and the peer receives a backpressure signal.
+    /// When `None` (default), no per-peer rate limiting is applied.
+    pub peer_inbound_rate_limit_tps: Option<u64>,
+    /// Burst size (token-bucket capacity) for per-peer inbound rate limiting.
+    /// Only used when `peer_inbound_rate_limit_tps` is set.  Defaults to the
+    /// value of `peer_inbound_rate_limit_tps` (i.e. one second of burst).
+    pub peer_inbound_rate_limit_burst: Option<u64>,
 }
 
 impl Default for MempoolConfig {
@@ -167,6 +176,8 @@ impl Default for MempoolConfig {
             ],
             enable_max_load_balancing_at_any_load: false,
             orderless_txn_capacity_per_user: 1000,
+            peer_inbound_rate_limit_tps: None,
+            peer_inbound_rate_limit_burst: None,
         }
     }
 }

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -296,7 +296,7 @@ async fn process_received_txns<NetworkClient, TransactionValidator>(
     smp: &mut SharedMempool<NetworkClient, TransactionValidator>,
     network_id: NetworkId,
     message_id: MempoolMessageId,
-    transactions: Vec<(
+    mut transactions: Vec<(
         SignedTransaction,
         Option<u64>,
         Option<BroadcastPeerPriority>,
@@ -306,10 +306,51 @@ async fn process_received_txns<NetworkClient, TransactionValidator>(
     NetworkClient: NetworkClientInterface<MempoolSyncMsg> + 'static,
     TransactionValidator: TransactionValidation + 'static,
 {
+    let peer = PeerNetworkId::new(network_id, peer_id);
+
+    // Per-peer rate limiting: if configured, check the token bucket for this
+    // peer and truncate the batch to the allowed count.  Dropped transactions
+    // are never validated — we immediately signal backpressure so the sender
+    // can throttle itself.
+    if let Some(ref mut limiter) = smp.peer_rate_limiter {
+        let requested = transactions.len();
+        let allowed = limiter.try_acquire(&peer, requested);
+        if allowed < requested {
+            let dropped = requested - allowed;
+            warn!(
+                LogSchema::new(LogEntry::CoordinatorRuntime)
+                    .peer(&peer),
+                "Per-peer rate limit exceeded: dropping {} of {} txns",
+                dropped,
+                requested,
+            );
+            counters::shared_mempool_event_inc("peer_rate_limited");
+            transactions.truncate(allowed);
+
+            // If the entire batch was dropped, send an immediate backpressure
+            // ACK and return — there is nothing left to process.
+            if transactions.is_empty() {
+                let ack = MempoolSyncMsg::BroadcastTransactionsResponse {
+                    message_id,
+                    retry: true,
+                    backoff: true,
+                };
+                if let Err(e) = smp.network_interface.send_message_to_peer(peer, ack) {
+                    counters::network_send_fail_inc(counters::ACK_TXNS);
+                    warn!(
+                        LogSchema::event_log(LogEntry::BroadcastACK, LogEvent::NetworkSendFail)
+                            .peer(&peer)
+                            .error(&e.into())
+                    );
+                }
+                return;
+            }
+        }
+    }
+
     smp.network_interface
         .num_mempool_txns_received_since_peers_updated += transactions.len() as u64;
     let smp_clone = smp.clone();
-    let peer = PeerNetworkId::new(network_id, peer_id);
     let ineligible_for_broadcast = (smp.network_interface.is_validator()
         && !smp.broadcast_within_validator_network())
         || smp.network_interface.is_upstream_peer(&peer, None);
@@ -438,6 +479,10 @@ async fn handle_update_peers<NetworkClient, TransactionValidator>(
         }
         for peer in &disabled {
             debug!(LogSchema::new(LogEntry::LostPeer).peer(peer));
+            // Remove stale rate-limiter state for disconnected peers.
+            if let Some(ref mut limiter) = smp.peer_rate_limiter {
+                limiter.remove_peer(peer);
+            }
         }
     }
 }

--- a/mempool/src/shared_mempool/mod.rs
+++ b/mempool/src/shared_mempool/mod.rs
@@ -10,5 +10,6 @@ pub use runtime::bootstrap;
 #[cfg(any(test, feature = "fuzzing"))]
 pub(crate) use runtime::start_shared_mempool;
 mod coordinator;
+pub(crate) mod peer_rate_limiter;
 pub(crate) mod tasks;
 pub(crate) mod use_case_history;

--- a/mempool/src/shared_mempool/peer_rate_limiter.rs
+++ b/mempool/src/shared_mempool/peer_rate_limiter.rs
@@ -1,0 +1,158 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-peer token-bucket rate limiter for inbound transaction broadcasts.
+//!
+//! Each peer gets an independent bucket that refills at `rate` tokens per
+//! second up to a maximum of `capacity` tokens.  When a broadcast arrives the
+//! coordinator calls [`PeerRateLimiter::try_acquire`] which returns the number
+//! of transactions the peer is allowed to submit right now — the rest should be
+//! dropped before validation.
+
+use aptos_config::network_id::PeerNetworkId;
+use std::{
+    collections::HashMap,
+    time::Instant,
+};
+
+/// A single token bucket.
+#[derive(Debug, Clone)]
+struct TokenBucket {
+    tokens: f64,
+    capacity: f64,
+    rate: f64, // tokens per second
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    fn new(capacity: f64, rate: f64) -> Self {
+        Self {
+            tokens: capacity, // start full
+            capacity,
+            rate,
+            last_refill: Instant::now(),
+        }
+    }
+
+    /// Refill tokens based on elapsed time, then try to consume `requested`.
+    /// Returns the number of tokens actually granted (may be less than requested).
+    fn try_acquire(&mut self, requested: usize) -> usize {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        self.tokens = (self.tokens + self.rate * elapsed).min(self.capacity);
+        self.last_refill = now;
+
+        let granted = (requested as f64).min(self.tokens).max(0.0) as usize;
+        self.tokens -= granted as f64;
+        granted
+    }
+}
+
+/// Manages per-peer token buckets.
+#[derive(Debug, Clone)]
+pub(crate) struct PeerRateLimiter {
+    buckets: HashMap<PeerNetworkId, TokenBucket>,
+    capacity: f64,
+    rate: f64,
+}
+
+impl PeerRateLimiter {
+    /// Create a new rate limiter.
+    ///
+    /// * `rate` — sustained transactions per second allowed per peer.
+    /// * `burst` — maximum burst size (token-bucket capacity).
+    pub(crate) fn new(rate: u64, burst: u64) -> Self {
+        Self {
+            buckets: HashMap::new(),
+            capacity: burst as f64,
+            rate: rate as f64,
+        }
+    }
+
+    /// Try to acquire `requested` tokens for `peer`.
+    /// Returns the number of transactions the peer is allowed to send.
+    /// A new bucket (starting full) is created on first contact with a peer.
+    pub(crate) fn try_acquire(&mut self, peer: &PeerNetworkId, requested: usize) -> usize {
+        let bucket = self
+            .buckets
+            .entry(*peer)
+            .or_insert_with(|| TokenBucket::new(self.capacity, self.rate));
+        bucket.try_acquire(requested)
+    }
+
+    /// Remove the bucket for a disconnected peer so we don't leak memory.
+    pub(crate) fn remove_peer(&mut self, peer: &PeerNetworkId) {
+        self.buckets.remove(peer);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aptos_config::network_id::NetworkId;
+    use aptos_types::PeerId;
+    use std::thread;
+    use std::time::Duration;
+
+    fn test_peer() -> PeerNetworkId {
+        PeerNetworkId::new(NetworkId::Validator, PeerId::ZERO)
+    }
+
+    #[test]
+    fn test_initial_burst_allowed() {
+        let mut limiter = PeerRateLimiter::new(100, 200);
+        let peer = test_peer();
+        // First request up to burst size should be fully granted
+        assert_eq!(limiter.try_acquire(&peer, 200), 200);
+    }
+
+    #[test]
+    fn test_over_burst_truncated() {
+        let mut limiter = PeerRateLimiter::new(100, 200);
+        let peer = test_peer();
+        // Requesting more than burst should be capped
+        assert_eq!(limiter.try_acquire(&peer, 300), 200);
+    }
+
+    #[test]
+    fn test_budget_exhausted_then_refills() {
+        let mut limiter = PeerRateLimiter::new(1000, 100);
+        let peer = test_peer();
+        // Exhaust the bucket
+        assert_eq!(limiter.try_acquire(&peer, 100), 100);
+        assert_eq!(limiter.try_acquire(&peer, 50), 0);
+
+        // Wait for some refill (100ms at 1000 TPS = ~100 tokens)
+        thread::sleep(Duration::from_millis(110));
+        let granted = limiter.try_acquire(&peer, 200);
+        assert!(granted >= 90 && granted <= 110, "granted={}", granted);
+    }
+
+    #[test]
+    fn test_independent_peers() {
+        let mut limiter = PeerRateLimiter::new(100, 50);
+        let peer_a = PeerNetworkId::new(NetworkId::Validator, PeerId::ZERO);
+        let peer_b = PeerNetworkId::new(NetworkId::Validator, PeerId::ONE);
+
+        // Exhaust peer A
+        assert_eq!(limiter.try_acquire(&peer_a, 50), 50);
+        assert_eq!(limiter.try_acquire(&peer_a, 10), 0);
+
+        // Peer B is independent and should still have full budget
+        assert_eq!(limiter.try_acquire(&peer_b, 50), 50);
+    }
+
+    #[test]
+    fn test_remove_peer_resets_on_reconnect() {
+        let mut limiter = PeerRateLimiter::new(100, 50);
+        let peer = test_peer();
+
+        // Exhaust
+        assert_eq!(limiter.try_acquire(&peer, 50), 50);
+        assert_eq!(limiter.try_acquire(&peer, 10), 0);
+
+        // Simulate disconnect + reconnect
+        limiter.remove_peer(&peer);
+        assert_eq!(limiter.try_acquire(&peer, 50), 50);
+    }
+}

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -6,7 +6,7 @@
 use crate::{
     core_mempool::{CoreMempool, TimelineId},
     network::{MempoolNetworkInterface, MempoolSyncMsg},
-    shared_mempool::use_case_history::UseCaseHistory,
+    shared_mempool::{peer_rate_limiter::PeerRateLimiter, use_case_history::UseCaseHistory},
 };
 use anyhow::Result;
 use aptos_config::{
@@ -56,6 +56,7 @@ pub(crate) struct SharedMempool<NetworkClient, TransactionValidator> {
     pub subscribers: Vec<UnboundedSender<SharedMempoolNotification>>,
     pub broadcast_within_validator_network: Arc<RwLock<bool>>,
     pub use_case_history: Arc<Mutex<UseCaseHistory>>,
+    pub peer_rate_limiter: Option<PeerRateLimiter>,
 }
 
 impl<
@@ -78,6 +79,10 @@ impl<
             config.usecase_stats_num_blocks_to_track,
             config.usecase_stats_num_top_to_track,
         );
+        let peer_rate_limiter = config.peer_inbound_rate_limit_tps.map(|tps| {
+            let burst = config.peer_inbound_rate_limit_burst.unwrap_or(tps);
+            PeerRateLimiter::new(tps, burst)
+        });
         SharedMempool {
             mempool,
             config,
@@ -87,6 +92,7 @@ impl<
             subscribers,
             broadcast_within_validator_network: Arc::new(RwLock::new(true)),
             use_case_history: Arc::new(Mutex::new(use_case_history)),
+            peer_rate_limiter,
         }
     }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
The mempool accepts transaction broadcasts from peers without any per-peer rate constraint. A single peer can submit transactions at an unbounded rate, potentially starving the mempool's processing pipeline (VM validation, storage reads) and degrading node performance. The only existing backpressure is the global "mempool is full" condition, which fires too late to isolate a single abusive peer. This change adds a configurable, per-peer token-bucket rate limiter for inbound transaction broadcasts

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Unit tests

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
