### PR TITLE
chore: bump `protobufjs ^7.2.5` → `^7.5.5`

### DIFF
--- a/protos/typescript/package.json
+++ b/protos/typescript/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.9.2",
     "long": "^5.2.3",
-    "protobufjs": "^7.2.5"
+    "protobufjs": "^7.5.5"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/protos/typescript/pnpm-lock.yaml
+++ b/protos/typescript/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^5.2.3
     version: 5.2.3
   protobufjs:
-    specifier: ^7.2.5
-    version: 7.2.5
+    specifier: ^7.5.5
+    version: 7.5.5
 
 devDependencies:
   typescript:
@@ -37,7 +37,7 @@ packages:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.2.3
-      protobufjs: 7.2.5
+      protobufjs: 7.5.5
       yargs: 17.7.2
     dev: false
 
@@ -149,8 +149,8 @@ packages:
     resolution: {integrity: sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==}
     dev: false
 
-  /protobufjs@7.2.5:
-    resolution: {integrity: sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==}
+  /protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
     requiresBuild: true
     dependencies:


### PR DESCRIPTION
# Bump protobufjs to 7.5.5 in protos/typescript

Resolves Dependabot alert #643 (GHSA-xq3m-2v4x-88gg / CVE-2026-41242): arbitrary code execution in `protobufjs < 7.5.5` via crafted JSON descriptors loaded through reflection. Very low exploit risk (some downstream app would have to pull in aptos-protos and also use protobufjs directly to load schemas from untrusted input) but might as well update out of an abundance of caution / defense-in-depth.

## Changes
- `protos/typescript/package.json`: `protobufjs ^7.2.5` → `^7.5.5`
- `protos/typescript/pnpm-lock.yaml`: regenerated; resolves to `7.5.5`

## Risk from bumping version
Low. Minor bump within the existing `^7` range. This package only decodes against its own generated schemas, so the vulnerable reflection path is not exercised at runtime. `pnpm install && pnpm run build` succeeds locally.