### PR TITLE
[vm] backport VM value depth checks (#16983)

### DIFF
--- a/aptos-move/aptos-gas-meter/src/meter.rs
+++ b/aptos-move/aptos-gas-meter/src/meter.rs
@@ -286,7 +286,7 @@ where
             .vm_gas_params()
             .misc
             .abs_val
-            .abstract_value_size_stack_and_heap(val, self.feature_version());
+            .abstract_value_size_stack_and_heap(val, self.feature_version())?;
 
         // Note(Gas): this makes a deep copy so we need to charge for the full value size
         self.algebra
@@ -345,7 +345,7 @@ where
             .vm_gas_params()
             .misc
             .abs_val
-            .abstract_value_size_stack_and_heap(val, self.feature_version());
+            .abstract_value_size_stack_and_heap(val, self.feature_version())?;
 
         // Note(Gas): this makes a deep copy so we need to charge for the full value size
         self.algebra
@@ -367,8 +367,9 @@ where
 
         let cost = EQ_BASE
             + EQ_PER_ABS_VAL_UNIT
-                * (abs_val_params.abstract_value_size_dereferenced(lhs, self.feature_version())
-                    + abs_val_params.abstract_value_size_dereferenced(rhs, self.feature_version()));
+                * (abs_val_params.abstract_value_size_dereferenced(lhs, self.feature_version())?
+                    + abs_val_params
+                        .abstract_value_size_dereferenced(rhs, self.feature_version())?);
 
         self.algebra.charge_execution(cost)
     }
@@ -379,8 +380,9 @@ where
 
         let cost = NEQ_BASE
             + NEQ_PER_ABS_VAL_UNIT
-                * (abs_val_params.abstract_value_size_dereferenced(lhs, self.feature_version())
-                    + abs_val_params.abstract_value_size_dereferenced(rhs, self.feature_version()));
+                * (abs_val_params.abstract_value_size_dereferenced(lhs, self.feature_version())?
+                    + abs_val_params
+                        .abstract_value_size_dereferenced(rhs, self.feature_version())?);
 
         self.algebra.charge_execution(cost)
     }

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/misc.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/misc.rs
@@ -251,7 +251,8 @@ impl ValueVisitor for AbstractValueSizeVisitor<'_> {
     #[inline]
     fn visit_closure(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
         self.check_depth(depth)?;
-        self.size += self.params.closure;
+        // TODO(#15664): introduce a dedicated gas parameter?
+        self.size += self.params.struct_;
         Ok(true)
     }
 
@@ -465,7 +466,8 @@ impl AbstractValueSizeGasParameters {
             #[inline]
             fn visit_closure(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
                 self.check_depth(depth)?;
-                self.res = Some(self.params.closure);
+                // TODO(#15664): introduce a dedicated gas parameter?
+                self.res = Some(self.params.struct_);
                 Ok(false)
             }
 
@@ -655,7 +657,8 @@ impl AbstractValueSizeGasParameters {
             #[inline]
             fn visit_closure(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
                 self.check_depth(depth)?;
-                self.res = Some(self.params.closure);
+                // TODO(#15664): introduce a dedicated gas parameter?
+                self.res = Some(self.params.struct_);
                 Ok(false)
             }
 

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/misc.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/misc.rs
@@ -9,9 +9,13 @@ use crate::{
     traits::{FromOnChainGasSchedule, InitialGasSchedule, ToOnChainGasSchedule},
 };
 use aptos_gas_algebra::{AbstractValueSize, AbstractValueSizePerArg};
-use move_core_types::{account_address::AccountAddress, gas_algebra::NumArgs, u256::U256};
+use move_core_types::{
+    account_address::AccountAddress, gas_algebra::NumArgs, u256::U256, vm_status::StatusCode,
+};
 use move_vm_types::{
     delayed_values::delayed_field_id::DelayedFieldID,
+    natives::function::{PartialVMError, PartialVMResult},
+    values::DEFAULT_MAX_VM_VALUE_NESTED_DEPTH,
     views::{ValueView, ValueVisitor},
 };
 use std::collections::BTreeMap;
@@ -81,8 +85,9 @@ macro_rules! deref_visitor_delegate_simple {
     ($([$fn: ident, $ty: ty $(,)?]),+ $(,)?) => {
         $(
             #[inline]
-            fn $fn(&mut self, depth: usize, val: $ty) {
-                self.inner.$fn(depth - self.offset, val);
+            fn $fn(&mut self, depth: u64, val: $ty) -> PartialVMResult<()> {
+                self.inner.$fn(depth - self.offset as u64, val)?;
+                Ok(())
             }
         )*
     };
@@ -110,40 +115,60 @@ where
     );
 
     #[inline]
-    fn visit_struct(&mut self, depth: usize, len: usize) -> bool {
-        self.inner.visit_struct(depth - self.offset, len)
+    fn visit_struct(&mut self, depth: u64, len: usize) -> PartialVMResult<bool> {
+        self.inner.visit_struct(depth - self.offset as u64, len)
     }
 
     #[inline]
-    fn visit_vec(&mut self, depth: usize, len: usize) -> bool {
-        self.inner.visit_vec(depth - self.offset, len)
+    fn visit_vec(&mut self, depth: u64, len: usize) -> PartialVMResult<bool> {
+        self.inner.visit_vec(depth - self.offset as u64, len)
     }
 
     #[inline]
-    fn visit_ref(&mut self, depth: usize, _is_global: bool) -> bool {
+    fn visit_ref(&mut self, depth: u64, _is_global: bool) -> PartialVMResult<bool> {
         assert_eq!(depth, 0, "There shouldn't be inner refs");
         self.offset = 1;
-        true
+        Ok(true)
     }
 
     #[inline]
-    fn visit_closure(&mut self, depth: usize, len: usize) -> bool {
+    fn visit_closure(&mut self, depth: u64, len: usize) -> PartialVMResult<bool> {
         self.inner.visit_closure(depth, len)
     }
+}
+
+/// Checks that the provided depth is not too deep. Used to bound recursion, preventing stack from
+/// overflowing.
+macro_rules! check_depth_impl {
+    () => {
+        fn check_depth(&self, depth: u64) -> PartialVMResult<()> {
+            if self
+                .max_value_nest_depth
+                .map_or(false, |max_value_nest_depth| depth > max_value_nest_depth)
+            {
+                return Err(PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED));
+            }
+            Ok(())
+        }
+    };
 }
 
 struct AbstractValueSizeVisitor<'a> {
     feature_version: u64,
     params: &'a AbstractValueSizeGasParameters,
     size: AbstractValueSize,
+    max_value_nest_depth: Option<u64>,
 }
 
 impl<'a> AbstractValueSizeVisitor<'a> {
+    check_depth_impl!();
+
     fn new(params: &'a AbstractValueSizeGasParameters, feature_version: u64) -> Self {
         Self {
             feature_version,
             params,
             size: 0.into(),
+            max_value_nest_depth: Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH),
         }
     }
 
@@ -154,137 +179,173 @@ impl<'a> AbstractValueSizeVisitor<'a> {
 
 impl ValueVisitor for AbstractValueSizeVisitor<'_> {
     #[inline]
-    fn visit_delayed(&mut self, _depth: usize, _id: DelayedFieldID) {
-        // TODO[agg_v2](cleanup): add a new abstract value size parameter?
+    fn visit_delayed(&mut self, depth: u64, _id: DelayedFieldID) -> PartialVMResult<()> {
+        self.check_depth(depth)?;
         self.size += self.params.u64;
+        Ok(())
     }
 
     #[inline]
-    fn visit_u8(&mut self, _depth: usize, _val: u8) {
+    fn visit_u8(&mut self, depth: u64, _val: u8) -> PartialVMResult<()> {
+        self.check_depth(depth)?;
         self.size += self.params.u8;
+        Ok(())
     }
 
     #[inline]
-    fn visit_u16(&mut self, _depth: usize, _val: u16) {
-        self.size += self.params.u16
+    fn visit_u16(&mut self, depth: u64, _val: u16) -> PartialVMResult<()> {
+        self.check_depth(depth)?;
+        self.size += self.params.u16;
+        Ok(())
     }
 
     #[inline]
-    fn visit_u32(&mut self, _depth: usize, _val: u32) {
-        self.size += self.params.u32
+    fn visit_u32(&mut self, depth: u64, _val: u32) -> PartialVMResult<()> {
+        self.check_depth(depth)?;
+        self.size += self.params.u32;
+        Ok(())
     }
 
     #[inline]
-    fn visit_u64(&mut self, _depth: usize, _val: u64) {
+    fn visit_u64(&mut self, depth: u64, _val: u64) -> PartialVMResult<()> {
+        self.check_depth(depth)?;
         self.size += self.params.u64;
+        Ok(())
     }
 
     #[inline]
-    fn visit_u128(&mut self, _depth: usize, _val: u128) {
+    fn visit_u128(&mut self, depth: u64, _val: u128) -> PartialVMResult<()> {
+        self.check_depth(depth)?;
         self.size += self.params.u128;
+        Ok(())
     }
 
     #[inline]
-    fn visit_u256(&mut self, _depth: usize, _val: U256) {
-        self.size += self.params.u256
+    fn visit_u256(&mut self, depth: u64, _val: U256) -> PartialVMResult<()> {
+        self.check_depth(depth)?;
+        self.size += self.params.u256;
+        Ok(())
     }
 
     #[inline]
-    fn visit_bool(&mut self, _depth: usize, _val: bool) {
+    fn visit_bool(&mut self, depth: u64, _val: bool) -> PartialVMResult<()> {
+        self.check_depth(depth)?;
         self.size += self.params.bool;
+        Ok(())
     }
 
     #[inline]
-    fn visit_address(&mut self, _depth: usize, _val: AccountAddress) {
+    fn visit_address(&mut self, depth: u64, _val: AccountAddress) -> PartialVMResult<()> {
+        self.check_depth(depth)?;
         self.size += self.params.address;
+        Ok(())
     }
 
     #[inline]
-    fn visit_struct(&mut self, _depth: usize, _len: usize) -> bool {
+    fn visit_struct(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
+        self.check_depth(depth)?;
         self.size += self.params.struct_;
-        true
+        Ok(true)
     }
 
     #[inline]
-    fn visit_closure(&mut self, _depth: usize, _len: usize) -> bool {
-        // TODO(#15664): introduce a dedicated gas parameter?
-        self.size += self.params.struct_;
-        true
+    fn visit_closure(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
+        self.check_depth(depth)?;
+        self.size += self.params.closure;
+        Ok(true)
     }
 
     #[inline]
-    fn visit_vec(&mut self, _depth: usize, _len: usize) -> bool {
+    fn visit_vec(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
+        self.check_depth(depth)?;
         self.size += self.params.vector;
-        true
+        Ok(true)
     }
 
     #[inline]
-    fn visit_vec_u8(&mut self, _depth: usize, vals: &[u8]) {
+    fn visit_vec_u8(&mut self, depth: u64, vals: &[u8]) -> PartialVMResult<()> {
+        self.check_depth(depth)?;
         let mut size = self.params.per_u8_packed * NumArgs::new(vals.len() as u64);
         if self.feature_version >= 3 {
             size += self.params.vector;
         }
         self.size += size;
+        Ok(())
     }
 
     #[inline]
-    fn visit_vec_u16(&mut self, _depth: usize, vals: &[u16]) {
+    fn visit_vec_u16(&mut self, depth: u64, vals: &[u16]) -> PartialVMResult<()> {
+        self.check_depth(depth)?;
         self.size +=
             self.params.vector + self.params.per_u16_packed * NumArgs::new(vals.len() as u64);
+        Ok(())
     }
 
     #[inline]
-    fn visit_vec_u32(&mut self, _depth: usize, vals: &[u32]) {
+    fn visit_vec_u32(&mut self, depth: u64, vals: &[u32]) -> PartialVMResult<()> {
+        self.check_depth(depth)?;
         self.size +=
             self.params.vector + self.params.per_u32_packed * NumArgs::new(vals.len() as u64);
+        Ok(())
     }
 
     #[inline]
-    fn visit_vec_u64(&mut self, _depth: usize, vals: &[u64]) {
+    fn visit_vec_u64(&mut self, depth: u64, vals: &[u64]) -> PartialVMResult<()> {
+        self.check_depth(depth)?;
         let mut size = self.params.per_u64_packed * NumArgs::new(vals.len() as u64);
         if self.feature_version >= 3 {
             size += self.params.vector;
         }
         self.size += size;
+        Ok(())
     }
 
     #[inline]
-    fn visit_vec_u128(&mut self, _depth: usize, vals: &[u128]) {
+    fn visit_vec_u128(&mut self, depth: u64, vals: &[u128]) -> PartialVMResult<()> {
+        self.check_depth(depth)?;
         let mut size = self.params.per_u128_packed * NumArgs::new(vals.len() as u64);
         if self.feature_version >= 3 {
             size += self.params.vector;
         }
         self.size += size;
+        Ok(())
     }
 
     #[inline]
-    fn visit_vec_u256(&mut self, _depth: usize, vals: &[U256]) {
+    fn visit_vec_u256(&mut self, depth: u64, vals: &[U256]) -> PartialVMResult<()> {
+        self.check_depth(depth)?;
         self.size +=
             self.params.vector + self.params.per_u256_packed * NumArgs::new(vals.len() as u64);
+        Ok(())
     }
 
     #[inline]
-    fn visit_vec_bool(&mut self, _depth: usize, vals: &[bool]) {
+    fn visit_vec_bool(&mut self, depth: u64, vals: &[bool]) -> PartialVMResult<()> {
+        self.check_depth(depth)?;
         let mut size = self.params.per_bool_packed * NumArgs::new(vals.len() as u64);
         if self.feature_version >= 3 {
             size += self.params.vector;
         }
         self.size += size;
+        Ok(())
     }
 
     #[inline]
-    fn visit_vec_address(&mut self, _depth: usize, vals: &[AccountAddress]) {
+    fn visit_vec_address(&mut self, depth: u64, vals: &[AccountAddress]) -> PartialVMResult<()> {
+        self.check_depth(depth)?;
         let mut size = self.params.per_address_packed * NumArgs::new(vals.len() as u64);
         if self.feature_version >= 3 {
             size += self.params.vector;
         }
         self.size += size;
+        Ok(())
     }
 
     #[inline]
-    fn visit_ref(&mut self, _depth: usize, _is_global: bool) -> bool {
+    fn visit_ref(&mut self, depth: u64, _is_global: bool) -> PartialVMResult<bool> {
+        self.check_depth(depth)?;
         self.size += self.params.reference;
-        false
+        Ok(false)
     }
 }
 
@@ -294,10 +355,10 @@ impl AbstractValueSizeGasParameters {
         &self,
         val: impl ValueView,
         feature_version: u64,
-    ) -> AbstractValueSize {
+    ) -> PartialVMResult<AbstractValueSize> {
         let mut visitor = AbstractValueSizeVisitor::new(self, feature_version);
-        val.visit(&mut visitor);
-        visitor.finish()
+        val.visit(&mut visitor)?;
+        Ok(visitor.finish())
     }
 
     /// Calculates the abstract size of the given value.
@@ -306,10 +367,10 @@ impl AbstractValueSizeGasParameters {
         &self,
         val: impl ValueView,
         feature_version: u64,
-    ) -> AbstractValueSize {
+    ) -> PartialVMResult<AbstractValueSize> {
         let mut visitor = DerefVisitor::new(AbstractValueSizeVisitor::new(self, feature_version));
-        val.visit(&mut visitor);
-        visitor.into_inner().finish()
+        val.visit(&mut visitor)?;
+        Ok(visitor.into_inner().finish())
     }
 }
 
@@ -318,145 +379,182 @@ impl AbstractValueSizeGasParameters {
         &self,
         val: impl ValueView,
         feature_version: u64,
-    ) -> AbstractValueSize {
+    ) -> PartialVMResult<AbstractValueSize> {
         struct Visitor<'a> {
             feature_version: u64,
             params: &'a AbstractValueSizeGasParameters,
             res: Option<AbstractValueSize>,
+            max_value_nest_depth: Option<u64>,
+        }
+
+        impl Visitor<'_> {
+            check_depth_impl!();
         }
 
         impl ValueVisitor for Visitor<'_> {
             #[inline]
-            fn visit_delayed(&mut self, _depth: usize, _val: DelayedFieldID) {
-                // TODO[agg_v2](cleanup): add a new abstract value size parameter?
+            fn visit_delayed(&mut self, depth: u64, _val: DelayedFieldID) -> PartialVMResult<()> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.u64);
+                Ok(())
             }
 
             #[inline]
-            fn visit_u8(&mut self, _depth: usize, _val: u8) {
+            fn visit_u8(&mut self, depth: u64, _val: u8) -> PartialVMResult<()> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.u8);
+                Ok(())
             }
 
             #[inline]
-            fn visit_u16(&mut self, _depth: usize, _val: u16) {
+            fn visit_u16(&mut self, depth: u64, _val: u16) -> PartialVMResult<()> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.u16);
+                Ok(())
             }
 
             #[inline]
-            fn visit_u32(&mut self, _depth: usize, _val: u32) {
+            fn visit_u32(&mut self, depth: u64, _val: u32) -> PartialVMResult<()> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.u32);
+                Ok(())
             }
 
             #[inline]
-            fn visit_u64(&mut self, _depth: usize, _val: u64) {
+            fn visit_u64(&mut self, depth: u64, _val: u64) -> PartialVMResult<()> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.u64);
+                Ok(())
             }
 
             #[inline]
-            fn visit_u128(&mut self, _depth: usize, _val: u128) {
+            fn visit_u128(&mut self, depth: u64, _val: u128) -> PartialVMResult<()> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.u128);
+                Ok(())
             }
 
             #[inline]
-            fn visit_u256(&mut self, _depth: usize, _val: U256) {
+            fn visit_u256(&mut self, depth: u64, _val: U256) -> PartialVMResult<()> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.u256);
+                Ok(())
             }
 
             #[inline]
-            fn visit_bool(&mut self, _depth: usize, _val: bool) {
+            fn visit_bool(&mut self, depth: u64, _val: bool) -> PartialVMResult<()> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.bool);
+                Ok(())
             }
 
             #[inline]
-            fn visit_address(&mut self, _depth: usize, _val: AccountAddress) {
+            fn visit_address(&mut self, depth: u64, _val: AccountAddress) -> PartialVMResult<()> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.address);
+                Ok(())
             }
 
             #[inline]
-            fn visit_struct(&mut self, _depth: usize, _len: usize) -> bool {
+            fn visit_struct(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.struct_);
-                false
+                Ok(false)
             }
 
             #[inline]
-            fn visit_closure(&mut self, _depth: usize, _len: usize) -> bool {
-                // TODO(#15664): independent gas parameter for closures?
-                self.res = Some(self.params.struct_);
-                false
+            fn visit_closure(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
+                self.check_depth(depth)?;
+                self.res = Some(self.params.closure);
+                Ok(false)
             }
 
             #[inline]
-            fn visit_vec(&mut self, _depth: usize, _len: usize) -> bool {
+            fn visit_vec(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.vector);
-                false
+                Ok(false)
             }
 
             #[inline]
-            fn visit_ref(&mut self, _depth: usize, _is_global: bool) -> bool {
+            fn visit_ref(&mut self, depth: u64, _is_global: bool) -> PartialVMResult<bool> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.reference);
-                false
+                Ok(false)
             }
 
             // TODO(Gas): The following function impls are necessary due to a bug upstream.
             //            Remove them once the bug is fixed.
             #[inline]
-            fn visit_vec_u8(&mut self, depth: usize, vals: &[u8]) {
+            fn visit_vec_u8(&mut self, depth: u64, vals: &[u8]) -> PartialVMResult<()> {
                 if self.feature_version < 3 {
                     self.res = Some(0.into());
                 } else {
-                    self.visit_vec(depth, vals.len());
+                    self.visit_vec(depth, vals.len())?;
                 }
+                Ok(())
             }
 
             #[inline]
-            fn visit_vec_u16(&mut self, depth: usize, vals: &[u16]) {
-                self.visit_vec(depth, vals.len());
+            fn visit_vec_u16(&mut self, depth: u64, vals: &[u16]) -> PartialVMResult<()> {
+                self.visit_vec(depth, vals.len())?;
+                Ok(())
             }
 
             #[inline]
-            fn visit_vec_u32(&mut self, depth: usize, vals: &[u32]) {
-                self.visit_vec(depth, vals.len());
+            fn visit_vec_u32(&mut self, depth: u64, vals: &[u32]) -> PartialVMResult<()> {
+                self.visit_vec(depth, vals.len())?;
+                Ok(())
             }
 
             #[inline]
-            fn visit_vec_u64(&mut self, depth: usize, vals: &[u64]) {
+            fn visit_vec_u64(&mut self, depth: u64, vals: &[u64]) -> PartialVMResult<()> {
                 if self.feature_version < 3 {
                     self.res = Some(0.into());
                 } else {
-                    self.visit_vec(depth, vals.len());
+                    self.visit_vec(depth, vals.len())?;
                 }
+                Ok(())
             }
 
             #[inline]
-            fn visit_vec_u128(&mut self, depth: usize, vals: &[u128]) {
+            fn visit_vec_u128(&mut self, depth: u64, vals: &[u128]) -> PartialVMResult<()> {
                 if self.feature_version < 3 {
                     self.res = Some(0.into());
                 } else {
-                    self.visit_vec(depth, vals.len());
+                    self.visit_vec(depth, vals.len())?;
                 }
+                Ok(())
             }
 
             #[inline]
-            fn visit_vec_u256(&mut self, depth: usize, vals: &[U256]) {
-                self.visit_vec(depth, vals.len());
+            fn visit_vec_u256(&mut self, depth: u64, vals: &[U256]) -> PartialVMResult<()> {
+                self.visit_vec(depth, vals.len())?;
+                Ok(())
             }
 
             #[inline]
-            fn visit_vec_bool(&mut self, depth: usize, vals: &[bool]) {
+            fn visit_vec_bool(&mut self, depth: u64, vals: &[bool]) -> PartialVMResult<()> {
                 if self.feature_version < 3 {
                     self.res = Some(0.into());
                 } else {
-                    self.visit_vec(depth, vals.len());
+                    self.visit_vec(depth, vals.len())?;
                 }
+                Ok(())
             }
 
             #[inline]
-            fn visit_vec_address(&mut self, depth: usize, vals: &[AccountAddress]) {
+            fn visit_vec_address(
+                &mut self,
+                depth: u64,
+                vals: &[AccountAddress],
+            ) -> PartialVMResult<()> {
                 if self.feature_version < 3 {
                     self.res = Some(0.into());
                 } else {
-                    self.visit_vec(depth, vals.len());
+                    self.visit_vec(depth, vals.len())?;
                 }
+                Ok(())
             }
         }
 
@@ -464,162 +562,205 @@ impl AbstractValueSizeGasParameters {
             feature_version,
             params: self,
             res: None,
+            max_value_nest_depth: Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH),
         };
-        val.visit(&mut visitor);
-        visitor.res.unwrap()
+        val.visit(&mut visitor)?;
+        visitor.res.ok_or_else(|| {
+            PartialVMError::new_invariant_violation("Visitor should have set the `res` value")
+        })
     }
 
-    pub fn abstract_packed_size(&self, val: impl ValueView) -> AbstractValueSize {
+    pub fn abstract_packed_size(&self, val: impl ValueView) -> PartialVMResult<AbstractValueSize> {
         struct Visitor<'a> {
             params: &'a AbstractValueSizeGasParameters,
             res: Option<AbstractValueSize>,
+            max_value_nest_depth: Option<u64>,
+        }
+
+        impl Visitor<'_> {
+            check_depth_impl!();
         }
 
         impl ValueVisitor for Visitor<'_> {
             #[inline]
-            fn visit_delayed(&mut self, _depth: usize, _val: DelayedFieldID) {
-                // TODO[agg_v2](cleanup): add a new abstract value size parameter?
+            fn visit_delayed(&mut self, depth: u64, _val: DelayedFieldID) -> PartialVMResult<()> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.per_u64_packed * NumArgs::from(1));
+                Ok(())
             }
 
             #[inline]
-            fn visit_u8(&mut self, _depth: usize, _val: u8) {
+            fn visit_u8(&mut self, depth: u64, _val: u8) -> PartialVMResult<()> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.per_u8_packed * NumArgs::from(1));
+                Ok(())
             }
 
             #[inline]
-            fn visit_u16(&mut self, _depth: usize, _val: u16) {
+            fn visit_u16(&mut self, depth: u64, _val: u16) -> PartialVMResult<()> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.per_u16_packed * NumArgs::from(1));
+                Ok(())
             }
 
             #[inline]
-            fn visit_u32(&mut self, _depth: usize, _val: u32) {
+            fn visit_u32(&mut self, depth: u64, _val: u32) -> PartialVMResult<()> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.per_u32_packed * NumArgs::from(1));
+                Ok(())
             }
 
             #[inline]
-            fn visit_u64(&mut self, _depth: usize, _val: u64) {
+            fn visit_u64(&mut self, depth: u64, _val: u64) -> PartialVMResult<()> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.per_u64_packed * NumArgs::from(1));
+                Ok(())
             }
 
             #[inline]
-            fn visit_u128(&mut self, _depth: usize, _val: u128) {
+            fn visit_u128(&mut self, depth: u64, _val: u128) -> PartialVMResult<()> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.per_u128_packed * NumArgs::from(1));
+                Ok(())
             }
 
             #[inline]
-            fn visit_u256(&mut self, _depth: usize, _val: U256) {
+            fn visit_u256(&mut self, depth: u64, _val: U256) -> PartialVMResult<()> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.per_u256_packed * NumArgs::from(1));
+                Ok(())
             }
 
             #[inline]
-            fn visit_bool(&mut self, _depth: usize, _val: bool) {
+            fn visit_bool(&mut self, depth: u64, _val: bool) -> PartialVMResult<()> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.per_bool_packed * NumArgs::from(1));
+                Ok(())
             }
 
             #[inline]
-            fn visit_address(&mut self, _depth: usize, _val: AccountAddress) {
+            fn visit_address(&mut self, depth: u64, _val: AccountAddress) -> PartialVMResult<()> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.per_address_packed * NumArgs::from(1));
+                Ok(())
             }
 
             #[inline]
-            fn visit_struct(&mut self, _depth: usize, _len: usize) -> bool {
+            fn visit_struct(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.struct_);
-                false
+                Ok(false)
             }
 
             #[inline]
-            fn visit_closure(&mut self, _depth: usize, _len: usize) -> bool {
-                // TODO(#15664): independent gas parameter
-                self.res = Some(self.params.struct_);
-                false
+            fn visit_closure(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
+                self.check_depth(depth)?;
+                self.res = Some(self.params.closure);
+                Ok(false)
             }
 
             #[inline]
-            fn visit_vec(&mut self, _depth: usize, _len: usize) -> bool {
+            fn visit_vec(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
+                self.check_depth(depth)?;
                 self.res = Some(self.params.vector);
-                false
+                Ok(false)
             }
 
             #[inline]
-            fn visit_ref(&mut self, _depth: usize, _is_global: bool) -> bool {
+            fn visit_ref(&mut self, depth: u64, _is_global: bool) -> PartialVMResult<bool> {
                 // TODO(Gas): This should be unreachable...
                 //            See if we can handle this in a more graceful way.
+                self.check_depth(depth)?;
                 self.res = Some(self.params.reference);
-                false
+                Ok(false)
             }
 
             // TODO(Gas): The following function impls are necessary due to a bug upstream.
             //            Remove them once the bug is fixed.
             #[inline]
-            fn visit_vec_u8(&mut self, depth: usize, vals: &[u8]) {
-                self.visit_vec(depth, vals.len());
+            fn visit_vec_u8(&mut self, depth: u64, vals: &[u8]) -> PartialVMResult<()> {
+                self.visit_vec(depth, vals.len())?;
+                Ok(())
             }
 
             #[inline]
-            fn visit_vec_u16(&mut self, depth: usize, vals: &[u16]) {
-                self.visit_vec(depth, vals.len());
+            fn visit_vec_u16(&mut self, depth: u64, vals: &[u16]) -> PartialVMResult<()> {
+                self.visit_vec(depth, vals.len())?;
+                Ok(())
             }
 
             #[inline]
-            fn visit_vec_u32(&mut self, depth: usize, vals: &[u32]) {
-                self.visit_vec(depth, vals.len());
+            fn visit_vec_u32(&mut self, depth: u64, vals: &[u32]) -> PartialVMResult<()> {
+                self.visit_vec(depth, vals.len())?;
+                Ok(())
             }
 
             #[inline]
-            fn visit_vec_u64(&mut self, depth: usize, vals: &[u64]) {
-                self.visit_vec(depth, vals.len());
+            fn visit_vec_u64(&mut self, depth: u64, vals: &[u64]) -> PartialVMResult<()> {
+                self.visit_vec(depth, vals.len())?;
+                Ok(())
             }
 
             #[inline]
-            fn visit_vec_u128(&mut self, depth: usize, vals: &[u128]) {
-                self.visit_vec(depth, vals.len());
+            fn visit_vec_u128(&mut self, depth: u64, vals: &[u128]) -> PartialVMResult<()> {
+                self.visit_vec(depth, vals.len())?;
+                Ok(())
             }
 
-            fn visit_vec_u256(&mut self, depth: usize, vals: &[U256]) {
-                self.visit_vec(depth, vals.len());
-            }
-
-            #[inline]
-            fn visit_vec_bool(&mut self, depth: usize, vals: &[bool]) {
-                self.visit_vec(depth, vals.len());
+            fn visit_vec_u256(&mut self, depth: u64, vals: &[U256]) -> PartialVMResult<()> {
+                self.visit_vec(depth, vals.len())?;
+                Ok(())
             }
 
             #[inline]
-            fn visit_vec_address(&mut self, depth: usize, vals: &[AccountAddress]) {
-                self.visit_vec(depth, vals.len());
+            fn visit_vec_bool(&mut self, depth: u64, vals: &[bool]) -> PartialVMResult<()> {
+                self.visit_vec(depth, vals.len())?;
+                Ok(())
+            }
+
+            #[inline]
+            fn visit_vec_address(
+                &mut self,
+                depth: u64,
+                vals: &[AccountAddress],
+            ) -> PartialVMResult<()> {
+                self.visit_vec(depth, vals.len())?;
+                Ok(())
             }
         }
 
         let mut visitor = Visitor {
             params: self,
             res: None,
+            max_value_nest_depth: Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH),
         };
-        val.visit(&mut visitor);
-        visitor.res.unwrap()
+        val.visit(&mut visitor)?;
+        visitor.res.ok_or_else(|| {
+            PartialVMError::new_invariant_violation("Visitor should have set the `res` value")
+        })
     }
 
     pub fn abstract_value_size_stack_and_heap(
         &self,
         val: impl ValueView,
         feature_version: u64,
-    ) -> (AbstractValueSize, AbstractValueSize) {
-        let stack_size = self.abstract_stack_size(&val, feature_version);
-        let abs_size = self.abstract_value_size(val, feature_version);
+    ) -> PartialVMResult<(AbstractValueSize, AbstractValueSize)> {
+        let stack_size = self.abstract_stack_size(&val, feature_version)?;
+        let abs_size = self.abstract_value_size(val, feature_version)?;
         let heap_size = abs_size.checked_sub(stack_size).unwrap_or_else(|| 0.into());
 
-        (stack_size, heap_size)
+        Ok((stack_size, heap_size))
     }
 
     pub fn abstract_heap_size(
         &self,
         val: impl ValueView,
         feature_version: u64,
-    ) -> AbstractValueSize {
-        let stack_size = self.abstract_stack_size(&val, feature_version);
-        let abs_size = self.abstract_value_size(val, feature_version);
+    ) -> PartialVMResult<AbstractValueSize> {
+        let stack_size = self.abstract_stack_size(&val, feature_version)?;
+        let abs_size = self.abstract_value_size(val, feature_version)?;
 
-        abs_size.checked_sub(stack_size).unwrap_or_else(|| 0.into())
+        Ok(abs_size.checked_sub(stack_size).unwrap_or_else(|| 0.into()))
     }
 }
 

--- a/aptos-move/aptos-memory-usage-tracker/src/lib.rs
+++ b/aptos-move/aptos-memory-usage-tracker/src/lib.rs
@@ -226,13 +226,17 @@ where
     ) -> PartialVMResult<()> {
         // TODO(Gas): https://github.com/aptos-labs/aptos-core/issues/5485
         if !self.should_leak_memory_for_native {
-            self.release_heap_memory(args.clone().fold(AbstractValueSize::zero(), |acc, val| {
-                acc + self
-                    .vm_gas_params()
-                    .misc
-                    .abs_val
-                    .abstract_heap_size(val, self.feature_version())
-            }));
+            self.release_heap_memory(args.clone().try_fold(
+                AbstractValueSize::zero(),
+                |acc, val| {
+                    let heap_size = self
+                        .vm_gas_params()
+                        .misc
+                        .abs_val
+                        .abstract_heap_size(val, self.feature_version())?;
+                    Ok::<_, PartialVMError>(acc + heap_size)
+                },
+            )?);
         }
 
         self.base
@@ -245,14 +249,15 @@ where
         amount: InternalGas,
         ret_vals: Option<impl ExactSizeIterator<Item = impl ValueView> + Clone>,
     ) -> PartialVMResult<()> {
-        if let Some(ret_vals) = ret_vals.clone() {
-            self.use_heap_memory(ret_vals.fold(AbstractValueSize::zero(), |acc, val| {
-                acc + self
+        if let Some(mut ret_vals) = ret_vals.clone() {
+            self.use_heap_memory(ret_vals.try_fold(AbstractValueSize::zero(), |acc, val| {
+                let heap_size = self
                     .vm_gas_params()
                     .misc
                     .abs_val
-                    .abstract_heap_size(val, self.feature_version())
-            }))?;
+                    .abstract_heap_size(val, self.feature_version())?;
+                Ok::<_, PartialVMError>(acc + heap_size)
+            })?)?;
         }
 
         self.base.charge_native_function(amount, ret_vals)
@@ -261,7 +266,7 @@ where
     #[inline]
     fn charge_load_resource(
         &mut self,
-        addr: move_core_types::account_address::AccountAddress,
+        addr: AccountAddress,
         ty: impl TypeView,
         val: Option<impl ValueView>,
         bytes_loaded: NumBytes,
@@ -273,7 +278,7 @@ where
                     self.vm_gas_params()
                         .misc
                         .abs_val
-                        .abstract_heap_size(val, self.feature_version()),
+                        .abstract_heap_size(val, self.feature_version())?,
                 )?;
             }
         }
@@ -287,7 +292,7 @@ where
             self.vm_gas_params()
                 .misc
                 .abs_val
-                .abstract_heap_size(&popped_val, self.feature_version()),
+                .abstract_heap_size(&popped_val, self.feature_version())?,
         );
 
         self.base.charge_pop(popped_val)
@@ -302,7 +307,7 @@ where
             self.vm_gas_params()
                 .misc
                 .abs_val
-                .abstract_heap_size(&val, self.feature_version()),
+                .abstract_heap_size(&val, self.feature_version())?,
         )?;
 
         self.base.charge_ld_const_after_deserialization(val)
@@ -314,7 +319,7 @@ where
             .vm_gas_params()
             .misc
             .abs_val
-            .abstract_heap_size(&val, self.feature_version());
+            .abstract_heap_size(&val, self.feature_version())?;
 
         self.use_heap_memory(heap_size)?;
 
@@ -327,13 +332,17 @@ where
         is_generic: bool,
         args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
     ) -> PartialVMResult<()> {
-        self.use_heap_memory(args.clone().fold(AbstractValueSize::zero(), |acc, val| {
-            acc + self
-                .vm_gas_params()
-                .misc
-                .abs_val
-                .abstract_stack_size(val, self.feature_version())
-        }))?;
+        self.use_heap_memory(
+            args.clone()
+                .try_fold(AbstractValueSize::zero(), |acc, val| {
+                    let stack_size = self
+                        .vm_gas_params()
+                        .misc
+                        .abs_val
+                        .abstract_stack_size(val, self.feature_version())?;
+                    Ok::<_, PartialVMError>(acc + stack_size)
+                })?,
+        )?;
 
         self.base.charge_pack(is_generic, args)
     }
@@ -344,15 +353,40 @@ where
         is_generic: bool,
         args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
     ) -> PartialVMResult<()> {
-        self.release_heap_memory(args.clone().fold(AbstractValueSize::zero(), |acc, val| {
-            acc + self
-                .vm_gas_params()
-                .misc
-                .abs_val
-                .abstract_stack_size(val, self.feature_version())
-        }));
+        self.release_heap_memory(args.clone().try_fold(
+            AbstractValueSize::zero(),
+            |acc, val| {
+                let stack_size = self
+                    .vm_gas_params()
+                    .misc
+                    .abs_val
+                    .abstract_stack_size(val, self.feature_version())?;
+                Ok::<_, PartialVMError>(acc + stack_size)
+            },
+        )?);
 
         self.base.charge_unpack(is_generic, args)
+    }
+
+    #[inline]
+    fn charge_pack_closure(
+        &mut self,
+        is_generic: bool,
+        args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
+    ) -> PartialVMResult<()> {
+        self.use_heap_memory(
+            args.clone()
+                .try_fold(AbstractValueSize::zero(), |acc, val| {
+                    let stack_size = self
+                        .vm_gas_params()
+                        .misc
+                        .abs_val
+                        .abstract_stack_size(val, self.feature_version())?;
+                    Ok::<_, PartialVMError>(acc + stack_size)
+                })?,
+        )?;
+
+        self.base.charge_pack_closure(is_generic, args)
     }
 
     #[inline]
@@ -361,7 +395,7 @@ where
             .vm_gas_params()
             .misc
             .abs_val
-            .abstract_heap_size(&val, self.feature_version());
+            .abstract_heap_size(&val, self.feature_version())?;
 
         self.use_heap_memory(heap_size)?;
 
@@ -378,7 +412,7 @@ where
             self.vm_gas_params()
                 .misc
                 .abs_val
-                .abstract_heap_size(&old_val, self.feature_version()),
+                .abstract_heap_size(&old_val, self.feature_version())?,
         );
 
         self.base.charge_write_ref(new_val, old_val)
@@ -390,13 +424,13 @@ where
             self.vm_gas_params()
                 .misc
                 .abs_val
-                .abstract_heap_size(&lhs, self.feature_version()),
+                .abstract_heap_size(&lhs, self.feature_version())?,
         );
         self.release_heap_memory(
             self.vm_gas_params()
                 .misc
                 .abs_val
-                .abstract_heap_size(&rhs, self.feature_version()),
+                .abstract_heap_size(&rhs, self.feature_version())?,
         );
 
         self.base.charge_eq(lhs, rhs)
@@ -408,13 +442,13 @@ where
             self.vm_gas_params()
                 .misc
                 .abs_val
-                .abstract_heap_size(&lhs, self.feature_version()),
+                .abstract_heap_size(&lhs, self.feature_version())?,
         );
         self.release_heap_memory(
             self.vm_gas_params()
                 .misc
                 .abs_val
-                .abstract_heap_size(&rhs, self.feature_version()),
+                .abstract_heap_size(&rhs, self.feature_version())?,
         );
 
         self.base.charge_neq(lhs, rhs)
@@ -426,9 +460,18 @@ where
         ty: impl TypeView + 'a,
         args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
     ) -> PartialVMResult<()> {
-        self.use_heap_memory(args.clone().fold(AbstractValueSize::zero(), |acc, val| {
-            acc + self.vm_gas_params().misc.abs_val.abstract_packed_size(val)
-        }))?;
+        self.use_heap_memory(
+            args.clone()
+                .try_fold(AbstractValueSize::zero(), |acc, val| {
+                    Ok::<_, PartialVMError>(
+                        acc + self
+                            .vm_gas_params()
+                            .misc
+                            .abs_val
+                            .abstract_packed_size(val)?,
+                    )
+                })?,
+        )?;
 
         self.base.charge_vec_pack(ty, args)
     }
@@ -440,9 +483,18 @@ where
         expect_num_elements: NumArgs,
         elems: impl ExactSizeIterator<Item = impl ValueView> + Clone,
     ) -> PartialVMResult<()> {
-        self.release_heap_memory(elems.clone().fold(AbstractValueSize::zero(), |acc, val| {
-            acc + self.vm_gas_params().misc.abs_val.abstract_packed_size(val)
-        }));
+        self.release_heap_memory(elems.clone().try_fold(
+            AbstractValueSize::zero(),
+            |acc, val| {
+                Ok::<_, PartialVMError>(
+                    acc + self
+                        .vm_gas_params()
+                        .misc
+                        .abs_val
+                        .abstract_packed_size(val)?,
+                )
+            },
+        )?);
 
         self.base.charge_vec_unpack(ty, expect_num_elements, elems)
     }
@@ -453,7 +505,12 @@ where
         ty: impl TypeView,
         val: impl ValueView,
     ) -> PartialVMResult<()> {
-        self.use_heap_memory(self.vm_gas_params().misc.abs_val.abstract_packed_size(&val))?;
+        self.use_heap_memory(
+            self.vm_gas_params()
+                .misc
+                .abs_val
+                .abstract_packed_size(&val)?,
+        )?;
 
         self.base.charge_vec_push_back(ty, val)
     }
@@ -465,7 +522,12 @@ where
         val: Option<impl ValueView>,
     ) -> PartialVMResult<()> {
         if let Some(val) = &val {
-            self.release_heap_memory(self.vm_gas_params().misc.abs_val.abstract_packed_size(val));
+            self.release_heap_memory(
+                self.vm_gas_params()
+                    .misc
+                    .abs_val
+                    .abstract_packed_size(val)?,
+            );
         }
 
         self.base.charge_vec_pop_back(ty, val)
@@ -476,13 +538,17 @@ where
         &mut self,
         locals: impl Iterator<Item = impl ValueView> + Clone,
     ) -> PartialVMResult<()> {
-        self.release_heap_memory(locals.clone().fold(AbstractValueSize::zero(), |acc, val| {
-            acc + self
-                .vm_gas_params()
-                .misc
-                .abs_val
-                .abstract_heap_size(val, self.feature_version())
-        }));
+        self.release_heap_memory(locals.clone().try_fold(
+            AbstractValueSize::zero(),
+            |acc, val| {
+                let heap_size = self
+                    .vm_gas_params()
+                    .misc
+                    .abs_val
+                    .abstract_heap_size(val, self.feature_version())?;
+                Ok::<_, PartialVMError>(acc + heap_size)
+            },
+        )?);
 
         self.base.charge_drop_frame(locals)
     }

--- a/aptos-move/aptos-memory-usage-tracker/src/lib.rs
+++ b/aptos-move/aptos-memory-usage-tracker/src/lib.rs
@@ -369,27 +369,6 @@ where
     }
 
     #[inline]
-    fn charge_pack_closure(
-        &mut self,
-        is_generic: bool,
-        args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
-    ) -> PartialVMResult<()> {
-        self.use_heap_memory(
-            args.clone()
-                .try_fold(AbstractValueSize::zero(), |acc, val| {
-                    let stack_size = self
-                        .vm_gas_params()
-                        .misc
-                        .abs_val
-                        .abstract_stack_size(val, self.feature_version())?;
-                    Ok::<_, PartialVMError>(acc + stack_size)
-                })?,
-        )?;
-
-        self.base.charge_pack_closure(is_generic, args)
-    }
-
-    #[inline]
     fn charge_read_ref(&mut self, val: impl ValueView) -> PartialVMResult<()> {
         let heap_size = self
             .vm_gas_params()

--- a/aptos-move/aptos-native-interface/src/context.rs
+++ b/aptos-move/aptos-native-interface/src/context.rs
@@ -10,7 +10,7 @@ use aptos_gas_schedule::{
     NativeGasParameters,
 };
 use aptos_types::on_chain_config::{Features, TimedFeatureFlag, TimedFeatures};
-use move_binary_format::errors::VMResult;
+use move_binary_format::errors::{PartialVMResult, VMResult};
 use move_core_types::{
     gas_algebra::InternalGas, identifier::Identifier, language_storage::ModuleId,
 };
@@ -122,14 +122,14 @@ impl SafeNativeContext<'_, '_, '_, '_> {
     }
 
     /// Computes the abstract size of the input value.
-    pub fn abs_val_size(&self, val: &Value) -> AbstractValueSize {
+    pub fn abs_val_size(&self, val: &Value) -> PartialVMResult<AbstractValueSize> {
         self.misc_gas_params
             .abs_val
             .abstract_value_size(val, self.gas_feature_version)
     }
 
     /// Computes the abstract size of the input value.
-    pub fn abs_val_size_dereferenced(&self, val: &Value) -> AbstractValueSize {
+    pub fn abs_val_size_dereferenced(&self, val: &Value) -> PartialVMResult<AbstractValueSize> {
         self.misc_gas_params
             .abs_val
             .abstract_value_size_dereferenced(val, self.gas_feature_version)
@@ -143,6 +143,20 @@ impl SafeNativeContext<'_, '_, '_, '_> {
     /// Returns the current gas feature version.
     pub fn gas_feature_version(&self) -> u64 {
         self.gas_feature_version
+    }
+
+    pub fn max_value_nest_depth(&self) -> Option<u64> {
+        self.module_storage()
+            .runtime_environment()
+            .vm_config()
+            .enable_depth_checks
+            .then(|| {
+                self.module_storage()
+                    .runtime_environment()
+                    .vm_config()
+                    .max_value_nest_depth
+            })
+            .flatten()
     }
 
     /// Returns a reference to the struct representing on-chain features.

--- a/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
+++ b/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
@@ -58,7 +58,10 @@ use move_transactional_test_runner::{
     vm_test_harness::{PrecompiledFilesModules, TestRunConfig},
 };
 use move_vm_runtime::{move_vm::SerializedReturnValues, AsFunctionValueExtension};
-use move_vm_types::{value_serde::ValueSerDeContext, values::Value};
+use move_vm_types::{
+    value_serde::{FunctionValueExtension, ValueSerDeContext},
+    values::Value,
+};
 use once_cell::sync::Lazy;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -1031,8 +1034,10 @@ impl<'a> MoveTestAdapter<'a> for AptosTestAdapter<'a> {
     fn deserialize(&self, bytes: &[u8], layout: &MoveTypeLayout) -> Option<Value> {
         let environment = AptosEnvironment::new(&self.storage);
         let code_storage = self.storage.as_aptos_code_storage(&environment);
-        ValueSerDeContext::new()
-            .with_func_args_deserialization(&code_storage.as_function_value_extension())
+
+        let function_value_extension = code_storage.as_function_value_extension();
+        ValueSerDeContext::new(function_value_extension.max_value_nest_depth())
+            .with_func_args_deserialization(&function_value_extension)
             .deserialize(bytes, layout)
     }
 }

--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -16,7 +16,9 @@ use aptos_types::{
 use move_binary_format::deserializer::DeserializerConfig;
 use move_bytecode_verifier::VerifierConfig;
 use move_vm_runtime::config::VMConfig;
-use move_vm_types::loaded_data::runtime_types::TypeBuilder;
+use move_vm_types::{
+    loaded_data::runtime_types::TypeBuilder, values::DEFAULT_MAX_VM_VALUE_NESTED_DEPTH,
+};
 use once_cell::sync::OnceCell;
 
 static PARANOID_TYPE_CHECKS: OnceCell<bool> = OnceCell::new();
@@ -127,12 +129,21 @@ pub fn aptos_prod_vm_config(
         256
     };
 
-    VMConfig {
+    // Value runtime depth checks have been introduced together with function values and are only
+    // enabled when the function values are enabled. Previously, checks were performed over types
+    // to bound the value depth (checking the size of a packed struct type bounds the value), but
+    // this no longer applies once function values are enabled. With function values, types can be
+    // shallow while the value can be deeply nested, thanks to captured arguments not visible in a
+    // type. Hence, depth checks have been adjusted to operate on values.
+    let enable_depth_checks = features.is_enabled(FeatureFlag::ENABLE_FUNCTION_VALUES);
+
+    let config = VMConfig {
         verifier_config,
         deserializer_config,
         paranoid_type_checks,
         check_invariant_in_swap_loc,
-        max_value_nest_depth: Some(128),
+        // Note: if updating, make sure the constant is in-sync.
+        max_value_nest_depth: Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH),
         layout_max_size,
         layout_max_depth: 128,
         // 5000 limits type tag total size < 5000 bytes and < 50 nodes.
@@ -146,7 +157,17 @@ pub fn aptos_prod_vm_config(
         use_call_tree_and_instruction_cache: features
             .is_call_tree_and_instruction_vm_cache_enabled(),
         enable_lazy_loading: features.is_lazy_loading_enabled(),
-    }
+        enable_depth_checks,
+    };
+
+    // Note: if max_value_nest_depth changed, make sure the constant is in-sync. Do not remove this
+    // assertion as it ensures the constant value is set correctly.
+    assert_eq!(
+        config.max_value_nest_depth,
+        Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH)
+    );
+
+    config
 }
 
 /// A collection of on-chain randomness API configs that VM needs to be aware of.

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -44,7 +44,11 @@ use move_vm_runtime::{
     native_extensions::NativeContextExtensions,
     AsFunctionValueExtension, LoadedFunction, ModuleStorage, VerifiedModuleBundle,
 };
-use move_vm_types::{gas::GasMeter, value_serde::ValueSerDeContext, values::Value};
+use move_vm_types::{
+    gas::GasMeter,
+    value_serde::{FunctionValueExtension, ValueSerDeContext},
+    values::Value,
+};
 use std::{borrow::Borrow, collections::BTreeMap, sync::Arc};
 
 pub mod respawned_session;
@@ -176,7 +180,7 @@ where
                 // We allow serialization of native values here because we want to
                 // temporarily store native values (via encoding to ensure deterministic
                 // gas charging) in block storage.
-                ValueSerDeContext::new()
+                ValueSerDeContext::new(function_extension.max_value_nest_depth())
                     .with_delayed_fields_serde()
                     .with_func_args_deserialization(&function_extension)
                     .serialize(&value, &layout)?
@@ -184,7 +188,7 @@ where
             } else {
                 // Otherwise, there should be no native values so ensure
                 // serialization fails here if there are any.
-                ValueSerDeContext::new()
+                ValueSerDeContext::new(function_extension.max_value_nest_depth())
                     .with_func_args_deserialization(&function_extension)
                     .serialize(&value, &layout)?
                     .map(|bytes| (bytes.into(), None))

--- a/aptos-move/block-executor/src/value_exchange.rs
+++ b/aptos-move/block-executor/src/value_exchange.rs
@@ -19,7 +19,7 @@ use move_core_types::value::{IdentifierMappingKind, MoveTypeLayout};
 use move_vm_runtime::AsFunctionValueExtension;
 use move_vm_types::{
     delayed_values::delayed_field_id::{DelayedFieldID, ExtractWidth, TryFromMoveValue},
-    value_serde::{ValueSerDeContext, ValueToIdentifierMapping},
+    value_serde::{FunctionValueExtension, ValueSerDeContext, ValueToIdentifierMapping},
     value_traversal::find_identifiers_in_value,
     values::Value,
 };
@@ -116,7 +116,7 @@ where
         //   See if can cache identifiers in advance, or combine it with
         //   deserialization.
         let function_value_extension = self.as_function_value_extension();
-        let value = ValueSerDeContext::new()
+        let value = ValueSerDeContext::new(function_value_extension.max_value_nest_depth())
             .with_func_args_deserialization(&function_value_extension)
             .with_delayed_fields_serde()
             .deserialize(bytes, layout)

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -59,7 +59,7 @@ use move_core_types::{language_storage::ModuleId, value::MoveTypeLayout, vm_stat
 use move_vm_runtime::{AsFunctionValueExtension, Module, RuntimeEnvironment};
 use move_vm_types::{
     delayed_values::delayed_field_id::{DelayedFieldID, ExtractUniqueIndex},
-    value_serde::ValueSerDeContext,
+    value_serde::{FunctionValueExtension, ValueSerDeContext},
 };
 use std::{
     cell::RefCell,
@@ -1173,15 +1173,16 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
                 // values with unique identifiers with the same type layout.
                 // The values are stored in aggregators multi-version data structure,
                 // see the actual trait implementation for more details.
-                let patched_value = ValueSerDeContext::new()
-                    .with_delayed_fields_replacement(&mapping)
-                    .with_func_args_deserialization(&function_value_extension)
-                    .deserialize(bytes.as_ref(), layout)
-                    .ok_or_else(|| {
-                        anyhow::anyhow!("Failed to deserialize resource during id replacement")
-                    })?;
+                let patched_value =
+                    ValueSerDeContext::new(function_value_extension.max_value_nest_depth())
+                        .with_delayed_fields_replacement(&mapping)
+                        .with_func_args_deserialization(&function_value_extension)
+                        .deserialize(bytes.as_ref(), layout)
+                        .ok_or_else(|| {
+                            anyhow::anyhow!("Failed to deserialize resource during id replacement")
+                        })?;
 
-                ValueSerDeContext::new()
+                ValueSerDeContext::new(function_value_extension.max_value_nest_depth())
                     .with_delayed_fields_serde()
                     .with_func_args_deserialization(&function_value_extension)
                     .serialize(&patched_value, layout)?
@@ -1206,7 +1207,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
         // This call will replace all occurrences of aggregator / snapshot
         // identifiers with values with the same type layout.
         let function_value_extension = self.as_function_value_extension();
-        let value = ValueSerDeContext::new()
+        let value = ValueSerDeContext::new(function_value_extension.max_value_nest_depth())
             .with_func_args_deserialization(&function_value_extension)
             .with_delayed_fields_serde()
             .deserialize(bytes, layout)
@@ -1218,7 +1219,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
             })?;
 
         let mapping = TemporaryValueToIdentifierMapping::new(self, self.txn_idx);
-        let patched_bytes = ValueSerDeContext::new()
+        let patched_bytes = ValueSerDeContext::new(function_value_extension.max_value_nest_depth())
             .with_delayed_fields_replacement(&mapping)
             .with_func_args_deserialization(&function_value_extension)
             .serialize(&value, layout)?
@@ -2538,7 +2539,7 @@ mod test {
 
     fn create_state_value(value: &Value, layout: &MoveTypeLayout) -> StateValue {
         StateValue::new_legacy(
-            ValueSerDeContext::new()
+            ValueSerDeContext::new(None)
                 .serialize(value, layout)
                 .unwrap()
                 .unwrap()

--- a/aptos-move/e2e-move-tests/src/tests/function_value_depth.rs
+++ b/aptos-move/e2e-move-tests/src/tests/function_value_depth.rs
@@ -1,0 +1,65 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for deeply-nested function values. The Move VM must ensure that it is not possible to
+//! construct values that are too deep, as this can cause stack overflow.
+
+use crate::{assert_success, assert_vm_status, tests::common, MoveHarness};
+use aptos_framework::BuildOptions;
+use aptos_package_builder::PackageBuilder;
+use aptos_transaction_simulation::Account;
+use aptos_types::transaction::TransactionStatus;
+use move_core_types::{account_address::AccountAddress, vm_status::StatusCode};
+
+#[test]
+fn test_vm_value_too_deep_with_function_values() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0x99").unwrap());
+
+    let status = publish(
+        &mut h,
+        &acc,
+        r#"
+        module 0x99::m {
+            public fun dummy2(_v: || has drop+copy) {}
+
+            // Creates a very deep value that can be tested for off by 1 around the current maximum
+            // depth value.
+            public entry fun run2(n: u64) {
+                let f: || has copy+drop = || {};
+                let i = 0;
+                while (i < n) {
+                  f = || dummy2(f);
+                  i = i + 1;
+                };
+            }
+        }
+        "#,
+    );
+    assert_success!(status);
+
+    let status = h.run_entry_function(&acc, str::parse("0x99::m::run2").unwrap(), vec![], vec![
+        bcs::to_bytes(&129_u64).unwrap(),
+    ]);
+    assert_vm_status!(status, StatusCode::VM_MAX_VALUE_DEPTH_REACHED);
+
+    let status = h.run_entry_function(&acc, str::parse("0x99::m::run2").unwrap(), vec![], vec![
+        bcs::to_bytes(&128_u64).unwrap(),
+    ]);
+    assert_success!(status);
+}
+
+fn publish(h: &mut MoveHarness, account: &Account, source: &str) -> TransactionStatus {
+    let mut builder = PackageBuilder::new("Package");
+    builder.add_source("m.move", source);
+    builder.add_local_dep(
+        "MoveStdlib",
+        &common::framework_dir_path("move-stdlib").to_string_lossy(),
+    );
+    let path = builder.write_to_temp().unwrap();
+    h.publish_package_with_options(
+        account,
+        path.path(),
+        BuildOptions::move_2().set_latest_language(),
+    )
+}

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -22,6 +22,7 @@ mod enum_variant_count;
 mod error_map;
 mod events;
 mod fee_payer;
+mod function_value_depth;
 mod function_values;
 mod fungible_asset;
 mod gas;

--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -88,6 +88,7 @@ claims = { workspace = true }
 move-cli = { workspace = true }
 move-prover = { workspace = true }
 move-unit-test = { workspace = true }
+move-vm-types = { workspace = true, features = ["testing"] }
 
 [features]
 default = []

--- a/aptos-move/framework/move-stdlib/src/natives/bcs.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/bcs.rs
@@ -70,7 +70,8 @@ fn native_to_bytes(
     let val = ref_to_val.read_ref()?;
 
     let function_value_extension = context.function_value_extension();
-    let serialized_value = match ValueSerDeContext::new()
+    let max_value_nest_depth = context.max_value_nest_depth();
+    let serialized_value = match ValueSerDeContext::new(max_value_nest_depth)
         .with_legacy_signer()
         .with_func_args_deserialization(&function_value_extension)
         .serialize(&val, &layout)?
@@ -138,7 +139,8 @@ fn serialized_size_impl(
     let ty_layout = context.type_to_type_layout(ty)?;
 
     let function_value_extension = context.function_value_extension();
-    ValueSerDeContext::new()
+    let max_value_nest_depth = context.max_value_nest_depth();
+    ValueSerDeContext::new(max_value_nest_depth)
         .with_legacy_signer()
         .with_func_args_deserialization(&function_value_extension)
         .with_delayed_fields_serde()

--- a/aptos-move/framework/move-stdlib/src/natives/cmp.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/cmp.rs
@@ -47,8 +47,8 @@ fn native_compare(
 
     let cost = CMP_COMPARE_BASE
         + CMP_COMPARE_PER_ABS_VAL_UNIT
-            * (context.abs_val_size_dereferenced(&args[0])
-                + context.abs_val_size_dereferenced(&args[1]));
+            * (context.abs_val_size_dereferenced(&args[0])?
+                + context.abs_val_size_dereferenced(&args[1])?);
     context.charge(cost)?;
 
     let ordering = args[0].compare(&args[1])?;

--- a/aptos-move/framework/src/natives/event.rs
+++ b/aptos-move/framework/src/natives/event.rs
@@ -87,14 +87,15 @@ fn native_write_to_event_store(
     // TODO(Gas): Get rid of abstract memory size
     context.charge(
         EVENT_WRITE_TO_EVENT_STORE_BASE
-            + EVENT_WRITE_TO_EVENT_STORE_PER_ABSTRACT_VALUE_UNIT * context.abs_val_size(&msg),
+            + EVENT_WRITE_TO_EVENT_STORE_PER_ABSTRACT_VALUE_UNIT * context.abs_val_size(&msg)?,
     )?;
     let ty_tag = context.type_to_type_tag(&ty)?;
     let (layout, has_aggregator_lifting) =
         context.type_to_type_layout_with_identifier_mappings(&ty)?;
 
     let function_value_extension = context.function_value_extension();
-    let blob = ValueSerDeContext::new()
+    let max_value_nest_depth = context.max_value_nest_depth();
+    let blob = ValueSerDeContext::new(max_value_nest_depth)
         .with_delayed_fields_serde()
         .with_func_args_deserialization(&function_value_extension)
         .serialize(&msg, &layout)?
@@ -161,7 +162,8 @@ fn native_emitted_events_by_handle(
         .into_iter()
         .map(|blob| {
             let function_value_extension = context.function_value_extension();
-            ValueSerDeContext::new()
+            let max_value_nest_depth = context.max_value_nest_depth();
+            ValueSerDeContext::new(max_value_nest_depth)
                 .with_func_args_deserialization(&function_value_extension)
                 .deserialize(blob, &ty_layout)
                 .ok_or_else(|| {
@@ -194,7 +196,8 @@ fn native_emitted_events(
         .into_iter()
         .map(|blob| {
             let function_value_extension = context.function_value_extension();
-            ValueSerDeContext::new()
+            let max_value_nest_depth = context.max_value_nest_depth();
+            ValueSerDeContext::new(max_value_nest_depth)
                 .with_func_args_deserialization(&function_value_extension)
                 .with_delayed_fields_serde()
                 .deserialize(blob, &ty_layout)
@@ -222,7 +225,7 @@ fn native_write_module_event_to_store(
 
     context.charge(
         EVENT_WRITE_TO_EVENT_STORE_BASE
-            + EVENT_WRITE_TO_EVENT_STORE_PER_ABSTRACT_VALUE_UNIT * context.abs_val_size(&msg),
+            + EVENT_WRITE_TO_EVENT_STORE_PER_ABSTRACT_VALUE_UNIT * context.abs_val_size(&msg)?,
     )?;
 
     let type_tag = context.type_to_type_tag(&ty)?;
@@ -262,7 +265,8 @@ fn native_write_module_event_to_store(
         context.type_to_type_layout_with_identifier_mappings(&ty)?;
 
     let function_value_extension = context.function_value_extension();
-    let blob = ValueSerDeContext::new()
+    let max_value_nest_depth = context.max_value_nest_depth();
+    let blob = ValueSerDeContext::new(max_value_nest_depth)
         .with_delayed_fields_serde()
         .with_func_args_deserialization(&function_value_extension)
         .serialize(&msg, &layout)?

--- a/aptos-move/framework/src/natives/util.rs
+++ b/aptos-move/framework/src/natives/util.rs
@@ -44,7 +44,8 @@ fn native_from_bytes(
     )?;
 
     let function_value_extension = context.function_value_extension();
-    let val = match ValueSerDeContext::new()
+    let max_value_nest_depth = context.max_value_nest_depth();
+    let val = match ValueSerDeContext::new(max_value_nest_depth)
         .with_legacy_signer()
         .with_func_args_deserialization(&function_value_extension)
         .deserialize(&bytes, &layout)

--- a/aptos-move/framework/table-natives/src/lib.rs
+++ b/aptos-move/framework/table-natives/src/lib.rs
@@ -385,13 +385,14 @@ fn native_add_box(
     let (gv, loaded) =
         table.get_or_create_global_value(&function_value_extension, table_context, key_bytes)?;
     let mem_usage = if !fix_memory_double_counting || loaded.is_some() {
-        gv.view().map(|val| {
-            u64::from(
+        gv.view()
+            .map(|val| {
                 context
                     .abs_val_gas_params()
-                    .abstract_heap_size(&val, context.gas_feature_version()),
-            )
-        })
+                    .abstract_heap_size(&val, context.gas_feature_version())
+                    .map(u64::from)
+            })
+            .transpose()?
     } else {
         None
     };
@@ -441,13 +442,14 @@ fn native_borrow_box(
     let (gv, loaded) =
         table.get_or_create_global_value(&function_value_extension, table_context, key_bytes)?;
     let mem_usage = if !fix_memory_double_counting || loaded.is_some() {
-        gv.view().map(|val| {
-            u64::from(
+        gv.view()
+            .map(|val| {
                 context
                     .abs_val_gas_params()
-                    .abstract_heap_size(&val, context.gas_feature_version()),
-            )
-        })
+                    .abstract_heap_size(&val, context.gas_feature_version())
+                    .map(u64::from)
+            })
+            .transpose()?
     } else {
         None
     };
@@ -498,13 +500,14 @@ fn native_contains_box(
     let (gv, loaded) =
         table.get_or_create_global_value(&function_value_extension, table_context, key_bytes)?;
     let mem_usage = if !fix_memory_double_counting || loaded.is_some() {
-        gv.view().map(|val| {
-            u64::from(
+        gv.view()
+            .map(|val| {
                 context
                     .abs_val_gas_params()
-                    .abstract_heap_size(&val, context.gas_feature_version()),
-            )
-        })
+                    .abstract_heap_size(&val, context.gas_feature_version())
+                    .map(u64::from)
+            })
+            .transpose()?
     } else {
         None
     };
@@ -549,13 +552,14 @@ fn native_remove_box(
     let (gv, loaded) =
         table.get_or_create_global_value(&function_value_extension, table_context, key_bytes)?;
     let mem_usage = if !fix_memory_double_counting || loaded.is_some() {
-        gv.view().map(|val| {
-            u64::from(
+        gv.view()
+            .map(|val| {
                 context
                     .abs_val_gas_params()
-                    .abstract_heap_size(&val, context.gas_feature_version()),
-            )
-        })
+                    .abstract_heap_size(&val, context.gas_feature_version())
+                    .map(u64::from)
+            })
+            .transpose()?
     } else {
         None
     };
@@ -631,7 +635,7 @@ fn serialize_key(
     layout: &MoveTypeLayout,
     key: &Value,
 ) -> PartialVMResult<Vec<u8>> {
-    ValueSerDeContext::new()
+    ValueSerDeContext::new(function_value_extension.max_value_nest_depth())
         .with_func_args_deserialization(function_value_extension)
         .serialize(key, layout)?
         .ok_or_else(|| partial_extension_error("cannot serialize table key"))
@@ -642,9 +646,10 @@ fn serialize_value(
     layout_info: &LayoutInfo,
     val: &Value,
 ) -> PartialVMResult<(Bytes, Option<Arc<MoveTypeLayout>>)> {
+    let max_value_nest_depth = function_value_extension.max_value_nest_depth();
     let serialization_result = if layout_info.has_identifier_mappings {
         // Value contains delayed fields, so we should be able to serialize it.
-        ValueSerDeContext::new()
+        ValueSerDeContext::new(max_value_nest_depth)
             .with_delayed_fields_serde()
             .with_func_args_deserialization(function_value_extension)
             .serialize(val, layout_info.layout.as_ref())?
@@ -652,7 +657,7 @@ fn serialize_value(
     } else {
         // No delayed fields, make sure serialization fails if there are any
         // native values.
-        ValueSerDeContext::new()
+        ValueSerDeContext::new(max_value_nest_depth)
             .with_func_args_deserialization(function_value_extension)
             .serialize(val, layout_info.layout.as_ref())?
             .map(|bytes| (bytes.into(), None))
@@ -667,12 +672,12 @@ fn deserialize_value(
 ) -> PartialVMResult<Value> {
     let layout = layout_info.layout.as_ref();
     let deserialization_result = if layout_info.has_identifier_mappings {
-        ValueSerDeContext::new()
+        ValueSerDeContext::new(function_value_extension.max_value_nest_depth())
             .with_func_args_deserialization(function_value_extension)
             .with_delayed_fields_serde()
             .deserialize(bytes, layout)
     } else {
-        ValueSerDeContext::new()
+        ValueSerDeContext::new(function_value_extension.max_value_nest_depth())
             .with_func_args_deserialization(function_value_extension)
             .deserialize(bytes, layout)
     };

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/value_deserialize.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/value_deserialize.rs
@@ -19,6 +19,5 @@ fuzz_target!(|fuzz_data: FuzzData| {
     if fuzz_data.data.is_empty() || !is_valid_layout(&fuzz_data.layout) {
         return;
     }
-    // TODO: How do we fuzz function resolution?
-    let _ = ValueSerDeContext::new().deserialize(&fuzz_data.data, &fuzz_data.layout);
+    let _ = ValueSerDeContext::new(None).deserialize(&fuzz_data.data, &fuzz_data.layout);
 });

--- a/third_party/move/extensions/move-table-extension/src/lib.rs
+++ b/third_party/move/extensions/move-table-extension/src/lib.rs
@@ -708,7 +708,8 @@ fn serialize(
     layout: &MoveTypeLayout,
     val: &Value,
 ) -> PartialVMResult<Vec<u8>> {
-    ValueSerDeContext::new()
+    let max_value_nest_depth = function_value_extension.max_value_nest_depth();
+    ValueSerDeContext::new(max_value_nest_depth)
         .with_func_args_deserialization(function_value_extension)
         .serialize(val, layout)?
         .ok_or_else(|| partial_extension_error("cannot serialize table key or value"))
@@ -719,7 +720,8 @@ fn deserialize(
     bytes: &[u8],
     layout: &MoveTypeLayout,
 ) -> PartialVMResult<Value> {
-    ValueSerDeContext::new()
+    let max_value_nest_depth = function_value_extension.max_value_nest_depth();
+    ValueSerDeContext::new(max_value_nest_depth)
         .with_func_args_deserialization(function_value_extension)
         .deserialize(bytes, layout)
         .ok_or_else(|| partial_extension_error("cannot deserialize table key or value"))

--- a/third_party/move/move-core/types/src/vm_status.rs
+++ b/third_party/move/move-core/types/src/vm_status.rs
@@ -211,7 +211,6 @@ impl VMStatus {
                     | StatusCode::IO_LIMIT_REACHED
                     | StatusCode::STORAGE_LIMIT_REACHED
                     | StatusCode::TOO_MANY_DELAYED_FIELDS
-                    | StatusCode::UNABLE_TO_CAPTURE_DELAYED_FIELDS
                     | StatusCode::VM_MAX_VALUE_DEPTH_REACHED,
                 ..
             }
@@ -221,7 +220,6 @@ impl VMStatus {
                     | StatusCode::IO_LIMIT_REACHED
                     | StatusCode::STORAGE_LIMIT_REACHED
                     | StatusCode::TOO_MANY_DELAYED_FIELDS
-                    | StatusCode::UNABLE_TO_CAPTURE_DELAYED_FIELDS
                     | StatusCode::VM_MAX_VALUE_DEPTH_REACHED,
                 ..
             } => Ok(KeptVMStatus::MiscellaneousError),

--- a/third_party/move/move-core/types/src/vm_status.rs
+++ b/third_party/move/move-core/types/src/vm_status.rs
@@ -210,7 +210,9 @@ impl VMStatus {
                     StatusCode::EXECUTION_LIMIT_REACHED
                     | StatusCode::IO_LIMIT_REACHED
                     | StatusCode::STORAGE_LIMIT_REACHED
-                    | StatusCode::TOO_MANY_DELAYED_FIELDS,
+                    | StatusCode::TOO_MANY_DELAYED_FIELDS
+                    | StatusCode::UNABLE_TO_CAPTURE_DELAYED_FIELDS
+                    | StatusCode::VM_MAX_VALUE_DEPTH_REACHED,
                 ..
             }
             | VMStatus::Error {
@@ -218,7 +220,9 @@ impl VMStatus {
                     StatusCode::EXECUTION_LIMIT_REACHED
                     | StatusCode::IO_LIMIT_REACHED
                     | StatusCode::STORAGE_LIMIT_REACHED
-                    | StatusCode::TOO_MANY_DELAYED_FIELDS,
+                    | StatusCode::TOO_MANY_DELAYED_FIELDS
+                    | StatusCode::UNABLE_TO_CAPTURE_DELAYED_FIELDS
+                    | StatusCode::VM_MAX_VALUE_DEPTH_REACHED,
                 ..
             } => Ok(KeptVMStatus::MiscellaneousError),
 

--- a/third_party/move/move-stdlib/src/natives/bcs.rs
+++ b/third_party/move/move-stdlib/src/natives/bcs.rs
@@ -13,7 +13,7 @@ use move_vm_types::{
     loaded_data::runtime_types::Type,
     natives::function::NativeResult,
     pop_arg,
-    value_serde::ValueSerDeContext,
+    value_serde::{FunctionValueExtension, ValueSerDeContext},
     values::{values_impl::Reference, Value},
 };
 use smallvec::smallvec;
@@ -65,7 +65,8 @@ fn native_to_bytes(
     let val = ref_to_val.read_ref()?;
 
     let function_value_extension = context.function_value_extension();
-    let serialized_value = match ValueSerDeContext::new()
+    let max_value_nest_depth = function_value_extension.max_value_nest_depth();
+    let serialized_value = match ValueSerDeContext::new(max_value_nest_depth)
         .with_legacy_signer()
         .with_func_args_deserialization(&function_value_extension)
         .serialize(&val, &layout)?

--- a/third_party/move/move-vm/runtime/src/config.rs
+++ b/third_party/move/move-vm/runtime/src/config.rs
@@ -3,7 +3,9 @@
 
 use move_binary_format::deserializer::DeserializerConfig;
 use move_bytecode_verifier::VerifierConfig;
-use move_vm_types::loaded_data::runtime_types::TypeBuilder;
+use move_vm_types::{
+    loaded_data::runtime_types::TypeBuilder, values::DEFAULT_MAX_VM_VALUE_NESTED_DEPTH,
+};
 use serde::Serialize;
 
 /// Dynamic config options for the Move VM.
@@ -29,6 +31,7 @@ pub struct VMConfig {
     pub ty_builder: TypeBuilder,
     pub use_call_tree_and_instruction_cache: bool,
     pub enable_lazy_loading: bool,
+    pub enable_depth_checks: bool,
 }
 
 impl Default for VMConfig {
@@ -38,7 +41,7 @@ impl Default for VMConfig {
             deserializer_config: DeserializerConfig::default(),
             paranoid_type_checks: false,
             check_invariant_in_swap_loc: true,
-            max_value_nest_depth: Some(128),
+            max_value_nest_depth: Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH),
             layout_max_size: 256,
             layout_max_depth: 128,
             type_max_cost: 0,
@@ -48,6 +51,7 @@ impl Default for VMConfig {
             ty_builder: TypeBuilder::with_limits(128, 20),
             use_call_tree_and_instruction_cache: true,
             enable_lazy_loading: false,
+            enable_depth_checks: true,
         }
     }
 }

--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -22,7 +22,7 @@ use move_core_types::{
 use move_vm_types::{
     loaded_data::runtime_types::Type,
     resolver::ResourceResolver,
-    value_serde::ValueSerDeContext,
+    value_serde::{FunctionValueExtension, ValueSerDeContext},
     values::{GlobalValue, Value},
 };
 use std::collections::btree_map::{BTreeMap, Entry};
@@ -77,7 +77,8 @@ impl TransactionDataCache {
         let resource_converter =
             |value: Value, layout: MoveTypeLayout, _: bool| -> PartialVMResult<Bytes> {
                 let function_value_extension = FunctionValueExtensionAdapter { module_storage };
-                ValueSerDeContext::new()
+                let max_value_nest_depth = function_value_extension.max_value_nest_depth();
+                ValueSerDeContext::new(max_value_nest_depth)
                     .with_func_args_deserialization(&function_value_extension)
                     .serialize(&value, &layout)?
                     .map(Into::into)
@@ -170,7 +171,8 @@ impl TransactionDataCache {
         let function_value_extension = FunctionValueExtensionAdapter { module_storage };
         let value = match data {
             Some(blob) => {
-                let val = ValueSerDeContext::new()
+                let max_value_nest_depth = function_value_extension.max_value_nest_depth();
+                let val = ValueSerDeContext::new(max_value_nest_depth)
                     .with_func_args_deserialization(&function_value_extension)
                     .with_delayed_fields_serde()
                     .deserialize(&blob, &layout)

--- a/third_party/move/move-vm/runtime/src/move_vm.rs
+++ b/third_party/move/move-vm/runtime/src/move_vm.rs
@@ -20,7 +20,7 @@ use move_vm_types::{
     gas::GasMeter,
     loaded_data::runtime_types::Type,
     resolver::ResourceResolver,
-    value_serde::ValueSerDeContext,
+    value_serde::{FunctionValueExtension, ValueSerDeContext},
     values::{Locals, Reference, VMValueCast, Value},
 };
 use std::borrow::Borrow;
@@ -146,7 +146,8 @@ fn deserialize_arg(
     }
 
     let function_value_extension = module_storage.as_function_value_extension();
-    ValueSerDeContext::new()
+    let max_value_nest_depth = function_value_extension.max_value_nest_depth();
+    ValueSerDeContext::new(max_value_nest_depth)
         .with_func_args_deserialization(&function_value_extension)
         .deserialize(arg.borrow(), &layout)
         .ok_or_else(deserialization_error)
@@ -226,7 +227,8 @@ fn serialize_return_value(
     }
 
     let function_value_extension = module_storage.as_function_value_extension();
-    let bytes = ValueSerDeContext::new()
+    let max_value_nest_depth = function_value_extension.max_value_nest_depth();
+    let bytes = ValueSerDeContext::new(max_value_nest_depth)
         .with_func_args_deserialization(&function_value_extension)
         .serialize(&value, &layout)?
         .ok_or_else(serialization_error)?;

--- a/third_party/move/move-vm/runtime/src/storage/module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/module_storage.rs
@@ -632,4 +632,12 @@ impl FunctionValueExtension for FunctionValueExtensionAdapter<'_> {
             },
         }
     }
+
+    fn max_value_nest_depth(&self) -> Option<u64> {
+        let vm_config = self.module_storage.runtime_environment().vm_config();
+        vm_config
+            .enable_depth_checks
+            .then_some(vm_config.max_value_nest_depth)
+            .flatten()
+    }
 }

--- a/third_party/move/move-vm/types/src/value_serde.rs
+++ b/third_party/move/move-vm/types/src/value_serde.rs
@@ -31,6 +31,9 @@ pub trait FunctionValueExtension {
         &self,
         fun: &dyn AbstractFunction,
     ) -> PartialVMResult<SerializedFunctionData>;
+
+    /// Returns the maximum allowed nesting depth of a VM value.
+    fn max_value_nest_depth(&self) -> Option<u64>;
 }
 
 /// An extension to (de)serializer to lookup information about delayed fields.
@@ -100,16 +103,18 @@ pub struct ValueSerDeContext<'a> {
     pub(crate) function_extension: Option<FunctionValueExtensionWithContext<'a>>,
     pub(crate) delayed_fields_extension: Option<DelayedFieldsExtension<'a>>,
     pub(crate) legacy_signer: bool,
+    /// Maximum allowed depth of a VM value. Enforced by serializer.
+    pub(crate) max_value_nested_depth: Option<u64>,
 }
 
 impl<'a> ValueSerDeContext<'a> {
     /// Default (de)serializer that disallows delayed fields.
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    pub fn new(max_value_nested_depth: Option<u64>) -> Self {
         Self {
             function_extension: None,
             delayed_fields_extension: None,
             legacy_signer: false,
+            max_value_nested_depth,
         }
     }
 
@@ -148,7 +153,18 @@ impl<'a> ValueSerDeContext<'a> {
             function_extension: self.function_extension.clone(),
             delayed_fields_extension: None,
             legacy_signer: self.legacy_signer,
+            max_value_nested_depth: self.max_value_nested_depth,
         }
+    }
+
+    pub(crate) fn check_depth(&self, depth: u64) -> PartialVMResult<()> {
+        if self
+            .max_value_nested_depth
+            .map_or(false, |max_depth| depth > max_depth)
+        {
+            return Err(PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED));
+        }
+        Ok(())
     }
 
     /// Custom (de)serializer such that:
@@ -189,6 +205,7 @@ impl<'a> ValueSerDeContext<'a> {
             ctx: &self,
             layout,
             value: &value.0,
+            depth: 1,
         };
 
         match bcs::to_bytes(&value).ok() {
@@ -229,6 +246,7 @@ impl<'a> ValueSerDeContext<'a> {
             ctx: &self,
             layout,
             value: &value.0,
+            depth: 1,
         };
         bcs::serialized_size(&value).map_err(|e| {
             PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR).with_message(format!(

--- a/third_party/move/move-vm/types/src/values/function_values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/function_values_impl.rs
@@ -130,6 +130,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, (), Closure> {
                 ctx: self.ctx,
                 layout: &layout,
                 value,
+                depth: self.depth + 1,
             })?
         }
         seq.end()

--- a/third_party/move/move-vm/types/src/values/mod.rs
+++ b/third_party/move/move-vm/types/src/values/mod.rs
@@ -10,6 +10,8 @@ mod value_tests;
 
 #[cfg(test)]
 mod serialization_tests;
+#[cfg(test)]
+mod value_depth_tests;
 #[cfg(all(test, feature = "fuzzing"))]
 mod value_prop_tests;
 

--- a/third_party/move/move-vm/types/src/values/serialization_tests.rs
+++ b/third_party/move/move-vm/types/src/values/serialization_tests.rs
@@ -99,11 +99,11 @@ mod tests {
             )),
         ];
         for value in good_values {
-            let blob = ValueSerDeContext::new()
+            let blob = ValueSerDeContext::new(None)
                 .serialize(&value, &layout)
                 .unwrap()
                 .expect("serialization succeeds");
-            let de_value = ValueSerDeContext::new()
+            let de_value = ValueSerDeContext::new(None)
                 .deserialize(&blob, &layout)
                 .expect("deserialization succeeds");
             assert!(
@@ -113,7 +113,7 @@ mod tests {
         }
         let bad_tag_value = Value::struct_(Struct::pack_variant(3, [Value::u64(42)]));
         assert!(
-            ValueSerDeContext::new()
+            ValueSerDeContext::new(None)
                 .serialize(&bad_tag_value, &layout)
                 .unwrap()
                 .is_none(),
@@ -121,7 +121,7 @@ mod tests {
         );
         let bad_struct_value = Value::struct_(Struct::pack([Value::u64(42)]));
         assert!(
-            ValueSerDeContext::new()
+            ValueSerDeContext::new(None)
                 .serialize(&bad_struct_value, &layout)
                 .unwrap()
                 .is_none(),
@@ -184,7 +184,7 @@ mod tests {
             RustEnum::BoolNumber(true, 13),
         ];
         for (move_value, rust_value) in move_values.into_iter().zip(rust_values) {
-            let from_move = ValueSerDeContext::new()
+            let from_move = ValueSerDeContext::new(None)
                 .serialize(&move_value, &layout)
                 .unwrap()
                 .expect("from move succeeds");
@@ -192,7 +192,7 @@ mod tests {
             assert_eq!(to_rust, rust_value);
 
             let from_rust = bcs::to_bytes(&rust_value).expect("from rust succeeds");
-            let to_move = ValueSerDeContext::new()
+            let to_move = ValueSerDeContext::new(None)
                 .deserialize(&from_rust, &layout)
                 .expect("to move succeeds");
             assert!(
@@ -407,11 +407,11 @@ mod tests {
             .expect_create_from_serialization_data()
             .returning(move |data| Ok(Box::new(MockAbstractFunction::new_from_data(data))));
         let value = Value::closure(Box::new(fun), captured);
-        let blob = assert_ok!(ValueSerDeContext::new()
+        let blob = assert_ok!(ValueSerDeContext::new(None)
             .with_func_args_deserialization(&ext_mock)
             .serialize(&value, &fun_layout))
         .expect("serialization result not None");
-        let de_value = ValueSerDeContext::new()
+        let de_value = ValueSerDeContext::new(None)
             .with_func_args_deserialization(&ext_mock)
             .deserialize_or_err(&blob, &fun_layout);
         (value, de_value)
@@ -550,11 +550,11 @@ mod tests {
             ),
         ];
         for (value, layout) in good_values_layouts_sizes {
-            let bytes = assert_some!(assert_ok!(ValueSerDeContext::new()
+            let bytes = assert_some!(assert_ok!(ValueSerDeContext::new(None)
                 .with_delayed_fields_serde()
                 .serialize(&value, &layout)));
 
-            let size = assert_ok!(ValueSerDeContext::new()
+            let size = assert_ok!(ValueSerDeContext::new(None)
                 .with_delayed_fields_serde()
                 .serialized_size(&value, &layout));
             assert_eq!(size, bytes.len());
@@ -570,7 +570,7 @@ mod tests {
             (Value::u64(12), Native(Aggregator, Box::new(U64))),
         ];
         for (value, layout) in bad_values_layouts_sizes {
-            assert_err!(ValueSerDeContext::new()
+            assert_err!(ValueSerDeContext::new(None)
                 .with_delayed_fields_serde()
                 .serialized_size(&value, &layout));
         }
@@ -585,13 +585,13 @@ mod tests {
         let bytes = move_value.simple_serialize().unwrap();
 
         let vm_value = Value::master_signer(AccountAddress::ZERO);
-        let vm_bytes = ValueSerDeContext::new()
+        let vm_bytes = ValueSerDeContext::new(None)
             .serialize(&vm_value, &MoveTypeLayout::Signer)
             .unwrap()
             .unwrap();
 
         // VM Value Roundtrip
-        assert!(ValueSerDeContext::new()
+        assert!(ValueSerDeContext::new(None)
             .deserialize(&vm_bytes, &MoveTypeLayout::Signer)
             .unwrap()
             .equals(&vm_value)
@@ -605,20 +605,20 @@ mod tests {
 
         // Permissioned Signer Roundtrip
         let vm_value = Value::permissioned_signer(AccountAddress::ZERO, AccountAddress::ONE);
-        let vm_bytes = ValueSerDeContext::new()
+        let vm_bytes = ValueSerDeContext::new(None)
             .serialize(&vm_value, &MoveTypeLayout::Signer)
             .unwrap()
             .unwrap();
 
         // VM Value Roundtrip
-        assert!(ValueSerDeContext::new()
+        assert!(ValueSerDeContext::new(None)
             .deserialize(&vm_bytes, &MoveTypeLayout::Signer)
             .unwrap()
             .equals(&vm_value)
             .unwrap());
 
         // Cannot serialize permissioned signer into bytes with legacy signer
-        assert!(ValueSerDeContext::new()
+        assert!(ValueSerDeContext::new(None)
             .with_legacy_signer()
             .serialize(&vm_value, &MoveTypeLayout::Signer)
             .unwrap()
@@ -631,14 +631,14 @@ mod tests {
         let bytes = move_value.simple_serialize().unwrap();
 
         let vm_value = Value::master_signer(AccountAddress::ZERO);
-        let vm_bytes = ValueSerDeContext::new()
+        let vm_bytes = ValueSerDeContext::new(None)
             .with_legacy_signer()
             .serialize(&vm_value, &MoveTypeLayout::Signer)
             .unwrap()
             .unwrap();
 
         // VM Value Roundtrip
-        assert!(ValueSerDeContext::new()
+        assert!(ValueSerDeContext::new(None)
             .with_legacy_signer()
             .deserialize(&vm_bytes, &MoveTypeLayout::Signer)
             .is_none());

--- a/third_party/move/move-vm/types/src/values/value_depth_tests.rs
+++ b/third_party/move/move-vm/types/src/values/value_depth_tests.rs
@@ -1,0 +1,243 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    value_serde::{MockFunctionValueExtension, ValueSerDeContext},
+    values::{AbstractFunction, GlobalValue, SerializedFunctionData, Struct, StructRef, Value},
+};
+use better_any::{Tid, TidAble, TidExt};
+use claims::{assert_err, assert_none, assert_ok, assert_some};
+use move_binary_format::errors::PartialVMResult;
+use move_core_types::{
+    account_address::AccountAddress,
+    function::{ClosureMask, FUNCTION_DATA_SERIALIZATION_FORMAT_V1},
+    ident_str,
+    language_storage::ModuleId,
+    value::{MoveStructLayout, MoveTypeLayout},
+    vm_status::StatusCode,
+};
+use std::{cmp::Ordering, fmt::Debug};
+
+#[derive(Clone, Tid)]
+struct MockFunction {
+    data: SerializedFunctionData,
+}
+
+impl MockFunction {
+    fn closure(
+        mask: ClosureMask,
+        captured: impl IntoIterator<Item = Value>,
+        captured_layouts: impl IntoIterator<Item = MoveTypeLayout>,
+    ) -> Value {
+        let data = SerializedFunctionData {
+            format_version: FUNCTION_DATA_SERIALIZATION_FORMAT_V1,
+            module_id: ModuleId::new(AccountAddress::ONE, ident_str!("mock").to_owned()),
+            fun_id: ident_str!("mock").to_owned(),
+            ty_args: vec![],
+            mask,
+            captured_layouts: captured_layouts.into_iter().collect(),
+        };
+        Value::closure(Box::new(Self { data }), captured)
+    }
+}
+
+impl AbstractFunction for MockFunction {
+    fn closure_mask(&self) -> ClosureMask {
+        self.data.mask
+    }
+
+    fn cmp_dyn(&self, _other: &dyn AbstractFunction) -> PartialVMResult<Ordering> {
+        Ok(Ordering::Equal)
+    }
+
+    fn clone_dyn(&self) -> PartialVMResult<Box<dyn AbstractFunction>> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn to_canonical_string(&self) -> String {
+        "0x1::mock::mock".to_string()
+    }
+}
+
+#[test]
+fn test_equals() {
+    test_binop_with_max_depth(|l, r, max_depth| l.equals_with_depth(r, max_depth));
+}
+
+#[test]
+fn test_compare() {
+    test_binop_with_max_depth(|l, r, max_depth| l.compare_with_depth(r, max_depth));
+}
+
+#[test]
+fn test_copy_value() {
+    test_unop_with_max_depth(|v, max_depth| v.copy_value_with_depth(max_depth));
+
+    // Special-case: reference clone Rcs, so their depth can be larger.
+    let v = assert_ok!(GlobalValue::cached(Value::struct_(Struct::pack(vec![
+        Value::u8(0)
+    ]))));
+    let v_ref = assert_ok!(v.borrow_global());
+    assert_ok!(v_ref.copy_value_with_depth(3));
+    assert_ok!(v_ref.copy_value_with_depth(2));
+    assert_ok!(v_ref.copy_value_with_depth(1));
+}
+
+#[test]
+fn test_read_ref() {
+    let v = assert_ok!(GlobalValue::cached(Value::struct_(Struct::pack(vec![
+        Value::u8(0)
+    ]))));
+    let v_ref = assert_ok!(assert_ok!(v.borrow_global()).value_as::<StructRef>());
+
+    // Note: reading a reference will clone the value, so here it is a clone of a struct with 1
+    // field of depth 2.
+    assert_ok!(v_ref.read_ref_with_depth(2));
+
+    let v_ref = assert_ok!(assert_ok!(v.borrow_global()).value_as::<StructRef>());
+    let err = assert_err!(v_ref.read_ref_with_depth(1));
+    assert_eq!(err.major_status(), StatusCode::VM_MAX_VALUE_DEPTH_REACHED);
+}
+
+#[test]
+fn test_serialization() {
+    use MoveStructLayout::*;
+    use MoveTypeLayout as L;
+
+    let mut extension = MockFunctionValueExtension::new();
+    extension
+        .expect_get_serialization_data()
+        .returning(move |af| Ok(af.downcast_ref::<MockFunction>().unwrap().data.clone()));
+
+    let depth_1_ok = [
+        (Value::u64(0), L::U64),
+        (Value::vector_u8(vec![0, 1]), L::Vector(Box::new(L::U8))),
+        (
+            MockFunction::closure(ClosureMask::empty(), vec![], vec![]),
+            L::Function,
+        ),
+    ];
+    let depth_2_ok = [
+        (
+            Value::struct_(Struct::pack(vec![Value::u16(0)])),
+            L::Struct(Runtime(vec![L::U16])),
+        ),
+        (
+            Value::vector_for_testing_only(vec![Value::vector_u8(vec![0, 1])]),
+            L::Vector(Box::new(L::Vector(Box::new(L::U8)))),
+        ),
+        (
+            // Serialize first variant, so the depth is 2.
+            Value::struct_(Struct::pack(vec![Value::u16(0), Value::bool(true)])),
+            L::Struct(RuntimeVariants(vec![vec![L::Bool], vec![L::Vector(
+                Box::new(L::Vector(Box::new(L::U8))),
+            )]])),
+        ),
+        (
+            MockFunction::closure(ClosureMask::empty(), vec![Value::u16(0)], vec![L::U16]),
+            L::Function,
+        ),
+    ];
+    let depth_3_ok = [(
+        // Serialize second variant, so the depth is 3.
+        Value::struct_(Struct::pack(vec![
+            Value::u16(1),
+            Value::vector_for_testing_only(vec![Value::vector_u8(vec![1, 2])]),
+        ])),
+        L::Struct(RuntimeVariants(vec![vec![L::Bool], vec![L::Vector(
+            Box::new(L::Vector(Box::new(L::U8))),
+        )]])),
+    )];
+
+    let ctx = |max_depth: u64| {
+        ValueSerDeContext::new(Some(max_depth)).with_func_args_deserialization(&extension)
+    };
+
+    for (v, l) in &depth_1_ok {
+        assert_some!(assert_ok!(ctx(1).serialize(v, l)));
+        assert_ok!(ctx(1).serialized_size(v, l));
+    }
+
+    for (v, l) in &depth_2_ok {
+        assert_some!(assert_ok!(ctx(2).serialize(v, l)));
+        assert_ok!(ctx(2).serialized_size(v, l));
+        assert_none!(assert_ok!(ctx(1).serialize(v, l)));
+        assert_err!(ctx(1).serialized_size(v, l));
+    }
+
+    for (v, l) in &depth_3_ok {
+        assert_some!(assert_ok!(ctx(3).serialize(v, l)));
+        assert_ok!(ctx(3).serialized_size(v, l));
+        assert_none!(assert_ok!(ctx(2).serialize(v, l)));
+        assert_err!(ctx(2).serialized_size(v, l));
+        assert_none!(assert_ok!(ctx(1).serialize(v, l)));
+        assert_err!(ctx(1).serialized_size(v, l));
+    }
+}
+
+fn test_binop_with_max_depth<F, T>(f: F)
+where
+    T: Debug,
+    F: Fn(&Value, &Value, u64) -> PartialVMResult<T>,
+{
+    let v = Value::u8(0);
+    assert_ok!(f(&v, &v, 1));
+
+    let v = Value::vector_u8(vec![0, 1]);
+    assert_ok!(f(&v, &v, 1));
+
+    let v = Value::vector_for_testing_only(vec![Value::vector_u8(vec![0, 1])]);
+    let err = assert_err!(f(&v, &v, 1));
+    assert_eq!(err.major_status(), StatusCode::VM_MAX_VALUE_DEPTH_REACHED);
+
+    let v = Value::struct_(Struct::pack(vec![Value::u8(0)]));
+    let err = assert_err!(f(&v, &v, 1));
+    assert_eq!(err.major_status(), StatusCode::VM_MAX_VALUE_DEPTH_REACHED);
+
+    let v = MockFunction::closure(ClosureMask::empty(), vec![], vec![]);
+    assert_ok!(f(&v, &v, 1));
+
+    let v = MockFunction::closure(ClosureMask::new_for_leading(1), vec![Value::u8(0)], vec![
+        MoveTypeLayout::U8,
+    ]);
+    let err = assert_err!(f(&v, &v, 1));
+    assert_eq!(err.major_status(), StatusCode::VM_MAX_VALUE_DEPTH_REACHED);
+
+    // Create a reference to struct with 1 field (3 nodes).
+    let v = assert_ok!(GlobalValue::cached(Value::struct_(Struct::pack(vec![
+        Value::u8(0)
+    ]))));
+    let v_ref = assert_ok!(v.borrow_global());
+    assert_ok!(f(&v_ref, &v_ref, 3));
+    let err = assert_err!(f(&v_ref, &v_ref, 2));
+    assert_eq!(err.major_status(), StatusCode::VM_MAX_VALUE_DEPTH_REACHED);
+}
+
+fn test_unop_with_max_depth<F, T>(f: F)
+where
+    T: Debug,
+    F: Fn(&Value, u64) -> PartialVMResult<T>,
+{
+    let v = Value::u8(0);
+    assert_ok!(f(&v, 1));
+
+    let v = Value::vector_u8(vec![0, 1]);
+    assert_ok!(f(&v, 1));
+
+    let v = Value::vector_for_testing_only(vec![Value::vector_u8(vec![0, 1])]);
+    let err = assert_err!(f(&v, 1));
+    assert_eq!(err.major_status(), StatusCode::VM_MAX_VALUE_DEPTH_REACHED);
+
+    let v = Value::struct_(Struct::pack(vec![Value::u8(0)]));
+    let err = assert_err!(f(&v, 1));
+    assert_eq!(err.major_status(), StatusCode::VM_MAX_VALUE_DEPTH_REACHED);
+
+    let v = MockFunction::closure(ClosureMask::empty(), vec![], vec![]);
+    assert_ok!(f(&v, 1));
+
+    let v = MockFunction::closure(ClosureMask::new_for_leading(1), vec![Value::u8(0)], vec![
+        MoveTypeLayout::U8,
+    ]);
+    let err = assert_err!(f(&v, 1));
+    assert_eq!(err.major_status(), StatusCode::VM_MAX_VALUE_DEPTH_REACHED);
+}

--- a/third_party/move/move-vm/types/src/values/value_prop_tests.rs
+++ b/third_party/move/move-vm/types/src/values/value_prop_tests.rs
@@ -9,8 +9,8 @@ use proptest::prelude::*;
 proptest! {
     #[test]
     fn serializer_round_trip((layout, value) in layout_and_value_strategy()) {
-        let blob = ValueSerDeContext::new().serialize(&value, &layout).unwrap().expect("must serialize");
-        let value_deserialized = ValueSerDeContext::new().deserialize(&blob, &layout).expect("must deserialize");
+        let blob = ValueSerDeContext::new(None).serialize(&value, &layout).unwrap().expect("must serialize");
+        let value_deserialized = ValueSerDeContext::new(None).deserialize(&blob, &layout).expect("must deserialize");
         assert!(value.equals(&value_deserialized).unwrap());
 
         let move_value = value.as_move_value(&layout);

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -40,6 +40,15 @@ use std::{
     rc::Rc,
 };
 
+/// Values can be recursive, and so it is important that we do not use recursive algorithms over
+/// deeply nested values as it can cause stack overflow. Since it is not always possible to avoid
+/// recursion, we opt for a reasonable limit on VM value depth. It is defined in Move VM config,
+/// but since it is difficult to propagate config context everywhere, we use this constant.
+///
+/// IMPORTANT: When changing this constant, make sure it is in-sync with one in VM config (it is
+/// used there now).
+pub const DEFAULT_MAX_VM_VALUE_NESTED_DEPTH: u64 = 128;
+
 /***************************************************************************************
  *
  * Internal Types
@@ -395,9 +404,10 @@ impl ValueImpl {
  *
  **************************************************************************************/
 impl ValueImpl {
-    fn copy_value(&self) -> PartialVMResult<Self> {
+    fn copy_value(&self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<Self> {
         use ValueImpl::*;
 
+        check_depth(depth, max_depth)?;
         Ok(match self {
             Invalid => Invalid,
 
@@ -410,12 +420,15 @@ impl ValueImpl {
             Bool(x) => Bool(*x),
             Address(x) => Address(*x),
 
-            ContainerRef(r) => ContainerRef(r.copy_value()),
-            IndexedRef(r) => IndexedRef(r.copy_value()),
+            // Note: refs copy only clones Rc, so no need to increment depth.
+            ContainerRef(r) => ContainerRef(r.copy_by_ref()),
+            IndexedRef(r) => IndexedRef(r.copy_by_ref()),
 
-            // When cloning a container, we need to make sure we make a deep
-            // copy of the data instead of a shallow copy of the Rc.
-            Container(c) => Container(c.copy_value()?),
+            // When cloning a container, we need to make sure we make a deep copy of the data
+            // instead of a shallow copy of the Rc. Note that we do not increment the depth here
+            // because we have done it when entering this value. Inside the container, depth will
+            // be further incremented for nested values.
+            Container(c) => Container(c.copy_value(depth, max_depth)?),
 
             // Native values can be copied because this is how read_ref operates,
             // and copying is an internal API.
@@ -424,7 +437,7 @@ impl ValueImpl {
             ClosureValue(Closure(fun, captured)) => {
                 let captured = captured
                     .iter()
-                    .map(|v| v.copy_value())
+                    .map(|v| v.copy_value(depth + 1, max_depth))
                     .collect::<PartialVMResult<_>>()?;
                 ClosureValue(Closure(fun.clone_dyn()?, captured))
             },
@@ -433,12 +446,12 @@ impl ValueImpl {
 }
 
 impl Container {
-    fn copy_value(&self) -> PartialVMResult<Self> {
+    fn copy_value(&self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<Self> {
         let copy_rc_ref_vec_val = |r: &Rc<RefCell<Vec<ValueImpl>>>| {
             Ok(Rc::new(RefCell::new(
                 r.borrow()
                     .iter()
-                    .map(|v| v.copy_value())
+                    .map(|v| v.copy_value(depth + 1, max_depth))
                     .collect::<PartialVMResult<_>>()?,
             )))
         };
@@ -485,16 +498,16 @@ impl Container {
 }
 
 impl IndexedRef {
-    fn copy_value(&self) -> Self {
+    fn copy_by_ref(&self) -> Self {
         Self {
             idx: self.idx,
-            container_ref: self.container_ref.copy_value(),
+            container_ref: self.container_ref.copy_by_ref(),
         }
     }
 }
 
 impl ContainerRef {
-    fn copy_value(&self) -> Self {
+    fn copy_by_ref(&self) -> Self {
         match self {
             Self::Local(container) => Self::Local(container.copy_by_ref()),
             Self::Global { status, container } => Self::Global {
@@ -502,6 +515,13 @@ impl ContainerRef {
                 container: container.copy_by_ref(),
             },
         }
+    }
+}
+
+#[cfg(test)]
+impl Value {
+    pub fn copy_value_with_depth(&self, max_depth: u64) -> PartialVMResult<Self> {
+        Ok(Self(self.0.copy_value(1, Some(max_depth))?))
     }
 }
 
@@ -523,9 +543,10 @@ impl ContainerRef {
  **************************************************************************************/
 
 impl ValueImpl {
-    fn equals(&self, other: &Self) -> PartialVMResult<bool> {
+    fn equals(&self, other: &Self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<bool> {
         use ValueImpl::*;
 
+        check_depth(depth, max_depth)?;
         let res = match (self, other) {
             (U8(l), U8(r)) => l == r,
             (U16(l), U16(r)) => l == r,
@@ -536,10 +557,11 @@ impl ValueImpl {
             (Bool(l), Bool(r)) => l == r,
             (Address(l), Address(r)) => l == r,
 
-            (Container(l), Container(r)) => l.equals(r)?,
+            (Container(l), Container(r)) => l.equals(r, depth, max_depth)?,
 
-            (ContainerRef(l), ContainerRef(r)) => l.equals(r)?,
-            (IndexedRef(l), IndexedRef(r)) => l.equals(r)?,
+            // We count references as +1 in nesting, hence increasing the depth.
+            (ContainerRef(l), ContainerRef(r)) => l.equals(r, depth + 1, max_depth)?,
+            (IndexedRef(l), IndexedRef(r)) => l.equals(r, depth + 1, max_depth)?,
 
             // Disallow equality for delayed values. The rationale behind this
             // semantics is that identifiers might not be deterministic, and
@@ -556,7 +578,7 @@ impl ValueImpl {
                     && captured1.len() == captured2.len()
                 {
                     for (v1, v2) in captured1.iter().zip(captured2.iter()) {
-                        if !v1.equals(v2)? {
+                        if !v1.equals(v2, depth + 1, max_depth)? {
                             return Ok(false);
                         }
                     }
@@ -592,9 +614,15 @@ impl ValueImpl {
         Ok(res)
     }
 
-    fn compare(&self, other: &Self) -> PartialVMResult<Ordering> {
+    fn compare(
+        &self,
+        other: &Self,
+        depth: u64,
+        max_depth: Option<u64>,
+    ) -> PartialVMResult<Ordering> {
         use ValueImpl::*;
 
+        check_depth(depth, max_depth)?;
         let res = match (self, other) {
             (U8(l), U8(r)) => l.cmp(r),
             (U16(l), U16(r)) => l.cmp(r),
@@ -605,10 +633,11 @@ impl ValueImpl {
             (Bool(l), Bool(r)) => l.cmp(r),
             (Address(l), Address(r)) => l.cmp(r),
 
-            (Container(l), Container(r)) => l.compare(r)?,
+            (Container(l), Container(r)) => l.compare(r, depth, max_depth)?,
 
-            (ContainerRef(l), ContainerRef(r)) => l.compare(r)?,
-            (IndexedRef(l), IndexedRef(r)) => l.compare(r)?,
+            // We count references as +1 in nesting, hence increasing the depth.
+            (ContainerRef(l), ContainerRef(r)) => l.compare(r, depth + 1, max_depth)?,
+            (IndexedRef(l), IndexedRef(r)) => l.compare(r, depth + 1, max_depth)?,
 
             // Disallow comparison for delayed values.
             // (see `ValueImpl::equals` above for details on reasoning behind it)
@@ -621,7 +650,7 @@ impl ValueImpl {
                 let o = fun1.cmp_dyn(fun2.as_ref())?;
                 if o == Ordering::Equal {
                     for (v1, v2) in captured1.iter().zip(captured2.iter()) {
-                        let o = v1.compare(v2)?;
+                        let o = v1.compare(v2, depth + 1, max_depth)?;
                         if o != Ordering::Equal {
                             return Ok(o);
                         }
@@ -660,7 +689,7 @@ impl ValueImpl {
 }
 
 impl Container {
-    fn equals(&self, other: &Self) -> PartialVMResult<bool> {
+    fn equals(&self, other: &Self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<bool> {
         use Container::*;
 
         let res = match (self, other) {
@@ -672,7 +701,7 @@ impl Container {
                     return Ok(false);
                 }
                 for (v1, v2) in l.iter().zip(r.iter()) {
-                    if !v1.equals(v2)? {
+                    if !v1.equals(v2, depth + 1, max_depth)? {
                         return Ok(false);
                     }
                 }
@@ -710,7 +739,12 @@ impl Container {
         Ok(res)
     }
 
-    fn compare(&self, other: &Self) -> PartialVMResult<Ordering> {
+    fn compare(
+        &self,
+        other: &Self,
+        depth: u64,
+        max_depth: Option<u64>,
+    ) -> PartialVMResult<Ordering> {
         use Container::*;
 
         let res = match (self, other) {
@@ -719,7 +753,7 @@ impl Container {
                 let r = &r.borrow();
 
                 for (v1, v2) in l.iter().zip(r.iter()) {
-                    let value_cmp = v1.compare(v2)?;
+                    let value_cmp = v1.compare(v2, depth + 1, max_depth)?;
                     if value_cmp.is_ne() {
                         return Ok(value_cmp);
                     }
@@ -761,19 +795,30 @@ impl Container {
 }
 
 impl ContainerRef {
-    fn equals(&self, other: &Self) -> PartialVMResult<bool> {
-        self.container().equals(other.container())
+    fn equals(&self, other: &Self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<bool> {
+        // Note: the depth passed in accounts for the container.
+        check_depth(depth, max_depth)?;
+        self.container().equals(other.container(), depth, max_depth)
     }
 
-    fn compare(&self, other: &Self) -> PartialVMResult<Ordering> {
-        self.container().compare(other.container())
+    fn compare(
+        &self,
+        other: &Self,
+        depth: u64,
+        max_depth: Option<u64>,
+    ) -> PartialVMResult<Ordering> {
+        // Note: the depth passed in accounts for the container.
+        check_depth(depth, max_depth)?;
+        self.container()
+            .compare(other.container(), depth, max_depth)
     }
 }
 
 impl IndexedRef {
-    fn equals(&self, other: &Self) -> PartialVMResult<bool> {
+    fn equals(&self, other: &Self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<bool> {
         use Container::*;
 
+        check_depth(depth, max_depth)?;
         let res = match (
             self.container_ref.container(),
             other.container_ref.container(),
@@ -787,7 +832,9 @@ impl IndexedRef {
             | (Struct(r1), Locals(r2))
             | (Locals(r1), Vec(r2))
             | (Locals(r1), Struct(r2))
-            | (Locals(r1), Locals(r2)) => r1.borrow()[self.idx].equals(&r2.borrow()[other.idx])?,
+            | (Locals(r1), Locals(r2)) => {
+                r1.borrow()[self.idx].equals(&r2.borrow()[other.idx], depth + 1, max_depth)?
+            },
 
             (VecU8(r1), VecU8(r2)) => r1.borrow()[self.idx] == r2.borrow()[other.idx],
             (VecU16(r1), VecU16(r2)) => r1.borrow()[self.idx] == r2.borrow()[other.idx],
@@ -872,7 +919,12 @@ impl IndexedRef {
         Ok(res)
     }
 
-    fn compare(&self, other: &Self) -> PartialVMResult<Ordering> {
+    fn compare(
+        &self,
+        other: &Self,
+        depth: u64,
+        max_depth: Option<u64>,
+    ) -> PartialVMResult<Ordering> {
         use Container::*;
 
         let res = match (
@@ -888,7 +940,9 @@ impl IndexedRef {
             | (Struct(r1), Locals(r2))
             | (Locals(r1), Vec(r2))
             | (Locals(r1), Struct(r2))
-            | (Locals(r1), Locals(r2)) => r1.borrow()[self.idx].compare(&r2.borrow()[other.idx])?,
+            | (Locals(r1), Locals(r2)) => {
+                r1.borrow()[self.idx].compare(&r2.borrow()[other.idx], depth + 1, max_depth)?
+            },
 
             (VecU8(r1), VecU8(r2)) => r1.borrow()[self.idx].cmp(&r2.borrow()[other.idx]),
             (VecU16(r1), VecU16(r2)) => r1.borrow()[self.idx].cmp(&r2.borrow()[other.idx]),
@@ -976,11 +1030,25 @@ impl IndexedRef {
 
 impl Value {
     pub fn equals(&self, other: &Self) -> PartialVMResult<bool> {
-        self.0.equals(&other.0)
+        self.0
+            .equals(&other.0, 1, Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH))
     }
 
     pub fn compare(&self, other: &Self) -> PartialVMResult<Ordering> {
-        self.0.compare(&other.0)
+        self.0
+            .compare(&other.0, 1, Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH))
+    }
+
+    // Test-only API to test depth checks.
+    #[cfg(test)]
+    pub fn equals_with_depth(&self, other: &Self, max_depth: u64) -> PartialVMResult<bool> {
+        self.0.equals(&other.0, 1, Some(max_depth))
+    }
+
+    // Test-only API to test depth checks.
+    #[cfg(test)]
+    pub fn compare_with_depth(&self, other: &Self, max_depth: u64) -> PartialVMResult<Ordering> {
+        self.0.compare(&other.0, 1, Some(max_depth))
     }
 }
 
@@ -993,18 +1061,20 @@ impl Value {
  **************************************************************************************/
 
 impl ContainerRef {
-    fn read_ref(self) -> PartialVMResult<Value> {
-        Ok(Value(ValueImpl::Container(self.container().copy_value()?)))
+    fn read_ref(self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<Value> {
+        Ok(Value(ValueImpl::Container(
+            self.container().copy_value(depth, max_depth)?,
+        )))
     }
 }
 
 impl IndexedRef {
-    fn read_ref(self) -> PartialVMResult<Value> {
+    fn read_ref(self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<Value> {
         use Container::*;
 
         let res = match self.container_ref.container() {
-            Vec(r) => r.borrow()[self.idx].copy_value()?,
-            Struct(r) => r.borrow()[self.idx].copy_value()?,
+            Vec(r) => r.borrow()[self.idx].copy_value(depth + 1, max_depth)?,
+            Struct(r) => r.borrow()[self.idx].copy_value(depth + 1, max_depth)?,
 
             VecU8(r) => ValueImpl::U8(r.borrow()[self.idx]),
             VecU16(r) => ValueImpl::U16(r.borrow()[self.idx]),
@@ -1015,7 +1085,7 @@ impl IndexedRef {
             VecBool(r) => ValueImpl::Bool(r.borrow()[self.idx]),
             VecAddress(r) => ValueImpl::Address(r.borrow()[self.idx]),
 
-            Locals(r) => r.borrow()[self.idx].copy_value()?,
+            Locals(r) => r.borrow()[self.idx].copy_value(depth + 1, max_depth)?,
         };
 
         Ok(Value(res))
@@ -1023,23 +1093,33 @@ impl IndexedRef {
 }
 
 impl ReferenceImpl {
-    fn read_ref(self) -> PartialVMResult<Value> {
+    fn read_ref(self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<Value> {
         match self {
-            Self::ContainerRef(r) => r.read_ref(),
-            Self::IndexedRef(r) => r.read_ref(),
+            Self::ContainerRef(r) => r.read_ref(depth, max_depth),
+            Self::IndexedRef(r) => r.read_ref(depth, max_depth),
         }
     }
 }
 
 impl StructRef {
     pub fn read_ref(self) -> PartialVMResult<Value> {
-        self.0.read_ref()
+        self.0.read_ref(1, Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH))
+    }
+
+    #[cfg(test)]
+    pub fn read_ref_with_depth(self, max_depth: u64) -> PartialVMResult<Value> {
+        self.0.read_ref(1, Some(max_depth))
     }
 }
 
 impl Reference {
     pub fn read_ref(self) -> PartialVMResult<Value> {
-        self.0.read_ref()
+        self.0.read_ref(1, Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH))
+    }
+
+    #[cfg(test)]
+    pub fn read_ref_with_depth(self, max_depth: u64) -> PartialVMResult<Value> {
+        self.0.read_ref(1, Some(max_depth))
     }
 }
 
@@ -1459,7 +1539,7 @@ impl ContainerRef {
                     | ValueImpl::ClosureValue(_)
                     | ValueImpl::DelayedFieldID { .. } => ValueImpl::IndexedRef(IndexedRef {
                         idx,
-                        container_ref: self.copy_value(),
+                        container_ref: self.copy_by_ref(),
                     }),
 
                     ValueImpl::ContainerRef(_) | ValueImpl::Invalid | ValueImpl::IndexedRef(_) => {
@@ -1480,7 +1560,7 @@ impl ContainerRef {
             | Container::VecAddress(_)
             | Container::VecBool(_) => ValueImpl::IndexedRef(IndexedRef {
                 idx,
-                container_ref: self.copy_value(),
+                container_ref: self.copy_by_ref(),
             }),
         })
     }
@@ -1618,13 +1698,23 @@ impl Locals {
     }
 
     pub fn copy_loc(&self, idx: usize) -> PartialVMResult<Value> {
+        self.copy_loc_impl(idx, Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH))
+    }
+
+    // Test-only API to test depth checks.
+    #[cfg(test)]
+    pub fn copy_loc_with_depth(&self, idx: usize, max_depth: u64) -> PartialVMResult<Value> {
+        self.copy_loc_impl(idx, Some(max_depth))
+    }
+
+    fn copy_loc_impl(&self, idx: usize, max_depth: Option<u64>) -> PartialVMResult<Value> {
         let v = self.0.borrow();
         match v.get(idx) {
             Some(ValueImpl::Invalid) => Err(PartialVMError::new(
                 StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
             )
             .with_message(format!("cannot copy invalid value at index {}", idx))),
-            Some(v) => Ok(Value(v.copy_value()?)),
+            Some(v) => Ok(Value(v.copy_value(1, max_depth)?)),
             None => Err(
                 PartialVMError::new(StatusCode::VERIFIER_INVARIANT_VIOLATION).with_message(
                     format!("local index out of bounds: got {}, len: {}", idx, v.len()),
@@ -3736,6 +3826,7 @@ pub(crate) struct SerializationReadyValue<'c, 'l, 'v, L, V> {
     pub(crate) layout: &'l L,
     // Value to serialize.
     pub(crate) value: &'v V,
+    pub(crate) depth: u64,
 }
 
 fn invariant_violation<S: serde::Serializer>(message: String) -> S::Error {
@@ -3748,6 +3839,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Va
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use MoveTypeLayout as L;
 
+        self.ctx.check_depth(self.depth).map_err(S::Error::custom)?;
         match (self.layout, self.value) {
             // Primitive types.
             (L::U8, ValueImpl::U8(x)) => serializer.serialize_u8(*x),
@@ -3765,6 +3857,9 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Va
                     ctx: self.ctx,
                     layout: struct_layout,
                     value: &*r.borrow(),
+                    // Note: for struct, we increment depth for fields in the corresponding
+                    // serializer.
+                    depth: self.depth,
                 })
                 .serialize(serializer)
             },
@@ -3774,6 +3869,9 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Va
                 ctx: self.ctx,
                 layout: &(),
                 value: clos,
+                // Note: for functions, we increment depth for captured arguments in the
+                // corresponding serializer.
+                depth: self.depth,
             }
             .serialize(serializer),
 
@@ -3797,6 +3895,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Va
                                 ctx: self.ctx,
                                 layout,
                                 value,
+                                depth: self.depth + 1,
                             })?;
                         }
                         t.end()
@@ -3842,6 +3941,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Va
                         ctx: self.ctx,
                         layout: &MoveStructLayout::signer_serialization_layout(),
                         value: &*r.borrow(),
+                        depth: self.depth,
                     })
                     .serialize(serializer)
                 }
@@ -3875,6 +3975,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Va
                             ctx: &ctx,
                             layout: layout.as_ref(),
                             value: &value.0,
+                            depth: self.depth,
                         };
                         value.serialize(serializer)
                     },
@@ -3928,6 +4029,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveStructLayout, 
                         ctx: self.ctx,
                         layout: &variant_layouts[0],
                         value: &values[0],
+                        depth: self.depth + 1,
                     },
                 ),
                 _ => {
@@ -3942,6 +4044,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveStructLayout, 
                             ctx: self.ctx,
                             layout,
                             value,
+                            depth: self.depth + 1,
                         })?
                     }
                     t.end()
@@ -3961,6 +4064,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveStructLayout, 
                     ctx: self.ctx,
                     layout: field_layout,
                     value,
+                    depth: self.depth + 1,
                 })?;
             }
             t.end()
@@ -4312,7 +4416,11 @@ impl Value {
 
     pub fn deserialize_constant(constant: &Constant) -> Option<Value> {
         let layout = Self::constant_sig_token_to_layout(&constant.type_)?;
-        ValueSerDeContext::new().deserialize(&constant.data, &layout)
+        // INVARIANT:
+        //   For constants, layout depth is bounded and cannot contain function values. Hence,
+        //   serialization depth is bounded. We still enable depth checks as a precaution.
+        ValueSerDeContext::new(Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH))
+            .deserialize(&constant.data, &layout)
     }
 }
 
@@ -4335,26 +4443,28 @@ impl Drop for Locals {
 *
 **************************************************************************************/
 impl Container {
-    fn visit_impl(&self, visitor: &mut impl ValueVisitor, depth: usize) {
+    fn visit_impl(&self, visitor: &mut impl ValueVisitor, depth: u64) -> PartialVMResult<()> {
         use Container::*;
 
         match self {
             Locals(_) => unreachable!("Should not ba able to visit a Locals container directly"),
             Vec(r) => {
                 let r = r.borrow();
-                if visitor.visit_vec(depth, r.len()) {
+                if visitor.visit_vec(depth, r.len())? {
                     for val in r.iter() {
-                        val.visit_impl(visitor, depth + 1);
+                        val.visit_impl(visitor, depth + 1)?;
                     }
                 }
+                Ok(())
             },
             Struct(r) => {
                 let r = r.borrow();
-                if visitor.visit_struct(depth, r.len()) {
+                if visitor.visit_struct(depth, r.len())? {
                     for val in r.iter() {
-                        val.visit_impl(visitor, depth + 1);
+                        val.visit_impl(visitor, depth + 1)?;
                     }
                 }
+                Ok(())
             },
             VecU8(r) => visitor.visit_vec_u8(depth, &r.borrow()),
             VecU16(r) => visitor.visit_vec_u16(depth, &r.borrow()),
@@ -4367,7 +4477,12 @@ impl Container {
         }
     }
 
-    fn visit_indexed(&self, visitor: &mut impl ValueVisitor, depth: usize, idx: usize) {
+    fn visit_indexed(
+        &self,
+        visitor: &mut impl ValueVisitor,
+        depth: u64,
+        idx: usize,
+    ) -> PartialVMResult<()> {
         use Container::*;
 
         match self {
@@ -4385,18 +4500,19 @@ impl Container {
 }
 
 impl Closure {
-    fn visit_impl(&self, visitor: &mut impl ValueVisitor, depth: usize) {
+    fn visit_impl(&self, visitor: &mut impl ValueVisitor, depth: u64) -> PartialVMResult<()> {
         let Self(_, captured) = self;
-        if visitor.visit_closure(depth, captured.len()) {
+        if visitor.visit_closure(depth, captured.len())? {
             for val in captured {
-                val.visit_impl(visitor, depth + 1);
+                val.visit_impl(visitor, depth + 1)?;
             }
         }
+        Ok(())
     }
 }
 
 impl ContainerRef {
-    fn visit_impl(&self, visitor: &mut impl ValueVisitor, depth: usize) {
+    fn visit_impl(&self, visitor: &mut impl ValueVisitor, depth: u64) -> PartialVMResult<()> {
         use ContainerRef::*;
 
         let (container, is_global) = match self {
@@ -4404,14 +4520,15 @@ impl ContainerRef {
             Global { container, .. } => (container, false),
         };
 
-        if visitor.visit_ref(depth, is_global) {
-            container.visit_impl(visitor, depth + 1);
+        if visitor.visit_ref(depth, is_global)? {
+            container.visit_impl(visitor, depth + 1)?;
         }
+        Ok(())
     }
 }
 
 impl IndexedRef {
-    fn visit_impl(&self, visitor: &mut impl ValueVisitor, depth: usize) {
+    fn visit_impl(&self, visitor: &mut impl ValueVisitor, depth: u64) -> PartialVMResult<()> {
         use ContainerRef::*;
 
         let (container, is_global) = match &self.container_ref {
@@ -4419,19 +4536,19 @@ impl IndexedRef {
             Global { container, .. } => (container, false),
         };
 
-        if visitor.visit_ref(depth, is_global) {
-            container.visit_indexed(visitor, depth, self.idx)
+        if visitor.visit_ref(depth, is_global)? {
+            container.visit_indexed(visitor, depth, self.idx)?;
         }
+        Ok(())
     }
 }
 
 impl ValueImpl {
-    fn visit_impl(&self, visitor: &mut impl ValueVisitor, depth: usize) {
+    fn visit_impl(&self, visitor: &mut impl ValueVisitor, depth: u64) -> PartialVMResult<()> {
         use ValueImpl::*;
 
         match self {
             Invalid => unreachable!("Should not be able to visit an invalid value"),
-
             U8(val) => visitor.visit_u8(depth, *val),
             U16(val) => visitor.visit_u16(depth, *val),
             U32(val) => visitor.visit_u32(depth, *val),
@@ -4440,64 +4557,46 @@ impl ValueImpl {
             U256(val) => visitor.visit_u256(depth, *val),
             Bool(val) => visitor.visit_bool(depth, *val),
             Address(val) => visitor.visit_address(depth, *val),
-
             Container(c) => c.visit_impl(visitor, depth),
-
             ContainerRef(r) => r.visit_impl(visitor, depth),
             IndexedRef(r) => r.visit_impl(visitor, depth),
-
             ClosureValue(c) => c.visit_impl(visitor, depth),
-
             DelayedFieldID { id } => visitor.visit_delayed(depth, *id),
         }
     }
 }
 
 impl ValueView for ValueImpl {
-    fn visit(&self, visitor: &mut impl ValueVisitor) {
+    fn visit(&self, visitor: &mut impl ValueVisitor) -> PartialVMResult<()> {
         self.visit_impl(visitor, 0)
     }
 }
 
 impl ValueView for Value {
-    fn visit(&self, visitor: &mut impl ValueVisitor) {
+    fn visit(&self, visitor: &mut impl ValueVisitor) -> PartialVMResult<()> {
         self.0.visit(visitor)
     }
 }
 
 impl ValueView for Struct {
-    fn visit(&self, visitor: &mut impl ValueVisitor) {
-        if visitor.visit_struct(0, self.fields.len()) {
+    fn visit(&self, visitor: &mut impl ValueVisitor) -> PartialVMResult<()> {
+        if visitor.visit_struct(0, self.fields.len())? {
             for val in self.fields.iter() {
-                val.visit_impl(visitor, 1);
+                val.visit_impl(visitor, 1)?;
             }
         }
+        Ok(())
     }
 }
 
 impl ValueView for Vector {
-    fn visit(&self, visitor: &mut impl ValueVisitor) {
+    fn visit(&self, visitor: &mut impl ValueVisitor) -> PartialVMResult<()> {
         self.0.visit_impl(visitor, 0)
     }
 }
 
-impl ValueView for IntegerValue {
-    fn visit(&self, visitor: &mut impl ValueVisitor) {
-        use IntegerValue::*;
-
-        match self {
-            U8(val) => visitor.visit_u8(0, *val),
-            U16(val) => visitor.visit_u16(0, *val),
-            U32(val) => visitor.visit_u32(0, *val),
-            U64(val) => visitor.visit_u64(0, *val),
-            U128(val) => visitor.visit_u128(0, *val),
-            U256(val) => visitor.visit_u256(0, *val),
-        }
-    }
-}
-
 impl ValueView for Reference {
-    fn visit(&self, visitor: &mut impl ValueVisitor) {
+    fn visit(&self, visitor: &mut impl ValueVisitor) -> PartialVMResult<()> {
         use ReferenceImpl::*;
 
         match &self.0 {
@@ -4508,19 +4607,13 @@ impl ValueView for Reference {
 }
 
 impl ValueView for VectorRef {
-    fn visit(&self, visitor: &mut impl ValueVisitor) {
+    fn visit(&self, visitor: &mut impl ValueVisitor) -> PartialVMResult<()> {
         self.0.visit_impl(visitor, 0)
     }
 }
 
 impl ValueView for StructRef {
-    fn visit(&self, visitor: &mut impl ValueVisitor) {
-        self.0.visit_impl(visitor, 0)
-    }
-}
-
-impl ValueView for SignerRef {
-    fn visit(&self, visitor: &mut impl ValueVisitor) {
+    fn visit(&self, visitor: &mut impl ValueVisitor) -> PartialVMResult<()> {
         self.0.visit_impl(visitor, 0)
     }
 }
@@ -4541,7 +4634,7 @@ impl Vector {
         }
 
         impl ValueView for ElemView<'_> {
-            fn visit(&self, visitor: &mut impl ValueVisitor) {
+            fn visit(&self, visitor: &mut impl ValueVisitor) -> PartialVMResult<()> {
                 self.container.visit_indexed(visitor, 0, self.idx)
             }
         }
@@ -4560,7 +4653,7 @@ impl Reference {
         struct ValueBehindRef<'b>(&'b ReferenceImpl);
 
         impl ValueView for ValueBehindRef<'_> {
-            fn visit(&self, visitor: &mut impl ValueVisitor) {
+            fn visit(&self, visitor: &mut impl ValueVisitor) -> PartialVMResult<()> {
                 use ReferenceImpl::*;
 
                 match self.0 {
@@ -4581,13 +4674,14 @@ impl GlobalValue {
         struct Wrapper<'b>(&'b Rc<RefCell<Vec<ValueImpl>>>);
 
         impl ValueView for Wrapper<'_> {
-            fn visit(&self, visitor: &mut impl ValueVisitor) {
+            fn visit(&self, visitor: &mut impl ValueVisitor) -> PartialVMResult<()> {
                 let r = self.0.borrow();
-                if visitor.visit_struct(0, r.len()) {
+                if visitor.visit_struct(0, r.len())? {
                     for val in r.iter() {
-                        val.visit_impl(visitor, 1);
+                        val.visit_impl(visitor, 1)?;
                     }
                 }
+                Ok(())
             }
         }
 
@@ -4855,4 +4949,11 @@ fn try_get_variant_field_layouts<'a>(
         }
     }
     None
+}
+
+fn check_depth(depth: u64, max_depth: Option<u64>) -> PartialVMResult<()> {
+    if max_depth.map_or(false, |max_depth| depth > max_depth) {
+        return Err(PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED));
+    }
+    Ok(())
 }

--- a/third_party/move/move-vm/types/src/views.rs
+++ b/third_party/move/move-vm/types/src/views.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{delayed_values::delayed_field_id::DelayedFieldID, values::LEGACY_CLOSURE_SIZE};
+use move_binary_format::errors::PartialVMResult;
 use move_core_types::{
     account_address::AccountAddress, gas_algebra::AbstractMemorySize, language_storage::TypeTag,
 };
@@ -21,7 +22,7 @@ pub trait TypeView {
 /// This is used to expose certain info to clients (e.g. the gas meter),
 /// usually in a lazily evaluated fashion.
 pub trait ValueView {
-    fn visit(&self, visitor: &mut impl ValueVisitor);
+    fn visit(&self, visitor: &mut impl ValueVisitor) -> PartialVMResult<()>;
 
     /// Returns the abstract memory size of the value.
     ///
@@ -36,99 +37,129 @@ pub trait ValueView {
         struct Acc(AbstractMemorySize);
 
         impl ValueVisitor for Acc {
-            fn visit_delayed(&mut self, _depth: usize, _id: DelayedFieldID) {
+            fn visit_delayed(&mut self, _depth: u64, _id: DelayedFieldID) -> PartialVMResult<()> {
                 // TODO[agg_v2](cleanup): `legacy_abstract_memory_size` is not used
                 //   anyway, so this function will be removed soon (hopefully).
                 //   Contributions are appreciated!
+                Ok(())
             }
 
-            fn visit_u8(&mut self, _depth: usize, _val: u8) {
+            fn visit_u8(&mut self, _depth: u64, _val: u8) -> PartialVMResult<()> {
                 self.0 += LEGACY_CONST_SIZE;
+                Ok(())
             }
 
-            fn visit_u16(&mut self, _depth: usize, _val: u16) {
+            fn visit_u16(&mut self, _depth: u64, _val: u16) -> PartialVMResult<()> {
                 self.0 += LEGACY_CONST_SIZE;
+                Ok(())
             }
 
-            fn visit_u32(&mut self, _depth: usize, _val: u32) {
+            fn visit_u32(&mut self, _depth: u64, _val: u32) -> PartialVMResult<()> {
                 self.0 += LEGACY_CONST_SIZE;
+                Ok(())
             }
 
-            fn visit_u64(&mut self, _depth: usize, _val: u64) {
+            fn visit_u64(&mut self, _depth: u64, _val: u64) -> PartialVMResult<()> {
                 self.0 += LEGACY_CONST_SIZE;
+                Ok(())
             }
 
-            fn visit_u128(&mut self, _depth: usize, _val: u128) {
+            fn visit_u128(&mut self, _depth: u64, _val: u128) -> PartialVMResult<()> {
                 self.0 += LEGACY_CONST_SIZE;
+                Ok(())
             }
 
-            fn visit_u256(&mut self, _depth: usize, _val: move_core_types::u256::U256) {
+            fn visit_u256(
+                &mut self,
+                _depth: u64,
+                _val: move_core_types::u256::U256,
+            ) -> PartialVMResult<()> {
                 self.0 += LEGACY_CONST_SIZE;
+                Ok(())
             }
 
-            fn visit_bool(&mut self, _depth: usize, _val: bool) {
+            fn visit_bool(&mut self, _depth: u64, _val: bool) -> PartialVMResult<()> {
                 self.0 += LEGACY_CONST_SIZE;
+                Ok(())
             }
 
-            fn visit_address(&mut self, _depth: usize, _val: AccountAddress) {
+            fn visit_address(&mut self, _depth: u64, _val: AccountAddress) -> PartialVMResult<()> {
                 self.0 += AbstractMemorySize::new(AccountAddress::LENGTH as u64);
+                Ok(())
             }
 
-            fn visit_struct(&mut self, _depth: usize, _len: usize) -> bool {
+            fn visit_struct(&mut self, _depth: u64, _len: usize) -> PartialVMResult<bool> {
                 self.0 += LEGACY_STRUCT_SIZE;
-                true
+                Ok(true)
             }
 
-            fn visit_closure(&mut self, _depth: usize, _len: usize) -> bool {
+            fn visit_closure(&mut self, _depth: u64, _len: usize) -> PartialVMResult<bool> {
                 self.0 += LEGACY_CLOSURE_SIZE;
-                true
+                Ok(true)
             }
 
-            fn visit_vec(&mut self, _depth: usize, _len: usize) -> bool {
+            fn visit_vec(&mut self, _depth: u64, _len: usize) -> PartialVMResult<bool> {
                 self.0 += LEGACY_STRUCT_SIZE;
-                true
+                Ok(true)
             }
 
-            fn visit_vec_u8(&mut self, _depth: usize, vals: &[u8]) {
+            fn visit_vec_u8(&mut self, _depth: u64, vals: &[u8]) -> PartialVMResult<()> {
                 self.0 += (size_of_val(vals) as u64).into();
+                Ok(())
             }
 
-            fn visit_vec_u16(&mut self, _depth: usize, vals: &[u16]) {
+            fn visit_vec_u16(&mut self, _depth: u64, vals: &[u16]) -> PartialVMResult<()> {
                 self.0 += (size_of_val(vals) as u64).into();
+                Ok(())
             }
 
-            fn visit_vec_u32(&mut self, _depth: usize, vals: &[u32]) {
+            fn visit_vec_u32(&mut self, _depth: u64, vals: &[u32]) -> PartialVMResult<()> {
                 self.0 += (size_of_val(vals) as u64).into();
+                Ok(())
             }
 
-            fn visit_vec_u64(&mut self, _depth: usize, vals: &[u64]) {
+            fn visit_vec_u64(&mut self, _depth: u64, vals: &[u64]) -> PartialVMResult<()> {
                 self.0 += (size_of_val(vals) as u64).into();
+                Ok(())
             }
 
-            fn visit_vec_u128(&mut self, _depth: usize, vals: &[u128]) {
+            fn visit_vec_u128(&mut self, _depth: u64, vals: &[u128]) -> PartialVMResult<()> {
                 self.0 += (size_of_val(vals) as u64).into();
+                Ok(())
             }
 
-            fn visit_vec_u256(&mut self, _depth: usize, vals: &[move_core_types::u256::U256]) {
+            fn visit_vec_u256(
+                &mut self,
+                _depth: u64,
+                vals: &[move_core_types::u256::U256],
+            ) -> PartialVMResult<()> {
                 self.0 += (size_of_val(vals) as u64).into();
+                Ok(())
             }
 
-            fn visit_vec_bool(&mut self, _depth: usize, vals: &[bool]) {
+            fn visit_vec_bool(&mut self, _depth: u64, vals: &[bool]) -> PartialVMResult<()> {
                 self.0 += (size_of_val(vals) as u64).into();
+                Ok(())
             }
 
-            fn visit_vec_address(&mut self, _depth: usize, vals: &[AccountAddress]) {
+            fn visit_vec_address(
+                &mut self,
+                _depth: u64,
+                vals: &[AccountAddress],
+            ) -> PartialVMResult<()> {
                 self.0 += (size_of_val(vals) as u64).into();
+                Ok(())
             }
 
-            fn visit_ref(&mut self, _depth: usize, _is_global: bool) -> bool {
+            fn visit_ref(&mut self, _depth: u64, _is_global: bool) -> PartialVMResult<bool> {
                 self.0 += LEGACY_REFERENCE_SIZE;
-                false
+                Ok(false)
             }
         }
 
         let mut acc = Acc(0.into());
-        self.visit(&mut acc);
+        self.visit(&mut acc)
+            .expect("Legacy function: should not fail");
 
         acc.0
     }
@@ -136,76 +167,86 @@ pub trait ValueView {
 
 /// Trait that defines a visitor that could be used to traverse a value recursively.
 pub trait ValueVisitor {
-    fn visit_delayed(&mut self, depth: usize, id: DelayedFieldID);
-    fn visit_u8(&mut self, depth: usize, val: u8);
-    fn visit_u16(&mut self, depth: usize, val: u16);
-    fn visit_u32(&mut self, depth: usize, val: u32);
-    fn visit_u64(&mut self, depth: usize, val: u64);
-    fn visit_u128(&mut self, depth: usize, val: u128);
-    fn visit_u256(&mut self, depth: usize, val: move_core_types::u256::U256);
-    fn visit_bool(&mut self, depth: usize, val: bool);
-    fn visit_address(&mut self, depth: usize, val: AccountAddress);
+    fn visit_delayed(&mut self, depth: u64, id: DelayedFieldID) -> PartialVMResult<()>;
+    fn visit_u8(&mut self, depth: u64, val: u8) -> PartialVMResult<()>;
+    fn visit_u16(&mut self, depth: u64, val: u16) -> PartialVMResult<()>;
+    fn visit_u32(&mut self, depth: u64, val: u32) -> PartialVMResult<()>;
+    fn visit_u64(&mut self, depth: u64, val: u64) -> PartialVMResult<()>;
+    fn visit_u128(&mut self, depth: u64, val: u128) -> PartialVMResult<()>;
+    fn visit_u256(&mut self, depth: u64, val: move_core_types::u256::U256) -> PartialVMResult<()>;
+    fn visit_bool(&mut self, depth: u64, val: bool) -> PartialVMResult<()>;
+    fn visit_address(&mut self, depth: u64, val: AccountAddress) -> PartialVMResult<()>;
+    fn visit_struct(&mut self, depth: u64, len: usize) -> PartialVMResult<bool>;
+    fn visit_closure(&mut self, depth: u64, len: usize) -> PartialVMResult<bool>;
+    fn visit_vec(&mut self, depth: u64, len: usize) -> PartialVMResult<bool>;
+    fn visit_ref(&mut self, depth: u64, is_global: bool) -> PartialVMResult<bool>;
 
-    fn visit_struct(&mut self, depth: usize, len: usize) -> bool;
-    fn visit_closure(&mut self, depth: usize, len: usize) -> bool;
-    fn visit_vec(&mut self, depth: usize, len: usize) -> bool;
-
-    fn visit_ref(&mut self, depth: usize, is_global: bool) -> bool;
-
-    fn visit_vec_u8(&mut self, depth: usize, vals: &[u8]) {
-        self.visit_vec(depth, vals.len());
+    fn visit_vec_u8(&mut self, depth: u64, vals: &[u8]) -> PartialVMResult<()> {
+        self.visit_vec(depth, vals.len())?;
         for val in vals {
-            self.visit_u8(depth + 1, *val);
+            self.visit_u8(depth + 1, *val)?;
         }
+        Ok(())
     }
 
-    fn visit_vec_u16(&mut self, depth: usize, vals: &[u16]) {
-        self.visit_vec(depth, vals.len());
+    fn visit_vec_u16(&mut self, depth: u64, vals: &[u16]) -> PartialVMResult<()> {
+        self.visit_vec(depth, vals.len())?;
         for val in vals {
-            self.visit_u16(depth + 1, *val);
+            self.visit_u16(depth + 1, *val)?;
         }
+        Ok(())
     }
 
-    fn visit_vec_u32(&mut self, depth: usize, vals: &[u32]) {
-        self.visit_vec(depth, vals.len());
+    fn visit_vec_u32(&mut self, depth: u64, vals: &[u32]) -> PartialVMResult<()> {
+        self.visit_vec(depth, vals.len())?;
         for val in vals {
-            self.visit_u32(depth + 1, *val);
+            self.visit_u32(depth + 1, *val)?;
         }
+        Ok(())
     }
 
-    fn visit_vec_u64(&mut self, depth: usize, vals: &[u64]) {
-        self.visit_vec(depth, vals.len());
+    fn visit_vec_u64(&mut self, depth: u64, vals: &[u64]) -> PartialVMResult<()> {
+        self.visit_vec(depth, vals.len())?;
         for val in vals {
-            self.visit_u64(depth + 1, *val);
+            self.visit_u64(depth + 1, *val)?;
         }
+        Ok(())
     }
 
-    fn visit_vec_u128(&mut self, depth: usize, vals: &[u128]) {
-        self.visit_vec(depth, vals.len());
+    fn visit_vec_u128(&mut self, depth: u64, vals: &[u128]) -> PartialVMResult<()> {
+        self.visit_vec(depth, vals.len())?;
         for val in vals {
-            self.visit_u128(depth + 1, *val);
+            self.visit_u128(depth + 1, *val)?;
         }
+        Ok(())
     }
 
-    fn visit_vec_u256(&mut self, depth: usize, vals: &[move_core_types::u256::U256]) {
-        self.visit_vec(depth, vals.len());
+    fn visit_vec_u256(
+        &mut self,
+        depth: u64,
+        vals: &[move_core_types::u256::U256],
+    ) -> PartialVMResult<()> {
+        self.visit_vec(depth, vals.len())?;
         for val in vals {
-            self.visit_u256(depth + 1, *val);
+            self.visit_u256(depth + 1, *val)?;
         }
+        Ok(())
     }
 
-    fn visit_vec_bool(&mut self, depth: usize, vals: &[bool]) {
-        self.visit_vec(depth, vals.len());
+    fn visit_vec_bool(&mut self, depth: u64, vals: &[bool]) -> PartialVMResult<()> {
+        self.visit_vec(depth, vals.len())?;
         for val in vals {
-            self.visit_bool(depth + 1, *val);
+            self.visit_bool(depth + 1, *val)?;
         }
+        Ok(())
     }
 
-    fn visit_vec_address(&mut self, depth: usize, vals: &[AccountAddress]) {
-        self.visit_vec(depth, vals.len());
+    fn visit_vec_address(&mut self, depth: u64, vals: &[AccountAddress]) -> PartialVMResult<()> {
+        self.visit_vec(depth, vals.len())?;
         for val in vals {
-            self.visit_address(depth + 1, *val);
+            self.visit_address(depth + 1, *val)?;
         }
+        Ok(())
     }
 }
 
@@ -217,7 +258,7 @@ where
         <T as ValueView>::legacy_abstract_memory_size(*self)
     }
 
-    fn visit(&self, visitor: &mut impl ValueVisitor) {
+    fn visit(&self, visitor: &mut impl ValueVisitor) -> PartialVMResult<()> {
         <T as ValueView>::visit(*self, visitor)
     }
 }


### PR DESCRIPTION
## Description

Backport of upstream aptos-labs/aptos-core#16983 ([vm] VM value depth checks (bounded recursion), commit `5313b07572`, pre-license-cutoff).

Some merge conflicts arise because we didn't backport some other fixes previous of 16983.
- `misc.rs` — keeps the pre-existing `self.params.struct_` placeholder for `visit_closure` instead of the new `self.params.closure` field (the dedicated closure gas param is introduced by upstream #16969, out of scope here).
- `aptos-memory-usage-tracker` — drops the `charge_pack_closure` impl; our `GasMeter` trait does not have this method (also from #16969)
- `vm_status.rs` — drops `UNABLE_TO_CAPTURE_DELAYED_FIELDS` from the `MiscellaneousError` match arms; the variant is introduced by upstream #16576 (lazy-loading), not backported.

The `ty_depth_checker.rs` modify/delete conflict was resolved by deletion: the file does not exist on `m1` because its introducing PR (#16459, lazy-loading) was never backported, and #16983's change to it is a self-contained refactor with no external callers.

## How Has This Been Tested?

- `cargo check` of all cherry-pick-touched crates: ✅
- New unit tests added by #16983 in `move-vm-types`: `value_depth_tests::{test_read_ref, test_compare, test_equals, test_copy_value, test_serialization}` — **5/5 pass**.
- New e2e test added by #16983 in `e2e-move-tests`: `function_value_depth::test_vm_value_too_deep_with_function_values` — **1/1 pass**.

## Type of Change

- [x] Bug fix
- [x] Refactoring

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine
