### PR TITLE
fix: always verify ledger info signatures

### DIFF
--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -318,13 +318,6 @@ impl LedgerInfoWithV0 {
         &self,
         validator: &ValidatorVerifier,
     ) -> ::std::result::Result<(), VerifyError> {
-        // Check if this LedgerInfo is before the waypoint version
-        if let Some(waypoint_version) = get_waypoint_version() {
-            if self.ledger_info().version() <= waypoint_version {
-                return Ok(());
-            }
-        }
-
         validator.verify_multi_signatures(self.ledger_info(), &self.signatures)
     }
 


### PR DESCRIPTION

## Summary

[verify_signatures](https://github.com/movementlabsxyz/aptos-core/blob/07da2cae02f14230d4fb4c2349409fb6c9877cd8/types/src/ledger_info.rs#L317-L329) returned `Ok` without checking signatures for any ledger info at or below the node's [base waypoint](https://github.com/movementlabsxyz/aptos-core/blob/m1/aptos-node/src/storage.rs#L200-L201) (captured once into a [process-global](https://github.com/movementlabsxyz/aptos-core/blob/m1/types/src/ledger_info.rs#L35-L46) at startup). This PR removes that short-circuit so verification always runs.

**Origin:** [d66d3b2ae8](https://github.com/movementlabsxyz/aptos-core/commit/d66d3b2ae80626f1e328317b6374863771e81a7d) ("start validator fullnode"), alongside the L1-migration tooling and startup wiring — apparently a bootstrap shortcut during the migration cutover.

## The problem

`verify_signatures` is the shared primitive behind the state-sync epoch / validator-set ratchet ([EpochState::verify](https://github.com/movementlabsxyz/aptos-core/blob/m1/types/src/epoch_state.rs#L42-L51) and `EpochChangeProof::verify`). With the short-circuit, a forged epoch-ending ledger info at or below the waypoint — with absent or invalid signatures — passes `verify_signatures`. So an untrusted state-sync peer can feed forged sub-waypoint ledger infos to a bootstrapping node, and **forged historical validator-set data is accepted and persisted.** The weakening is in the shared primitive, so it hits every caller verifying a historical ledger info.

Not reachable: fund loss or live-consensus takeover — the current validator set and state are hash-anchored to the waypoint.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Notes / risk

The L1-migration is a continuation of an existing chain (original v0 genesis + latest waypoint), so a fresh node should verify the normally-signed epoch-ending ledger-info chain up to the waypoint without the bypass — it appears unnecessary for steady-state onboarding. **Not confirmed end to end.** If some chain genuinely cannot be verified, the fix is to anchor trust on the hash-verified waypoint (skip pre-waypoint proofs), not the global bypass.