### PR TITLE
chore: rename script-composer for Movement usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,24 +1314,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aptos-dynamic-transaction-composer"
-version = "0.1.4"
-dependencies = [
- "anyhow",
- "aptos-types",
- "bcs 0.1.4",
- "e2e-move-tests",
- "getrandom 0.2.11",
- "move-binary-format",
- "move-bytecode-verifier",
- "move-core-types",
- "serde",
- "serde_bytes",
- "wasm-bindgen",
- "wasm-bindgen-futures",
-]
-
-[[package]]
 name = "aptos-enum-conversion-derive"
 version = "0.0.3"
 dependencies = [
@@ -7910,6 +7892,24 @@ name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
+name = "dynamic-transaction-composer"
+version = "0.1.4"
+dependencies = [
+ "anyhow",
+ "aptos-types",
+ "bcs 0.1.4",
+ "e2e-move-tests",
+ "getrandom 0.2.11",
+ "move-binary-format",
+ "move-bytecode-verifier",
+ "move-core-types",
+ "serde",
+ "serde_bytes",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
 
 [[package]]
 name = "e2e-move-tests"

--- a/aptos-move/script-composer/Cargo.toml
+++ b/aptos-move/script-composer/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "aptos-dynamic-transaction-composer"
+name = "dynamic-transaction-composer"
 description = "Generating Move Script from a batched Move calls"
 version = "0.1.4"
 


### PR DESCRIPTION
- Renames the `aptos-move/script-composer` package from `aptos-dynamic-transaction-composer` to `dynamic-transaction-composer` and regenerates `Cargo.lock`.
- Drops the `aptos-` prefix so the published crate name is Movement-owned rather than carrying Aptos branding for use by packages that import ut.
- No reverse dependencies: nothing in the workspace imports the crate, so no consumers needed updating. The workspace alias (`aptos-script-composer`) links by path and is unaffected.
- `pkg/` wasm-pack output is gitignored and regenerates on the next build.