### PR TITLE
fix(cli): correct faucet hint on init (drop stale movementlabs link, hide on mainnet)

### DIFF
--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -6,9 +6,10 @@ use crate::{
     account::key_rotation::lookup_address,
     common::{
         types::{
-            account_address_from_public_key, CliCommand, CliConfig, CliError, CliTypedResult,
-            ConfigSearchMode, EncodingOptions, HardwareWalletOptions, PrivateKeyInputOptions,
-            ProfileConfig, ProfileOptions, PromptOptions, RngArgs, DEFAULT_PROFILE,
+            account_address_from_public_key, get_mint_site_url, CliCommand, CliConfig, CliError,
+            CliTypedResult, ConfigSearchMode, EncodingOptions, HardwareWalletOptions,
+            PrivateKeyInputOptions, ProfileConfig, ProfileOptions, PromptOptions, RngArgs,
+            DEFAULT_PROFILE,
         },
         utils::{
             explorer_account_link, fund_account, prompt_yes_with_override, read_line,
@@ -333,13 +334,21 @@ impl CliCommand<()> for InitTool {
             .unwrap_or(DEFAULT_PROFILE);
 
         eprintln!(
-            "\n---\nMovement CLI is now set up for account {} as profile {}!\n See the account here: {}\n 
-            Run `movement --help` for more information about commands. \n 
-            Visit https://faucet.movementlabs.xyz to use the testnet faucet.",
+            "\n---\nMovement CLI is now set up for account {} as profile {}!\n \
+             See the account here: {}\n \
+             Run `movement --help` for more information about commands.",
             address,
             profile_name,
-            explorer_account_link(address, Some(network))
+            explorer_account_link(address, Some(network)),
         );
+
+        // Faucet hint is testnet-only.
+        if network == Network::Testnet {
+            eprintln!(
+                " Visit {} to use the testnet faucet.",
+                get_mint_site_url(None)
+            );
+        }
 
         Ok(())
     }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1668,7 +1668,7 @@ impl FaucetOptions {
                     Err(CliError::CommandArgumentError("There is no faucet for mainnet. Please create and fund the account by transferring funds from another account. If you are confident you want to use a faucet, set --faucet-url or add a faucet URL to .movement/config.yaml for the current profile".to_string()))
                 },
                 Some(Network::Testnet) => {
-                    Err(CliError::CommandArgumentError(format!("To get testnet APT you must visit {}. If you are confident you want to use a faucet programmatically, set --faucet-url or add a faucet URL to .movement/config.yaml for the current profile", get_mint_site_url(None))))
+                    Err(CliError::CommandArgumentError(format!("To get testnet MOVE you must visit {}. If you are confident you want to use a faucet programmatically, set --faucet-url or add a faucet URL to .movement/config.yaml for the current profile", get_mint_site_url(None))))
                 },
                 _ => {
                     Err(CliError::CommandArgumentError("No faucet given. Please set --faucet-url or add a faucet URL to .movement/config.yaml for the current profile".to_string()))
@@ -2547,7 +2547,7 @@ pub struct ChunkedPublishOption {
     pub(crate) chunk_size: usize,
 }
 
-/// For minting testnet APT.
+/// For minting testnet MOVE.
 pub fn get_mint_site_url(address: Option<AccountAddress>) -> String {
     let params = match address {
         Some(address) => format!("?address={}", address.to_standard_string()),


### PR DESCRIPTION
## Problem

`movement init` always ended with:

```
Visit https://faucet.movementlabs.xyz to use the testnet faucet.
```

…regardless of the network chosen. Two issues:

1. **Stale domain.** `movementlabs.xyz` is the old host; the faucet site is now `https://faucet.movementnetwork.xyz`.
2. **Wrong on mainnet.** Mainnet has no faucet, but init still advertised a testnet faucet. Reported from a real `--network mainnet` init.

## Fix

`crates/aptos/src/common/init.rs` — print the faucet hint on **testnet only**, sourcing the URL from the canonical `get_mint_site_url()` helper so it stays in sync with the rest of the CLI. On mainnet/devnet/local/custom no faucet line prints at all.

`crates/aptos/src/common/types.rs` — fix stale token branding: `testnet APT` → `testnet MOVE` in the faucet error message and the `get_mint_site_url` doc comment.

### Output after the fix

- `--network testnet`: `Visit https://faucet.movementnetwork.xyz to use the testnet faucet.`
- `--network mainnet` / `devnet` / `local` / custom: no faucet line — ends at `Run \`movement --help\` …`

## Verification

- `cargo check -p movement` passes (toolchain 1.86.0).
- `rustfmt` clean on the changed files.

(Verified it compiles; did not run a live `movement init` end-to-end.)
