### PR TITLE
feat(cli): default chunked-publish large_packages address on Movement

### DIFF
--- a/aptos-move/framework/src/chunked_publish.rs
+++ b/aptos-move/framework/src/chunked_publish.rs
@@ -26,7 +26,7 @@ pub enum PublishType {
 }
 
 pub fn default_large_packages_module_address(chain_id: &ChainId) -> &'static str {
-    if chain_id.is_movement_mainnet() || chain_id.is_movement_testnet() {
+    if chain_id.is_mainnet() || chain_id.is_testnet() {
         LARGE_PACKAGES_PROD_MODULE_ADDRESS
     } else {
         LARGE_PACKAGES_DEV_MODULE_ADDRESS

--- a/aptos-move/framework/src/chunked_publish.rs
+++ b/aptos-move/framework/src/chunked_publish.rs
@@ -10,7 +10,7 @@ use move_core_types::{account_address::AccountAddress, ident_str, language_stora
 /// The default address where the `large_packages.move` module is deployed.
 /// This address is used on both mainnet and testnet.
 pub const LARGE_PACKAGES_PROD_MODULE_ADDRESS: &str =
-    "0x0e1ca3011bdd07246d4d16d909dbb2d6953a86c4735d5acf5865d962c630cce7";
+    "0x5535c0246b3da2a0632edc13bac62aa352a9829adc2e060ed227955457aa9f06";
 
 /// Address where large packages module is deployed on dev network started from genesis
 /// (including devnet and localnet)
@@ -26,7 +26,7 @@ pub enum PublishType {
 }
 
 pub fn default_large_packages_module_address(chain_id: &ChainId) -> &'static str {
-    if chain_id.is_mainnet() || chain_id.is_testnet() {
+    if chain_id.is_movement_mainnet() || chain_id.is_movement_testnet() {
         LARGE_PACKAGES_PROD_MODULE_ADDRESS
     } else {
         LARGE_PACKAGES_DEV_MODULE_ADDRESS

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -2499,10 +2499,8 @@ pub struct OverrideSizeCheckOption {
 pub struct LargePackagesModuleOption {
     /// Address of the `large_packages` move module for chunked publishing
     ///
-    /// By default, on the module is published at `0x0e1ca3011bdd07246d4d16d909dbb2d6953a86c4735d5acf5865d962c630cce7`
-    /// on Testnet and Mainnet, and `0x7` on localnest/devnet.
-    /// On any custom network where neither is used, you will need to first publish it from the framework
-    /// under move-examples/large_packages.
+    /// Defaults to `0x5535c0246b3da2a0632edc13bac62aa352a9829adc2e060ed227955457aa9f06`
+    /// on mainnet and testnet.
     #[clap(long, value_parser = crate::common::types::load_account_arg)]
     pub(crate) large_packages_module_address: Option<AccountAddress>,
 }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -1659,7 +1659,7 @@ async fn submit_chunked_publish_transactions(
         let message = format!(
             "The resource {}::large_packages::StagingArea under account {} is not empty.\
         \nThis may cause package publishing to fail if the data is unexpected. \
-        \nUse the `aptos move clear-staging-area` command to clean up the `StagingArea` resource under the account.",
+        \nUse the `movement move clear-staging-area` command to clean up the `StagingArea` resource under the account.",
             large_packages_module_address, account_address,
         )
             .bold();
@@ -1693,7 +1693,7 @@ async fn submit_chunked_publish_transactions(
                 println!("{}", "Caution: An error occurred while submitting chunked publish transactions. \
                 \nDue to this error, there may be incomplete data left in the `StagingArea` resource. \
                 \nThis could cause further errors if you attempt to run the chunked publish command again. \
-                \nTo avoid this, use the `aptos move clear-staging-area` command to clean up the `StagingArea` resource under your account before retrying.".bold());
+                \nTo avoid this, use the `movement move clear-staging-area` command to clean up the `StagingArea` resource under your account before retrying.".bold());
                 return Err(e);
             },
         }


### PR DESCRIPTION
## Summary

Point the default `large_packages` module address for `--chunked-publish` at the audited Movement deployment, so chunked publishing works out-of-the-box on Movement instead of requiring `--large-packages-module-address` on every call.

Uses deployment from https://github.com/movementlabsxyz/aptos-core/pull/303

`default_large_packages_module_address` gated the prod address on `is_mainnet() || is_testnet()`, which match chain IDs 1/2 (Aptos). Movement mainnet/testnet are chain IDs 126/250, so publishing there fell through to the localnet/devnet default (`0x7`), which has no `large_packages` deployed.

## Changes

- `chunked_publish.rs`: set `LARGE_PACKAGES_PROD_MODULE_ADDRESS` to `0x5535c0246b3da2a0632edc13bac62aa352a9829adc2e060ed227955457aa9f06` and gate it on `is_movement_mainnet() || is_movement_testnet()`.
- `crates/aptos/src/common/types.rs`: update the `--large-packages-module-address` flag doc.

## Address

`0x5535c0246b3da2a0632edc13bac62aa352a9829adc2e060ed227955457aa9f06` — the `large_packages` module, published to the same account on Movement mainnet and testnet.

## Testing

Build the CLI: `cargo build -p movement` (binary at `target/debug/movement`).

On Movement testnet, run a chunked publish **without** `--large-packages-module-address` and confirm the staging call resolves to `0x5535…::large_packages`:

- `cargo test -p movement --lib` passes.
- **Address publishing** — `movement move publish --chunked-publish` on a package large enough to require chunking.
- **Object publishing** — `movement move create-object-and-publish-package --chunked-publish`. Example: MovementNames deployed as an object — https://github.com/movementlabsxyz/movement-name-service/tree/main/contracts
