### PR TITLE
ci: build tools and validator images produced together with aptos-node

### DIFF
--- a/.github/workflows/publish-builder-images.yaml
+++ b/.github/workflows/publish-builder-images.yaml
@@ -3,15 +3,6 @@ run-name: "Publish builder images for ${{ inputs.ref || github.ref_name }}"
 
 on:
   push:
-    branches:
-      - m1
-    paths:
-      - ".github/workflows/publish-builder-images.yaml"
-      - ".cargo/**"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "docker/builder/**"
-      - "rust-toolchain.toml"
   workflow_dispatch:
     inputs:
       ref:
@@ -160,4 +151,18 @@ jobs:
             --build-context "tools-builder=docker-image://$IMAGE_NAMESPACE/tools-builder:$SHORT_SHA" \
             "${common_metadata_args[@]}" \
             "${tools_tags[@]}" \
+            .
+
+          validator_tags=()
+          add_tags validator_tags "$IMAGE_NAMESPACE/validator"
+
+          docker buildx build \
+            --push \
+            --file docker/builder/validator.Dockerfile \
+            --target validator \
+            --build-context "debian-base=$DEBIAN_CONTEXT" \
+            --build-context "node-builder=docker-image://$IMAGE_NAMESPACE/aptos-node-builder:$SHORT_SHA" \
+            --build-context "tools-builder=docker-image://$IMAGE_NAMESPACE/tools-builder:$SHORT_SHA" \
+            "${common_metadata_args[@]}" \
+            "${validator_tags[@]}" \
             .

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ genesis_antithesis_*/
 
 # Ignore generated credentials from google-github-actions/auth
 gha-creds-*.json
+
+# Ignore Claude Code local config
+.claude/


### PR DESCRIPTION


> ⚠️ **Blocked on GHCR package permissions.** This workflow cannot push the `rust` / `builder-base` / `tools` / `validator` packages from CI — it fails with `permission_denied: write_package` (unlike `aptos-node`, whose package grants the repo write). Those packages need `movementlabsxyz/aptos-core` granted **Write** before CI here can go green.

## Summary

The [publish-builder-images](https://github.com/movementlabsxyz/aptos-core/blob/ci/publish-tools-validator-per-commit/.github/workflows/publish-builder-images.yaml) workflow rebuilt the `tools` image only on select `m1` changes and did not build the `validator` image at all — so neither rode along with the per-commit `aptos-node` image. This makes `tools` and `validator` build from the **same commit** as `aptos-node`, so every SHA carries a framework-consistent `aptos-node` / `validator` / `tools` set.

## Why

- **Same-commit requirement:** the `tools` image (bakes in the Move framework used for genesis) and the `validator` / `aptos-node` image (the node VM) must come from the same commit — a genesis blob or migration built against one framework version only runs correctly on a matching node VM.
- **Not produced together today:** `aptos-node` is produced at each commit, but `tools` / `validator` are not built alongside it, so no single SHA has all three aligned.
- **Concrete failure:** `0x1::governed_gas_pool`, which the post-move2 migration calls, is absent from the stale `tools` framework and fails with a `LINKER_ERROR`. Producing all three together keeps them consistent at any SHA.
- **Unblocks:** the ephemeral-devnet-via-forge work (movementlabsxyz/aptos-core#398), which hit exactly this mismatch.