### PR TITLE
fix(docker): repair the broken tools image build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,8 +140,9 @@ ecosystem/indexer-grpc/indexer-transaction-generator/*.yaml
 # ignore antithesis
 genesis_antithesis_*/
 
-# ignore cursor rules
-.cursor/rules
+# AI assistant tooling
+.cursor/
+.claude/
 
 #ignore proptest regressions
 **/proptest_regressions/*

--- a/docker/builder/build-tools.sh
+++ b/docker/builder/build-tools.sh
@@ -11,7 +11,7 @@ echo "CARGO_TARGET_DIR: $CARGO_TARGET_DIR"
 
 # Build all the rust binaries
 cargo build --locked --profile=$PROFILE \
-    -p aptos \
+    -p movement \
     -p aptos-backup-cli \
     -p aptos-faucet-service \
     -p aptos-fn-check-client \
@@ -26,7 +26,7 @@ cargo build --locked --profile=$PROFILE \
 
 # After building, copy the binaries we need to `dist` since the `target` directory is used as docker cache mount and only available during the RUN step
 BINS=(
-    aptos
+    movement
     aptos-faucet-service
     aptos-node-checker
     aptos-openapi-spec-generator

--- a/docker/builder/tools.Dockerfile
+++ b/docker/builder/tools.Dockerfile
@@ -7,7 +7,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     install \
     wget \
     curl \
-    perl-base=5.32.1-4+deb11u4 \
+    perl-base=5.32.1-4+deb11u5 \
     libtinfo6=6.2+20201114-2+deb11u2 \
     git \
             socat \
@@ -16,11 +16,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     gnupg2 \
     pigz
 
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
-    apt-get -y update && \
-    apt-get -y install google-cloud-sdk
-
 RUN ln -s /usr/bin/python3 /usr/local/bin/python
 COPY --link docker/tools/boto.cfg /etc/boto.cfg
 
@@ -28,7 +23,10 @@ RUN wget https://storage.googleapis.com/pub/gsutil.tar.gz -O- | tar --gzip --dir
 RUN cd /usr/local/bin && wget "https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubectl" -O kubectl && chmod +x kubectl
 
 COPY --link --from=tools-builder /aptos/dist/aptos-debugger /usr/local/bin/aptos-debugger
-COPY --link --from=tools-builder /aptos/dist/aptos /usr/local/bin/aptos
+COPY --link --from=tools-builder /aptos/dist/movement /usr/local/bin/movement
+# The CLI crate was renamed aptos -> movement; keep `aptos` as a compat alias so
+# callers like the genesis ceremony (`aptos genesis ...`) keep working.
+RUN ln -s /usr/local/bin/movement /usr/local/bin/aptos
 COPY --link --from=tools-builder /aptos/dist/aptos-openapi-spec-generator /usr/local/bin/aptos-openapi-spec-generator
 COPY --link --from=tools-builder /aptos/dist/aptos-fn-check-client /usr/local/bin/aptos-fn-check-client
 COPY --link --from=tools-builder /aptos/dist/aptos-transaction-emitter /usr/local/bin/aptos-transaction-emitter


### PR DESCRIPTION

## Description

The `tools` image build was broken in three independent ways. This fixes all three:

- **CLI rename:** [build-tools.sh](https://github.com/movementlabsxyz/aptos-core/blob/fix/tools-build/docker/builder/build-tools.sh) built `-p aptos`, but the crate is now `movement` — so the build failed. Build/copy `movement`, installed with an `aptos` → `movement` symlink **inside the image only** so `genesis.sh` (`aptos genesis …`) keeps working. The symlink exists solely in the tools container — it does not touch any developer's local `aptos`.
- **Bit-rot:** the pinned `perl-base=…u4` no longer resolves; bumped to `u5`.
- **Dead step:** dropped the unused `google-cloud-sdk` install — Movement uses S3 via `awscli`. It was also broken (needs Python ≥ 3.10, bullseye ships 3.9).

Also consolidates `.cursor/` and `.claude/` in `.gitignore`.

## How Has This Been Tested?

Built the `tools` image end-to-end locally with `docker/builder/docker-bake-rust-all.sh tools` — the full bake compiled green (both the `tools` image and the `aptos-node-builder` stage). Verified the resulting image:

- ships `/usr/local/bin/movement`, with `/usr/local/bin/aptos` → `movement` as a symlink; both `movement --version` and `aptos --version` report `movement 7.4.0`
- ships the genesis framework bundle at `/aptos-framework/move/head.mrb`

## Type of Change

- [x] Bug fix