### PR TITLE
fix mempool scheduled broadcast wakeup race

### DIFF
--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -117,13 +117,13 @@ pub(crate) async fn coordinator<NetworkClient, TransactionValidator, ConfigProvi
                 handle_mempool_reconfig_event(&mut smp, &bounded_executor, reconfig_notification.on_chain_configs).await;
             },
             (peer, backoff) = scheduled_broadcasts.select_next_some() => {
-                tasks::execute_broadcast(peer, backoff, &mut smp, &mut scheduled_broadcasts, executor.clone()).await;
+                tasks::execute_broadcast(peer, backoff, &mut smp, &mut scheduled_broadcasts).await;
             },
             (network_id, event) = events.select_next_some() => {
                 handle_network_event(&bounded_executor, &mut smp, network_id, event).await;
             },
             _ = update_peers_interval.tick().fuse() => {
-                handle_update_peers(peers_and_metadata.clone(), &mut smp, &mut scheduled_broadcasts, executor.clone()).await;
+                handle_update_peers(peers_and_metadata.clone(), &mut smp, &mut scheduled_broadcasts).await;
             },
             complete => break,
         }
@@ -420,7 +420,6 @@ async fn handle_update_peers<NetworkClient, TransactionValidator>(
     peers_and_metadata: Arc<PeersAndMetadata>,
     smp: &mut SharedMempool<NetworkClient, TransactionValidator>,
     scheduled_broadcasts: &mut FuturesUnordered<ScheduledBroadcast>,
-    executor: Handle,
 ) where
     NetworkClient: NetworkClientInterface<MempoolSyncMsg> + 'static,
     TransactionValidator: TransactionValidation + 'static,
@@ -433,8 +432,7 @@ async fn handle_update_peers<NetworkClient, TransactionValidator>(
         }
         for peer in &newly_added_upstream {
             debug!(LogSchema::new(LogEntry::NewPeer).peer(peer));
-            tasks::execute_broadcast(*peer, false, smp, scheduled_broadcasts, executor.clone())
-                .await;
+            tasks::execute_broadcast(*peer, false, smp, scheduled_broadcasts).await;
         }
         for peer in &disabled {
             debug!(LogSchema::new(LogEntry::LostPeer).peer(peer));

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -44,7 +44,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-use tokio::runtime::Handle;
+
 // ============================== //
 //  broadcast_coordinator tasks  //
 // ============================== //
@@ -55,7 +55,6 @@ pub(crate) async fn execute_broadcast<NetworkClient, TransactionValidator>(
     backoff: bool,
     smp: &mut SharedMempool<NetworkClient, TransactionValidator>,
     scheduled_broadcasts: &mut FuturesUnordered<ScheduledBroadcast>,
-    executor: Handle,
 ) where
     NetworkClient: NetworkClientInterface<MempoolSyncMsg>,
     TransactionValidator: TransactionValidation,
@@ -104,7 +103,6 @@ pub(crate) async fn execute_broadcast<NetworkClient, TransactionValidator>(
         Instant::now() + Duration::from_millis(interval_ms),
         peer,
         schedule_backoff,
-        executor,
     ))
 }
 

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -37,10 +37,9 @@ use std::{
     fmt,
     pin::Pin,
     sync::Arc,
-    task::Waker,
     time::{Instant, SystemTime},
 };
-use tokio::runtime::Handle;
+use tokio::time::Sleep;
 
 pub type MempoolSenderBucket = u8;
 pub type TimelineIndexIdentifier = u8;
@@ -120,34 +119,19 @@ pub(crate) fn notify_subscribers(
 
 /// A future that represents a scheduled mempool txn broadcast
 pub(crate) struct ScheduledBroadcast {
-    /// Time of scheduled broadcast
-    deadline: Instant,
+    sleep: Pin<Box<Sleep>>,
     peer: PeerNetworkId,
     backoff: bool,
-    waker: Arc<Mutex<Option<Waker>>>,
 }
 
 impl ScheduledBroadcast {
-    pub fn new(deadline: Instant, peer: PeerNetworkId, backoff: bool, executor: Handle) -> Self {
-        let waker: Arc<Mutex<Option<Waker>>> = Arc::new(Mutex::new(None));
-        let waker_clone = waker.clone();
-
-        if deadline > Instant::now() {
-            let tokio_instant = tokio::time::Instant::from_std(deadline);
-            executor.spawn(async move {
-                tokio::time::sleep_until(tokio_instant).await;
-                let mut waker = waker_clone.lock();
-                if let Some(waker) = waker.take() {
-                    waker.wake()
-                }
-            });
-        }
-
+    pub fn new(deadline: Instant, peer: PeerNetworkId, backoff: bool) -> Self {
         Self {
-            deadline,
+            sleep: Box::pin(tokio::time::sleep_until(tokio::time::Instant::from_std(
+                deadline,
+            ))),
             peer,
             backoff,
-            waker,
         }
     }
 }
@@ -157,15 +141,10 @@ impl Future for ScheduledBroadcast {
 
     // (peer, whether this broadcast was scheduled as a backoff broadcast)
 
-    fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
-        if Instant::now() < self.deadline {
-            let waker_clone = context.waker().clone();
-            let mut waker = self.waker.lock();
-            *waker = Some(waker_clone);
-
-            Poll::Pending
-        } else {
-            Poll::Ready((self.peer, self.backoff))
+    fn poll(mut self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
+        match self.sleep.as_mut().poll(context) {
+            Poll::Ready(()) => Poll::Ready((self.peer, self.backoff)),
+            Poll::Pending => Poll::Pending,
         }
     }
 }
@@ -428,9 +407,14 @@ impl Ord for MempoolMessageId {
 #[cfg(test)]
 mod test {
     use crate::shared_mempool::types::{
-        MempoolMessageId, MultiBucketTimelineIndexIds, TimelineIndexIdentifier,
+        MempoolMessageId, MultiBucketTimelineIndexIds, ScheduledBroadcast, TimelineIndexIdentifier,
     };
-    use std::collections::HashMap;
+    use aptos_config::network_id::{NetworkId, PeerNetworkId};
+    use aptos_types::PeerId;
+    use std::{
+        collections::HashMap,
+        time::{Duration, Instant},
+    };
 
     #[test]
     fn test_multi_bucket_timeline_ids_update() {
@@ -480,6 +464,19 @@ mod test {
         let left = MempoolMessageId(vec![]);
         let right = MempoolMessageId(vec![(1, 2)]);
         assert!(left < right);
+    }
+
+    #[tokio::test]
+    async fn test_scheduled_broadcast_fires() {
+        let peer = PeerNetworkId::new(NetworkId::Public, PeerId::random());
+        let scheduled_broadcast =
+            ScheduledBroadcast::new(Instant::now() + Duration::from_millis(10), peer, true);
+
+        let result = tokio::time::timeout(Duration::from_secs(1), scheduled_broadcast)
+            .await
+            .expect("scheduled broadcast should fire");
+
+        assert_eq!(result, (peer, true));
     }
 }
 


### PR DESCRIPTION
## Summary

- replace the custom shared-waker scheduler with a directly polled `tokio::time::Sleep`
- remove runtime handle plumbing used only by the custom sleeper task
- add a unit test for scheduled peer/backoff delivery

## Why

The custom implementation could miss a wakeup if its deadline elapsed between checking the deadline and registering the future's waker. Polling Tokio's timer directly makes timer registration and wakeup coordination atomic and avoids spawning a separate task for every broadcast interval.

## Validation

- `cargo test -p aptos-mempool --lib` (69 passed)
- `cargo check -p aptos-mempool --lib`
- `rustfmt --edition 2021 --check` on the touched files
- `git diff --check`