### PR TITLE
fix(features): drop deprecated bridge flags

### DIFF
--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -267,7 +267,7 @@ module std::features {
     }
 
     /// Whether we refund storage costs to the user upon deletion
-    /// 
+    ///
     /// Lifetime: transient
     const STORAGE_DELETION_REFUND: u64 = 28;
 
@@ -594,30 +594,12 @@ module std::features {
     }
 
     const TRANSACTION_SIMULATION_ENHANCEMENT: u64 = 78;
-    /// Whether the Atomic bridge is available
-    /// Lifetime: transient
-    const ATOMIC_BRIDGE: u64 = 71;
 
-    #[deprecated]
-    public fun get_atomic_bridge_feature(): u64 { ATOMIC_BRIDGE }
-
-    #[deprecated]
-    public fun abort_atomic_bridge_enabled(): bool {
-        true
-    }
-
-
-    /// Whether the Atomic bridge is available
-    /// Lifetime: transient
-    const NATIVE_BRIDGE: u64 = 72;
-
-    #[deprecated]
-    public fun get_native_bridge_feature(): u64 { NATIVE_BRIDGE }
-
-    #[deprecated]
-    public fun abort_native_bridge_enabled(): bool {
-        true
-    }
+    // Feature flags 71 (_DISALLOW_USER_NATIVES) and 72 (ALLOW_SERIALIZED_SCRIPT_ARGS) are
+    // VM-only flags owned by the Rust `FeatureFlag` enum (types/src/on_chain_config/aptos_features.rs).
+    // They are gated entirely in the VM and intentionally have no Move-side constant here.
+    // Do not reuse these indices in Move: the deprecated NATIVE_BRIDGE/ATOMIC_BRIDGE features
+    // previously aliased them, masking ALLOW_SERIALIZED_SCRIPT_ARGS.
 
     /// Whether the Governed Gas Pool is used to capture gas fees
     ///
@@ -779,7 +761,7 @@ module std::features {
         is_enabled(DISTRIBUTE_TRANSACTION_FEE)
     }
 
-    /// Whether the staking rewards are mint (diseable) or withdraw from the gouverned gas pool treasury (enable). 
+    /// Whether the staking rewards are mint (diseable) or withdraw from the gouverned gas pool treasury (enable).
     ///
     /// Lifetime: permanent
     const STAKE_REWARD_USING_TREASURY: u64 = 224;


### PR DESCRIPTION
## Summary

`std::features` defined two deprecated, Movement-specific feature-flag constants whose bit indices collide with VM-owned flags in the Rust `FeatureFlag` enum (`types/src/on_chain_config/aptos_features.rs`):

| Index | Rust `FeatureFlag` enum | Move `features.move` (before) |
|-------|-------------------------|-------------------------------|
| 71 | `_DISALLOW_USER_NATIVES` | `ATOMIC_BRIDGE` (deprecated) |
| 72 | `ALLOW_SERIALIZED_SCRIPT_ARGS` | `NATIVE_BRIDGE` (deprecated) |

Bit 72 is the flag the VM checks to allow serialized script arguments (the script-composer feature): `aptos_vm.rs` rejects `TransactionArgument::Serialized` with `FEATURE_UNDER_GATING` when it is off. On the Move side that same bit was named `NATIVE_BRIDGE`, so the two runtimes disagree on what bit 72 means. This both obscures the real flag and is a latent trap — re-introducing a live `is_enabled(NATIVE_BRIDGE)` check, or a fresh genesis with bit 72 defaulted on, would read the script-args bit as "native bridge enabled".

`NATIVE_BRIDGE`/`ATOMIC_BRIDGE` are already deprecated, and both bridge features were explicitly disabled on Movement chains; the bridge modules are legacy.

## Context

Resolves the flag-72 naming conflict and is a prerequisite to a separate governance proposal enabling `allow_serialized_script_args` (72) on Movement testnet for the script composer. No upstream security patch gates this flag; enabling it matches Aptos mainnet/testnet.
