### PR TITLE
[codex] Update core infrastructure CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,116 +1,12 @@
-# **Please** keep this file ordered alphabetically by directory paths.
+/ @musitdev @andygolay @Icarus131 @Primata
 
-# Owners for the `.github` directory and all its subdirectories.
-/.github/ @aptos-labs/prod-eng
-
-# Owners for the `/api` directory and all its subdirectories.
-/api/ @banool @gregnazario @0xmaayan
-
-# Owners for the `/aptos-move` directory and its subdirectories:`aptos-gas`, `aptos-vm`, `framework` and `framework/aptos-stdlib/sources/cryptography`.
-/aptos-move/aptos-aggregator/ @georgemitenkov @gelash @zekun000
-/aptos-move/aptos-gas/ @vgao1996
-/aptos-move/aptos-vm/ @davidiw @wrwg @zekun000 @vgao1996 @georgemitenkov
-/aptos-move/aptos-vm/src/keyless_validation.rs @alinush @heliuchuan
-/aptos-move/aptos-vm-types/ @georgemitenkov @gelash @vgao1996
-/aptos-move/framework/ @davidiw @movekevin @wrwg
-/aptos-move/framework/aptos-framework/sources/account.move @alinush
-/aptos-move/framework/aptos-framework/sources/jwks.move @zjma
-/aptos-move/framework/aptos-framework/sources/keyless_account.move @alinush
-/aptos-move/framework/aptos-stdlib/sources/cryptography/ @alinush @zjma @mstraka100
-/aptos-move/framework/**/*.spec.move @junkil-park
-/aptos-move/framework/aptos-stdlib/sources/hash.move @alinush
-
-# Owner for aptos-token, cryptography natives, parallel-executor and vm-genesis.
-/aptos-move/framework/aptos-token @areshand
-/aptos-move/framework/src/natives/cryptography/ @alinush @zjma @mstraka100
-/aptos-move/framework/src/natives/aggregator_natives/ @georgemitenkov @gelash @zekun000
-/aptos-move/block-executor/ @gelash @zekun000 @sasha8 @danielxiangzl
-/aptos-move/sharded_block-executor/ @sitalkedia
-/aptos-move/mvhashmap/ @gelash @runtian-zhou @sasha8 @danielxiangzl
-/aptos-move/vm-genesis/ @davidiw @movekevin
-
-# Owner for aptos node (to prevent things from becoming out of hand :D)
-/aptos-node/ @joshlind
-
-# Owner for the node configs (to prevent things from becoming out of hand :D)
-/config/ @joshlind @gregnazario
-
-# Owners for the `/consensus` directory and all its subdirectories.
-/consensus/ @zekun000 @sasha8 @ibalajiarun
-
-# Owners for consensus observer
-/consensus/src/consensus-observer/ @joshlind @zekun000
-
-# Owners for quorum store.
-/consensus/src/quorum_store/ @bchocho @sasha8 @gelash
-
-# Owners for the `/crates/aptos` directory and all its subdirectories.
-/crates/aptos @gregnazario @banool
-
-# Owners for the `/crates/aptos-crypto*` directories.
-/crates/aptos-crypto-derive/ @alinush @zjma @mstraka100 @rex1fernando
-/crates/aptos-crypto/ @alinush @zjma @mstraka100 @rex1fernando
-
-# Owners for the `/crates/aptos-faucet` directory and all its subdirectories. And other faucet, genesis, and OpenAPI-related crates.
-/crates/aptos-faucet @banool @gregnazario
-/crates/aptos-genesis @gregnazario
-
-# Owners for the aptos-logger crate
-/crates/aptos-logger @gregnazario @joshlind
-
-/crates/aptos-open-api @banool @gregnazario
-
-# Owners for the aptos-protos crate
-/crates/aptos-protos @banool @bowenyang007 @jillxuu @larry-aptos @rtso  @aptos-labs/ecosystem-infra
-
-/crates/aptos-rest-client @banool @gregnazario
-
-# Owners for the `/aptos-rosetta` directory and related crates.
-/crates/aptos-rosetta @gregnazario
-/crates/aptos-rosetta-cli @gregnazario
-
-# Owners for the aptos-speculative-state-helper crate
-/crates/aptos-speculative-state-helper @gelash
-
-# Owners for the `telemetry` related crates.
-/crates/aptos-telemetry @ibalajiarun @geekflyer
-/crates/aptos-telemetry-service @ibalajiarun @geekflyer
-
-# Owners for the inspection-service crate
-/crates/inspection-service/ @joshlind
-
-# Owners for the `/dashboards` directory and all its subdirectories.
-/dashboards/ @aptos-labs/prod-eng
-
-# Owners for the `/docker` directory and all its subdirectories.
-/docker/ @aptos-labs/prod-eng
-/docker/builder/docker-bake-rust-all.hcl @aptos-labs/prod-eng @aptos-labs/security
-
-# Owners for execution and storage.
-/execution/ @msmouse @lightmark @grao1991
-
-# Owners for mempool.
-/mempool/ @bchocho
-
-# Owners for the network and all its subdirectories.
-/network/ @joshlind @zekun000
-
-# Owners for the scripts
-/scripts/ @aptos-labs/prod-eng
-/scripts/authenticator_regenerate.sh @alinush @hariria @heliuchuan
-/scripts/algebra-gas/ @zjma
-
-# Owners for the `/state-sync` directory and all its subdirectories.
-/state-sync/ @joshlind
-
-# Owners for execution and storage.
-/storage/ @msmouse @lightmark @grao1991
-
-# Owners for the `/terraform` directory and all its subdirectories.
-/terraform/ @aptos-labs/prod-eng
-
-# Owners for the `aptos-dkg` crate.
-/crates/aptos-dkg @alinush @rex1fernando
-
-/types/src/keyless/ @alinush @heliuchuan
-/types/src/transaction/authenticator.rs @alinush @mstraka100
+# Core infrastructure owners
+/api/ @areshand
+/aptos-node/ @areshand
+/consensus/ @areshand
+/execution/ @areshand
+/keyless/ @areshand
+/mempool/ @areshand
+/network/ @areshand
+/storage/ @areshand
+/types/src/keyless/ @areshand


### PR DESCRIPTION
## Summary

- Replace `CODEOWNERS` with the simplified fork ownership rules
- Keep global owners as `@musitdev`, `@andygolay`, `@Icarus131`, and `@Primata`
- Add core infrastructure rules for `api`, `aptos-node`, `consensus`, `execution`, `keyless`, `mempool`, `network`, `storage`, and `types/src/keyless`
- Set `@areshand` as the sole owner for the core infrastructure rules so those changes request their review

## Validation

- CODEOWNERS-only change
- Commit hooks passed for formatting/EOF/large-file checks