### PR TITLE
Depth checker should return error if generic type not present 

### DIFF
--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1768,7 +1768,7 @@ fn check_depth_of_type_impl(
         Type::Struct { idx, .. } => {
             let formula =
                 DepthFormulaCalculator::new(module_storage).calculate_depth_of_struct(idx)?;
-            check_depth!(formula.solve(&[]))
+            check_depth!(formula.solve(&[])?)
         },
         // NB: substitution must be performed before calling this function
         Type::StructInstantiation { idx, ty_args, .. } => {
@@ -1782,7 +1782,7 @@ fn check_depth_of_type_impl(
                 .collect::<PartialVMResult<Vec<_>>>()?;
             let formula =
                 DepthFormulaCalculator::new(module_storage).calculate_depth_of_struct(idx)?;
-            check_depth!(formula.solve(&ty_arg_depths))
+            check_depth!(formula.solve(&ty_arg_depths)?)
         },
         Type::Function { args, results, .. } => {
             let mut ty_max_depth = depth;

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -105,13 +105,15 @@ impl DepthFormula {
         Ok(DepthFormula::normalize(formulas))
     }
 
-    pub fn solve(&self, tparam_depths: &[u64]) -> u64 {
+    pub fn solve(&self, tparam_depths: &[u64]) -> PartialVMResult<u64> {
         let Self { terms, constant } = self;
         let mut depth = constant.as_ref().copied().unwrap_or(0);
         for (t_i, c_i) in terms {
-            depth = max(depth, tparam_depths[*t_i as usize].saturating_add(*c_i))
+            depth = max(depth, tparam_depths.get(*t_i as usize).ok_or_else(|| {
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(format!("type parameter {t_i} out of bounds"))
+            })?.saturating_add(*c_i))
         }
-        depth
+        Ok(depth)
     }
 
     pub fn scale(&mut self, c: u64) {


### PR DESCRIPTION
## Description
Harden code against out of bounds in depth checker. It is not clear how we would hit this code path, however belt and braces are a good idea.

Backport of [PR#19649](http://github.com/aptos-labs/aptos-core/pull/19649)

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)
