### PR TITLE
Apply max_promotions_per_block determinstically

### DIFF
--- a/aptos-move/block-executor/src/hot_state_op_accumulator.rs
+++ b/aptos-move/block-executor/src/hot_state_op_accumulator.rs
@@ -13,9 +13,15 @@ use std::{collections::BTreeMap, fmt::Debug, hash::Hash};
 pub struct BlockHotStateOpAccumulator<'base_view, Key, BaseView> {
     first_version: Version,
     base_view: &'base_view BaseView,
-    /// Keys read but never written to across the entire block are to be made hot (or refreshed
-    /// `hot_since_version` one is already hot but last refresh is far in the history) as the side
-    /// effect of the block epilogue (subject to per block limit)
+    /// Keys read but never written to across the entire block that are to be made hot (or refreshed
+    /// `hot_since_version` if already hot but the last refresh is far in the history) as the side
+    /// effect of the block epilogue.
+    ///
+    /// All eligible keys are accumulated here without applying `max_promotions_per_block`. The cap
+    /// is applied deterministically at materialization time (see `get_slots_to_make_hot`) rather
+    /// than during accumulation: reads are fed in from a `HashSet` whose iteration order varies
+    /// across processes, so capping while accumulating would let different validators retain
+    /// different subsets and diverge.
     to_make_hot: BTreeMap<Key, StateSlot>,
     /// Keep track of all the keys that are written to across the whole block, these keys are made
     /// hot (or have a refreshed `hot_since_version`) immediately at the version they got changed,
@@ -76,10 +82,6 @@ where
         }
 
         for key in read_only {
-            if self.to_make_hot.len() >= self.max_promotions_per_block {
-                COUNTER.inc_with(&["max_promotions_per_block_hit"]);
-                continue;
-            }
             if self.to_make_hot.contains_key(key) {
                 continue;
             }
@@ -127,7 +129,21 @@ where
     }
 
     pub fn get_slots_to_make_hot(&self) -> BTreeMap<Key, StateSlot> {
-        self.to_make_hot.clone()
+        // Apply the per-block cap here rather than while accumulating, so the promoted subset is a
+        // deterministic function of the accumulated keys and not of the (non-deterministic) order
+        // in which reads were observed. `to_make_hot` is ordered by key, so retain the smallest
+        // `max_promotions_per_block` keys, which every process computes identically.
+        if self.to_make_hot.len() > self.max_promotions_per_block {
+            let num_dropped = self.to_make_hot.len() - self.max_promotions_per_block;
+            COUNTER.inc_with_by(&["promotions_dropped_over_cap"], num_dropped as u64);
+            self.to_make_hot
+                .iter()
+                .take(self.max_promotions_per_block)
+                .map(|(key, slot)| (key.clone(), slot.clone()))
+                .collect()
+        } else {
+            self.to_make_hot.clone()
+        }
     }
 
     pub fn should_refresh(&self, hot_since_version: Version) -> bool {
@@ -135,5 +151,88 @@ where
             error!("Unexpected: hot_since_version > block first version");
         }
         hot_since_version + self.refresh_interval_versions as Version >= self.first_version
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aptos_types::state_store::{
+        state_slot::StateSlot, state_storage_usage::StateStorageUsage, StateViewResult,
+    };
+
+    /// Every key is reported as cold & absent, so every read-only key is eligible for promotion.
+    /// This lets the tests exercise the cap in isolation from the slot classification logic.
+    struct MockBaseView;
+
+    impl TStateView for MockBaseView {
+        type Key = u64;
+
+        fn get_usage(&self) -> StateViewResult<StateStorageUsage> {
+            Ok(StateStorageUsage::new_untracked())
+        }
+
+        fn next_version(&self) -> Version {
+            0
+        }
+
+        fn get_state_slot(&self, _state_key: &Self::Key) -> StateViewResult<StateSlot> {
+            Ok(StateSlot::ColdVacant)
+        }
+    }
+
+    /// Feeding the same reads in two different orders must produce the exact same promoted subset,
+    /// even when the number of eligible keys exceeds the per-block cap. This is the property that
+    /// keeps validators from diverging when reads arrive in a non-deterministic (HashSet) order.
+    #[test]
+    fn cap_selection_is_independent_of_read_order() {
+        const CAP: usize = 5;
+        let base_view = MockBaseView;
+        let ascending: Vec<u64> = (0..20).collect();
+        let descending: Vec<u64> = (0..20).rev().collect();
+
+        let mut accu_asc = BlockHotStateOpAccumulator::new_with_config(&base_view, CAP, 1_000_000);
+        accu_asc.add_transaction(std::iter::empty(), ascending.iter());
+
+        let mut accu_desc = BlockHotStateOpAccumulator::new_with_config(&base_view, CAP, 1_000_000);
+        accu_desc.add_transaction(std::iter::empty(), descending.iter());
+
+        let promoted_asc: Vec<u64> = accu_asc.get_slots_to_make_hot().into_keys().collect();
+        let promoted_desc: Vec<u64> =
+            accu_desc.get_slots_to_make_hot().into_keys().collect();
+
+        assert_eq!(promoted_asc, promoted_desc);
+        // The cap retains the smallest keys deterministically.
+        assert_eq!(promoted_asc, vec![0, 1, 2, 3, 4]);
+    }
+
+    /// Below the cap, every eligible key is promoted.
+    #[test]
+    fn all_keys_promoted_when_under_cap() {
+        let base_view = MockBaseView;
+        let mut accu = BlockHotStateOpAccumulator::new_with_config(&base_view, 100, 1_000_000);
+        let reads: Vec<u64> = (0..10).collect();
+        accu.add_transaction(std::iter::empty(), reads.iter());
+
+        let promoted: Vec<u64> = accu.get_slots_to_make_hot().into_keys().collect();
+        assert_eq!(promoted, reads);
+    }
+
+    /// Keys written anywhere in the block are never promoted, regardless of whether the write is
+    /// seen before or after the read.
+    #[test]
+    fn written_keys_are_excluded() {
+        let base_view = MockBaseView;
+        let mut accu = BlockHotStateOpAccumulator::new_with_config(&base_view, 100, 1_000_000);
+
+        // Read 1 first, then a later transaction writes it: it must be removed from promotions.
+        accu.add_transaction(std::iter::empty(), [1u64, 2, 3].iter());
+        accu.add_transaction([1u64].iter(), std::iter::empty());
+        // Write 5 first, then read it: it must never be added.
+        accu.add_transaction([5u64].iter(), std::iter::empty());
+        accu.add_transaction(std::iter::empty(), [5u64].iter());
+
+        let promoted: Vec<u64> = accu.get_slots_to_make_hot().into_keys().collect();
+        assert_eq!(promoted, vec![2, 3]);
     }
 }


### PR DESCRIPTION
## Description
The set of hot reads depends on the execution order in the validator, which is not deterministic. Fix this.

Same fix as upstream https://github.com/aptos-labs/aptos-core/commit/69fe58b6494cf22608a5055cb67bd87de1ea937b

## How Has This Been Tested?
```
cargo test -p aptos-block-executor -- all_keys_promoted_when_under_cap written_keys_are_excluded cap_selection_is_independent_of_read_order 
```

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)
