### PR TITLE
fix(consensus-observer): verify payload block-info against ordered block

### DIFF
--- a/consensus/src/consensus_observer/observer/payload_store.rs
+++ b/consensus/src/consensus_observer/observer/payload_store.rs
@@ -171,6 +171,22 @@ impl BlockPayloadStore {
                     // Get the block transaction payload
                     let transaction_payload = match entry.get() {
                         BlockPayloadStatus::AvailableAndVerified(block_payload) => {
+                            // The stored block info is supplied by the (untrusted) publisher
+                            // and is not covered by payload signature verification. Ensure its
+                            // pre-execution fields match the ordered block's block info before
+                            // trusting the payload, otherwise forged metadata (e.g. a far-future
+                            // timestamp) could be accepted.
+                            if !block_payload
+                                .block()
+                                .match_ordered_only(&ordered_block.block_info())
+                            {
+                                return Err(Error::InvalidMessageError(format!(
+                                    "Payload verification failed! Block info for the stored payload does not match the ordered block for epoch: {:?} and round: {:?}",
+                                    ordered_block.epoch(),
+                                    ordered_block.round()
+                                )));
+                            }
+
                             block_payload.transaction_payload()
                         },
                         BlockPayloadStatus::AvailableAndUnverified(_) => {

--- a/consensus/src/consensus_observer/observer/payload_store.rs
+++ b/consensus/src/consensus_observer/observer/payload_store.rs
@@ -981,6 +981,79 @@ mod test {
     }
 
     #[test]
+    fn test_verify_payloads_against_ordered_block_forged_block_info() {
+        // Create a new block payload store
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add some verified blocks for the current epoch
+        let current_epoch = 0;
+        let num_verified_blocks = 10;
+        let verified_blocks = create_and_add_blocks_to_store(
+            &mut block_payload_store,
+            num_verified_blocks,
+            current_epoch,
+            true,
+        );
+
+        // Create an ordered block using the verified blocks
+        let ordered_block = OrderedBlock::new(
+            verified_blocks.clone(),
+            create_empty_ledger_info(current_epoch),
+        );
+
+        // Verify the ordered block and ensure it passes before any tampering
+        block_payload_store
+            .verify_payloads_against_ordered_block(&ordered_block)
+            .unwrap();
+
+        // Tamper with the first stored payload: keep the correct block id but forge the
+        // timestamp far into the future (the metadata is publisher-supplied and unsigned).
+        // Crucially, preserve the entry's existing valid transaction payload so the forged
+        // metadata is the only defect.
+        let tampered_block = &verified_blocks[0];
+        let original_block_info = tampered_block.block_info();
+        // Push the timestamp ~30 years into the future (the field is in microseconds): a
+        // far-future value that would force quorum store batch expiration, without
+        // resorting to a saturating sentinel.
+        let forged_timestamp_usecs = original_block_info.timestamp_usecs() + 1_000_000_000_000_000;
+        let forged_block_info = BlockInfo::new(
+            original_block_info.epoch(),
+            original_block_info.round(),
+            original_block_info.id(),
+            original_block_info.executed_state_id(),
+            original_block_info.version(),
+            forged_timestamp_usecs,
+            original_block_info.next_epoch_state().cloned(),
+        );
+        {
+            let block_payloads = block_payload_store.get_block_payloads();
+            let mut block_payloads = block_payloads.lock();
+            let block_payload_status = block_payloads
+                .get_mut(&(tampered_block.epoch(), tampered_block.round()))
+                .unwrap();
+            let existing_transaction_payload = match block_payload_status {
+                BlockPayloadStatus::AvailableAndVerified(block_payload) => {
+                    block_payload.transaction_payload().clone()
+                },
+                BlockPayloadStatus::AvailableAndUnverified(block_payload) => {
+                    block_payload.transaction_payload().clone()
+                },
+            };
+            *block_payload_status = BlockPayloadStatus::AvailableAndVerified(BlockPayload::new(
+                forged_block_info,
+                existing_transaction_payload,
+            ));
+        }
+
+        // Verify the ordered block and ensure it now fails (the forged block info mismatches)
+        let error = block_payload_store
+            .verify_payloads_against_ordered_block(&ordered_block)
+            .unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+    }
+
+    #[test]
     fn test_verify_payload_signatures_failure() {
         // Create a new consensus observer config
         let max_num_pending_blocks = 100;


### PR DESCRIPTION



## Description

The observer receives a single block as **two separate network messages** — [OrderedBlock](https://github.com/movementlabsxyz/aptos-core/blob/fix/observer-payload-block-info/consensus/src/consensus_observer/network/observer_message.rs#L181) and [BlockPayload](https://github.com/movementlabsxyz/aptos-core/blob/fix/observer-payload-block-info/consensus/src/consensus_observer/network/observer_message.rs#L838) — each carrying its own copy of the block info, one signed, one not:

```mermaid
sequenceDiagram
    participant P as Publisher (validator/VFN)
    participant O as Observer (fullnode)
    Note over P: one proposed block<br/>epoch, round, id, timestamp
    P->>O: BlockPayload — block info UNSIGNED + transactions
    rect rgb(255, 226, 226)
    Note over O: ATTACK — forged far-future timestamp<br/>expires every batch, transactions dropped<br/>during verify_payload_digests, still returns success
    end
    P->>O: OrderedBlock — block info + signed ordered proof TRUSTED
    rect rgb(223, 246, 221)
    Note over O: ★ NEW (this PR) — at the join,<br/>payload block info must equal ordered block info<br/>forged timestamp is rejected here
    end
    rect rgb(235, 235, 235)
    Note over O: the existing match_ordered_only checks run<br/>only at the later commit/execution stage<br/>TOO LATE — the gutted block would already be accepted
    end
```

The two messages exist because the ordered block (headers + proof) is small while the transaction payloads are large and streamed separately, so the observer routinely holds [BlockPayload](https://github.com/movementlabsxyz/aptos-core/blob/fix/observer-payload-block-info/consensus/src/consensus_observer/network/observer_message.rs#L838) messages before the matching ordered block arrives, caching them until the join in [verify_payloads_against_ordered_block](https://github.com/movementlabsxyz/aptos-core/blob/fix/observer-payload-block-info/consensus/src/consensus_observer/observer/payload_store.rs#L158).

**Honest path.** Both messages carry the same block info, so the `BlockPayload`'s timestamp equals the ordered block's. Batches reconstruct normally, the transactions match the ordered block's payload, and the block is processed.

**Malicious path.** The ordered block's block info is authenticated by its [signed ordered proof](https://github.com/movementlabsxyz/aptos-core/blob/fix/observer-payload-block-info/consensus/src/consensus_observer/network/observer_message.rs#L269), but the `BlockPayload` copy ([emitted by the publisher here](https://github.com/movementlabsxyz/aptos-core/blob/fix/observer-payload-block-info/consensus/src/payload_manager/quorum_store_payload_manager.rs#L478)) is unsigned. A malicious publisher sends the genuine transactions with a forged far-future timestamp; that timestamp expires every batch during reconstruction ([reconstruct_batch](https://github.com/movementlabsxyz/aptos-core/blob/fix/observer-payload-block-info/consensus/src/consensus_observer/network/observer_message.rs#L993)), so the payload reconstructs with its transactions silently dropped — and because that path returns success, digest and signature verification still pass. [verify_payloads_against_ordered_block](https://github.com/movementlabsxyz/aptos-core/blob/fix/observer-payload-block-info/consensus/src/consensus_observer/observer/payload_store.rs#L158) only checked the transactions, never the unsigned block info, so the observer accepts a block whose transactions have vanished, diverging from the committed chain.

**The fix.** Add a guard at the join that requires a verified payload's pre-execution block info to match the ordered block — via [match_ordered_only](https://github.com/movementlabsxyz/aptos-core/blob/fix/observer-payload-block-info/types/src/block_info.rs#L197) (ordered-only fields) — before it is trusted.

## How Has This Been Tested?

New test [test_verify_payloads_against_ordered_block_forged_block_info](https://github.com/movementlabsxyz/aptos-core/blob/fix/observer-payload-block-info/consensus/src/consensus_observer/observer/payload_store.rs#L1000).

**Failure (old behavior).** Before the fix, validation accepts the forged payload:

```bash
git checkout fix/observer-payload-block-info~1
cargo test -p aptos-consensus --lib test_verify_payloads_against_ordered_block_forged_block_info   # FAILS: unwrap_err() on an Ok value
```

**Success (with the fix).** After the fix, the same test passes:

```bash
git checkout fix/observer-payload-block-info
cargo test -p aptos-consensus --lib test_verify_payloads_against_ordered_block_forged_block_info
```

## Type of Change

- [x] Bug fix
- [x] Tests