### PR TITLE
fix: reject oversized inbound transcripts before deserialization

### DIFF
--- a/dkg/src/transcript_aggregation/mod.rs
+++ b/dkg/src/transcript_aggregation/mod.rs
@@ -85,6 +85,13 @@ impl<S: DKGTrait> BroadcastStatus<DKGMessage> for Arc<TranscriptAggregationState
             metadata.author == sender,
             "[DKG] adding peer transcript failed with node author mismatch"
         );
+        let session_max = S::expected_max_transcript_size(&self.dkg_pub_params);
+        ensure!(
+            transcript_bytes.len() <= session_max,
+            "[DKG] adding peer transcript failed: transcript size {} exceeds session max {}",
+            transcript_bytes.len(),
+            session_max,
+        );
         let transcript = bcs::from_bytes(transcript_bytes.as_slice()).map_err(|e| {
             anyhow!("[DKG] adding peer transcript failed with trx deserialization error: {e}")
         })?;

--- a/dkg/src/transcript_aggregation/tests.rs
+++ b/dkg/src/transcript_aggregation/tests.rs
@@ -15,7 +15,7 @@ use aptos_types::{
 };
 use move_core_types::account_address::AccountAddress;
 use rand::thread_rng;
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 #[test]
 fn test_transcript_aggregation_state() {
@@ -164,4 +164,68 @@ fn test_transcript_aggregation_state() {
         transcript_bytes: bcs::to_bytes(&good_trx_4).unwrap(),
     });
     assert!(matches!(result, Ok(Some(_))));
+}
+
+#[test]
+fn test_oversized_transcript_rejected_before_deserialization() {
+    let num_validators = 5;
+    let epoch = 999;
+    let addrs: Vec<AccountAddress> = (0..num_validators)
+        .map(|_| AccountAddress::random())
+        .collect();
+    let private_keys: Vec<bls12381_keys::PrivateKey> = (0..num_validators)
+        .map(|_| bls12381_keys::PrivateKey::generate_for_testing())
+        .collect();
+    let public_keys: Vec<bls12381_keys::PublicKey> = (0..num_validators)
+        .map(|i| bls12381_keys::PublicKey::from(&private_keys[i]))
+        .collect();
+    let voting_powers = [1, 1, 1, 6, 6];
+    let validator_infos: Vec<ValidatorConsensusInfo> = (0..num_validators)
+        .map(|i| ValidatorConsensusInfo::new(addrs[i], public_keys[i].clone(), voting_powers[i]))
+        .collect();
+    let validator_consensus_info_move_structs = validator_infos
+        .clone()
+        .into_iter()
+        .map(ValidatorConsensusInfoMoveStruct::from)
+        .collect::<Vec<_>>();
+    let verifier = ValidatorVerifier::new(validator_infos.clone());
+    let pub_params = RealDKG::new_public_params(&DKGSessionMetadata {
+        dealer_epoch: epoch,
+        randomness_config: OnChainRandomnessConfig::default_enabled().into(),
+        dealer_validator_set: validator_consensus_info_move_structs.clone(),
+        target_validator_set: validator_consensus_info_move_structs.clone(),
+    });
+    let epoch_state = Arc::new(EpochState::new(epoch, verifier));
+    let trx_agg_state = Arc::new(TranscriptAggregationState::<RealDKG>::new(
+        duration_since_epoch(),
+        addrs[0],
+        pub_params.clone(),
+        epoch_state,
+    ));
+
+    let session_max = RealDKG::expected_max_transcript_size(&pub_params);
+    let oversized_bytes = vec![0u8; session_max + 1];
+
+    let start = Instant::now();
+    let result = trx_agg_state.add(addrs[0], DKGTranscript {
+        metadata: DKGTranscriptMetadata {
+            epoch,
+            author: addrs[0],
+        },
+        transcript_bytes: oversized_bytes,
+    });
+    let elapsed = start.elapsed();
+
+    // Must be rejected with a size error.
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("exceeds session max"),
+        "unexpected error: {err_msg}"
+    );
+    // Must complete in under one second — proving deserialization was not attempted.
+    assert!(
+        elapsed.as_secs() < 1,
+        "size gate took too long ({elapsed:?}), deserialization may have been attempted"
+    );
 }

--- a/types/src/dkg/dummy_dkg/mod.rs
+++ b/types/src/dkg/dummy_dkg/mod.rs
@@ -122,6 +122,11 @@ impl DKGTrait for DummyDKG {
     fn get_dealers(transcript: &DummyDKGTranscript) -> BTreeSet<u64> {
         transcript.contributions_by_dealer.keys().copied().collect()
     }
+
+    fn expected_max_transcript_size(_params: &Self::PublicParams) -> usize {
+        // DummyDKGTranscript is a u64 + BTreeMap<u64, u64>; 64 KiB is more than sufficient.
+        64 * 1024
+    }
 }
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]

--- a/types/src/dkg/mod.rs
+++ b/types/src/dkg/mod.rs
@@ -227,6 +227,11 @@ pub trait DKGTrait: Debug {
         player_share_pairs: Vec<(u64, Self::DealtSecretShare)>,
     ) -> Result<Self::DealtSecret>;
     fn get_dealers(transcript: &Self::Transcript) -> BTreeSet<u64>;
+
+    /// Upper bound on the BCS-encoded byte size of a single valid inbound transcript for this
+    /// session, derived from the session's wire layout. Used as a cheap structural gate before
+    /// deserialization to reject oversized blobs without allocating memory proportional to input.
+    fn expected_max_transcript_size(params: &Self::PublicParams) -> usize;
 }
 
 pub mod dummy_dkg;

--- a/types/src/dkg/real_dkg/mod.rs
+++ b/types/src/dkg/real_dkg/mod.rs
@@ -500,6 +500,39 @@ impl DKGTrait for RealDKG {
             .map(|x| x.id as u64)
             .collect()
     }
+
+    fn expected_max_transcript_size(params: &Self::PublicParams) -> usize {
+        // Derives a tight upper bound from the session's WeightedConfig.
+        //
+        // WTrx (WeightedTranscript) BCS wire layout at total weight W (compressed curve points):
+        //   soks:  Vec<SoK> with 1 element per single-dealer transcript ≈ 240 B
+        //   R:     W × G1  (48 B each) + ULEB128 length prefix
+        //   R_hat: W × G2  (96 B each) + ULEB128 length prefix
+        //   V:     (W+1) × G1           + ULEB128 length prefix  [W evals + dealt pubkey]
+        //   V_hat: (W+1) × G2           + ULEB128 length prefix
+        //   C:     W × G1               + ULEB128 length prefix
+        // Plus 4 KiB slack for BCS framing overhead.
+        fn wtrx_bound(total_weight: usize) -> usize {
+            const G1: usize = 48;
+            const G2: usize = 96;
+            const SOK_VEC: usize = 240; // 1 SoK (~232 B) + 8 B ULEB128 length prefix
+            const VEC_PREFIXES: usize = 5 * 8; // 5 remaining Vec fields
+            const BCS_SLACK: usize = 4096;
+            SOK_VEC
+                + total_weight * (3 * G1 + 2 * G2)
+                + (G1 + G2) // V[W] and V_hat[W]: the dealt public key elements
+                + VEC_PREFIXES
+                + BCS_SLACK
+        }
+        let main_bound = wtrx_bound(params.pvss_config.wconfig.get_total_weight());
+        let fast_bound = params
+            .pvss_config
+            .fast_wconfig
+            .as_ref()
+            .map_or(0, |c| wtrx_bound(c.get_total_weight()));
+        // 4 KiB for the outer Transcripts struct (Option tag, BCS struct framing).
+        main_bound + fast_bound + 4096
+    }
 }
 
 impl RealDKG {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

The fix adds `expected_max_transcript_size` to `DKGTrait`. Each implementor derives a tight upper bound from the session's wire layout. For `RealDKG` this is computed from the `WeightedConfig` total weight and the known G1/G2 curve point sizes (48 B and 96 B respectively). In `BroadcastStatus::add`, the blob length is checked against this bound before `bcs::from_bytes` is called. Oversized blobs are rejected in O(1) with no allocation. The ideal path for valid transcripts is completely unaffected.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
Unit tests

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
