### PR TITLE
Remove code from before TRANSACTION_SIMULATION_ENHANCEMENT feature

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -2471,24 +2471,18 @@ impl AptosVM {
         )?;
 
         if let Some(multisig_address) = extra_config.multisig_address() {
-            // Once "simulation_enhancement" is enabled, the simulation path also validates the
-            // multisig transaction by running the multisig prologue.
-            if !self.is_simulation
-                || self
-                    .features()
-                    .is_transaction_simulation_enhancement_enabled()
-            {
-                transaction_validation::run_multisig_prologue(
-                    session,
-                    module_storage,
-                    txn_data,
-                    executable,
-                    multisig_address,
-                    self.features(),
-                    log_context,
-                    traversal_context,
-                )?
-            }
+            // The simulation path also validates the multisig transaction by running the
+            // multisig prologue.
+            transaction_validation::run_multisig_prologue(
+                session,
+                module_storage,
+                txn_data,
+                executable,
+                multisig_address,
+                self.features(),
+                log_context,
+                traversal_context,
+            )?
         }
         Ok(())
     }

--- a/aptos-move/aptos-vm/src/transaction_validation.rs
+++ b/aptos-move/aptos-vm/src/transaction_validation.rs
@@ -41,11 +41,7 @@ pub static APTOS_TRANSACTION_VALIDATION: Lazy<TransactionValidation> =
     Lazy::new(|| TransactionValidation {
         module_addr: CORE_CODE_ADDRESS,
         module_name: Identifier::new("transaction_validation").unwrap(),
-        fee_payer_prologue_name: Identifier::new("fee_payer_script_prologue").unwrap(),
-        script_prologue_name: Identifier::new("script_prologue").unwrap(),
-        multi_agent_prologue_name: Identifier::new("multi_agent_script_prologue").unwrap(),
         user_epilogue_name: Identifier::new("epilogue").unwrap(),
-        user_epilogue_gas_payer_name: Identifier::new("epilogue_gas_payer").unwrap(),
         fee_payer_prologue_extended_name: Identifier::new("fee_payer_script_prologue_extended")
             .unwrap(),
         script_prologue_extended_name: Identifier::new("script_prologue_extended").unwrap(),
@@ -69,11 +65,7 @@ pub static APTOS_TRANSACTION_VALIDATION: Lazy<TransactionValidation> =
 pub struct TransactionValidation {
     pub module_addr: AccountAddress,
     pub module_name: Identifier,
-    pub fee_payer_prologue_name: Identifier,
-    pub script_prologue_name: Identifier,
-    pub multi_agent_prologue_name: Identifier,
     pub user_epilogue_name: Identifier,
-    pub user_epilogue_gas_payer_name: Identifier,
     pub fee_payer_prologue_extended_name: Identifier,
     pub script_prologue_extended_name: Identifier,
     pub multi_agent_prologue_extended_name: Identifier,
@@ -271,107 +263,57 @@ pub(crate) fn run_script_prologue(
                 .as_ref()
                 .map(|proof| proof.optional_auth_key()),
         ) {
-            if features.is_transaction_simulation_enhancement_enabled() {
-                let args = vec![
-                    MoveValue::Signer(txn_data.sender),
-                    MoveValue::U64(txn_sequence_number),
-                    MoveValue::vector_u8(txn_authentication_key.unwrap_or_default()),
-                    MoveValue::vector_address(txn_data.secondary_signers()),
-                    MoveValue::Vector(secondary_auth_keys),
-                    MoveValue::Address(fee_payer),
-                    MoveValue::vector_u8(fee_payer_auth_key.unwrap_or_default()),
-                    MoveValue::U64(txn_gas_price.into()),
-                    MoveValue::U64(txn_max_gas_units.into()),
-                    MoveValue::U64(txn_expiration_timestamp_secs),
-                    MoveValue::U8(chain_id.id()),
-                    MoveValue::Bool(is_simulation),
-                ];
-                (
-                    &APTOS_TRANSACTION_VALIDATION.fee_payer_prologue_extended_name,
-                    args,
-                )
-            } else {
-                let args = vec![
-                    MoveValue::Signer(txn_data.sender),
-                    MoveValue::U64(txn_sequence_number),
-                    MoveValue::vector_u8(txn_authentication_key.unwrap_or_default()),
-                    MoveValue::vector_address(txn_data.secondary_signers()),
-                    MoveValue::Vector(secondary_auth_keys),
-                    MoveValue::Address(fee_payer),
-                    MoveValue::vector_u8(fee_payer_auth_key.unwrap_or_default()),
-                    MoveValue::U64(txn_gas_price.into()),
-                    MoveValue::U64(txn_max_gas_units.into()),
-                    MoveValue::U64(txn_expiration_timestamp_secs),
-                    MoveValue::U8(chain_id.id()),
-                ];
-                (&APTOS_TRANSACTION_VALIDATION.fee_payer_prologue_name, args)
-            }
+            let args = vec![
+                MoveValue::Signer(txn_data.sender),
+                MoveValue::U64(txn_sequence_number),
+                MoveValue::vector_u8(txn_authentication_key.unwrap_or_default()),
+                MoveValue::vector_address(txn_data.secondary_signers()),
+                MoveValue::Vector(secondary_auth_keys),
+                MoveValue::Address(fee_payer),
+                MoveValue::vector_u8(fee_payer_auth_key.unwrap_or_default()),
+                MoveValue::U64(txn_gas_price.into()),
+                MoveValue::U64(txn_max_gas_units.into()),
+                MoveValue::U64(txn_expiration_timestamp_secs),
+                MoveValue::U8(chain_id.id()),
+                MoveValue::Bool(is_simulation),
+            ];
+            (
+                &APTOS_TRANSACTION_VALIDATION.fee_payer_prologue_extended_name,
+                args,
+            )
         } else if txn_data.is_multi_agent() {
-            if features.is_transaction_simulation_enhancement_enabled() {
-                let args = vec![
-                    MoveValue::Signer(txn_data.sender),
-                    MoveValue::U64(txn_sequence_number),
-                    MoveValue::vector_u8(txn_authentication_key.unwrap_or_default()),
-                    MoveValue::vector_address(txn_data.secondary_signers()),
-                    MoveValue::Vector(secondary_auth_keys),
-                    MoveValue::U64(txn_gas_price.into()),
-                    MoveValue::U64(txn_max_gas_units.into()),
-                    MoveValue::U64(txn_expiration_timestamp_secs),
-                    MoveValue::U8(chain_id.id()),
-                    MoveValue::Bool(is_simulation),
-                ];
-                (
-                    &APTOS_TRANSACTION_VALIDATION.multi_agent_prologue_extended_name,
-                    args,
-                )
-            } else {
-                let args = vec![
-                    MoveValue::Signer(txn_data.sender),
-                    MoveValue::U64(txn_sequence_number),
-                    MoveValue::vector_u8(txn_authentication_key.unwrap_or_default()),
-                    MoveValue::vector_address(txn_data.secondary_signers()),
-                    MoveValue::Vector(secondary_auth_keys),
-                    MoveValue::U64(txn_gas_price.into()),
-                    MoveValue::U64(txn_max_gas_units.into()),
-                    MoveValue::U64(txn_expiration_timestamp_secs),
-                    MoveValue::U8(chain_id.id()),
-                ];
-                (
-                    &APTOS_TRANSACTION_VALIDATION.multi_agent_prologue_name,
-                    args,
-                )
-            }
+            let args = vec![
+                MoveValue::Signer(txn_data.sender),
+                MoveValue::U64(txn_sequence_number),
+                MoveValue::vector_u8(txn_authentication_key.unwrap_or_default()),
+                MoveValue::vector_address(txn_data.secondary_signers()),
+                MoveValue::Vector(secondary_auth_keys),
+                MoveValue::U64(txn_gas_price.into()),
+                MoveValue::U64(txn_max_gas_units.into()),
+                MoveValue::U64(txn_expiration_timestamp_secs),
+                MoveValue::U8(chain_id.id()),
+                MoveValue::Bool(is_simulation),
+            ];
+            (
+                &APTOS_TRANSACTION_VALIDATION.multi_agent_prologue_extended_name,
+                args,
+            )
         } else {
-            #[allow(clippy::collapsible_else_if)]
-            if features.is_transaction_simulation_enhancement_enabled() {
-                let args = vec![
-                    MoveValue::Signer(txn_data.sender),
-                    MoveValue::U64(txn_sequence_number),
-                    MoveValue::vector_u8(txn_authentication_key.unwrap_or_default()),
-                    MoveValue::U64(txn_gas_price.into()),
-                    MoveValue::U64(txn_max_gas_units.into()),
-                    MoveValue::U64(txn_expiration_timestamp_secs),
-                    MoveValue::U8(chain_id.id()),
-                    MoveValue::vector_u8(txn_data.script_hash.clone()),
-                    MoveValue::Bool(is_simulation),
-                ];
-                (
-                    &APTOS_TRANSACTION_VALIDATION.script_prologue_extended_name,
-                    args,
-                )
-            } else {
-                let args = vec![
-                    MoveValue::Signer(txn_data.sender),
-                    MoveValue::U64(txn_sequence_number),
-                    MoveValue::vector_u8(txn_authentication_key.unwrap_or_default()),
-                    MoveValue::U64(txn_gas_price.into()),
-                    MoveValue::U64(txn_max_gas_units.into()),
-                    MoveValue::U64(txn_expiration_timestamp_secs),
-                    MoveValue::U8(chain_id.id()),
-                    MoveValue::vector_u8(txn_data.script_hash.clone()),
-                ];
-                (&APTOS_TRANSACTION_VALIDATION.script_prologue_name, args)
-            }
+            let args = vec![
+                MoveValue::Signer(txn_data.sender),
+                MoveValue::U64(txn_sequence_number),
+                MoveValue::vector_u8(txn_authentication_key.unwrap_or_default()),
+                MoveValue::U64(txn_gas_price.into()),
+                MoveValue::U64(txn_max_gas_units.into()),
+                MoveValue::U64(txn_expiration_timestamp_secs),
+                MoveValue::U8(chain_id.id()),
+                MoveValue::vector_u8(txn_data.script_hash.clone()),
+                MoveValue::Bool(is_simulation),
+            ];
+            (
+                &APTOS_TRANSACTION_VALIDATION.script_prologue_extended_name,
+                args,
+            )
         };
 
         session
@@ -509,34 +451,19 @@ fn run_epilogue(
         // accepted it, in which case the gas payer feature is enabled.
         if let Some(fee_payer) = txn_data.fee_payer() {
             let (func_name, args) = {
-                if features.is_transaction_simulation_enhancement_enabled() {
-                    let args = vec![
-                        MoveValue::Signer(txn_data.sender),
-                        MoveValue::Address(fee_payer),
-                        MoveValue::U64(fee_statement.storage_fee_refund()),
-                        MoveValue::U64(txn_gas_price.into()),
-                        MoveValue::U64(txn_max_gas_units.into()),
-                        MoveValue::U64(gas_remaining.into()),
-                        MoveValue::Bool(is_simulation),
-                    ];
-                    (
-                        &APTOS_TRANSACTION_VALIDATION.user_epilogue_gas_payer_extended_name,
-                        args,
-                    )
-                } else {
-                    let args = vec![
-                        MoveValue::Signer(txn_data.sender),
-                        MoveValue::Address(fee_payer),
-                        MoveValue::U64(fee_statement.storage_fee_refund()),
-                        MoveValue::U64(txn_gas_price.into()),
-                        MoveValue::U64(txn_max_gas_units.into()),
-                        MoveValue::U64(gas_remaining.into()),
-                    ];
-                    (
-                        &APTOS_TRANSACTION_VALIDATION.user_epilogue_gas_payer_name,
-                        args,
-                    )
-                }
+                let args = vec![
+                    MoveValue::Signer(txn_data.sender),
+                    MoveValue::Address(fee_payer),
+                    MoveValue::U64(fee_statement.storage_fee_refund()),
+                    MoveValue::U64(txn_gas_price.into()),
+                    MoveValue::U64(txn_max_gas_units.into()),
+                    MoveValue::U64(gas_remaining.into()),
+                    MoveValue::Bool(is_simulation),
+                ];
+                (
+                    &APTOS_TRANSACTION_VALIDATION.user_epilogue_gas_payer_extended_name,
+                    args,
+                )
             };
             session.execute_function_bypass_visibility(
                 &APTOS_TRANSACTION_VALIDATION.module_id(),
@@ -550,29 +477,18 @@ fn run_epilogue(
         } else {
             // Regular tx, run the normal epilogue
             let (func_name, args) = {
-                if features.is_transaction_simulation_enhancement_enabled() {
-                    let args = vec![
-                        MoveValue::Signer(txn_data.sender),
-                        MoveValue::U64(fee_statement.storage_fee_refund()),
-                        MoveValue::U64(txn_gas_price.into()),
-                        MoveValue::U64(txn_max_gas_units.into()),
-                        MoveValue::U64(gas_remaining.into()),
-                        MoveValue::Bool(is_simulation),
-                    ];
-                    (
-                        &APTOS_TRANSACTION_VALIDATION.user_epilogue_extended_name,
-                        args,
-                    )
-                } else {
-                    let args = vec![
-                        MoveValue::Signer(txn_data.sender),
-                        MoveValue::U64(fee_statement.storage_fee_refund()),
-                        MoveValue::U64(txn_gas_price.into()),
-                        MoveValue::U64(txn_max_gas_units.into()),
-                        MoveValue::U64(gas_remaining.into()),
-                    ];
-                    (&APTOS_TRANSACTION_VALIDATION.user_epilogue_name, args)
-                }
+                let args = vec![
+                    MoveValue::Signer(txn_data.sender),
+                    MoveValue::U64(fee_statement.storage_fee_refund()),
+                    MoveValue::U64(txn_gas_price.into()),
+                    MoveValue::U64(txn_max_gas_units.into()),
+                    MoveValue::U64(gas_remaining.into()),
+                    MoveValue::Bool(is_simulation),
+                ];
+                (
+                    &APTOS_TRANSACTION_VALIDATION.user_epilogue_extended_name,
+                    args,
+                )
             };
             session.execute_function_bypass_visibility(
                 &APTOS_TRANSACTION_VALIDATION.module_id(),

--- a/aptos-move/aptos-vm/src/transaction_validation.rs
+++ b/aptos-move/aptos-vm/src/transaction_validation.rs
@@ -41,7 +41,6 @@ pub static APTOS_TRANSACTION_VALIDATION: Lazy<TransactionValidation> =
     Lazy::new(|| TransactionValidation {
         module_addr: CORE_CODE_ADDRESS,
         module_name: Identifier::new("transaction_validation").unwrap(),
-        user_epilogue_name: Identifier::new("epilogue").unwrap(),
         fee_payer_prologue_extended_name: Identifier::new("fee_payer_script_prologue_extended")
             .unwrap(),
         script_prologue_extended_name: Identifier::new("script_prologue_extended").unwrap(),
@@ -65,7 +64,6 @@ pub static APTOS_TRANSACTION_VALIDATION: Lazy<TransactionValidation> =
 pub struct TransactionValidation {
     pub module_addr: AccountAddress,
     pub module_name: Identifier,
-    pub user_epilogue_name: Identifier,
     pub fee_payer_prologue_extended_name: Identifier,
     pub script_prologue_extended_name: Identifier,
     pub multi_agent_prologue_extended_name: Identifier,
@@ -594,7 +592,7 @@ pub(crate) fn run_failure_epilogue(
     .or_else(|err| {
         expect_only_successful_execution(
             err,
-            APTOS_TRANSACTION_VALIDATION.user_epilogue_name.as_str(),
+            APTOS_TRANSACTION_VALIDATION.user_epilogue_extended_name.as_str(),
             log_context,
         )
     })

--- a/aptos-move/framework/aptos-framework/doc/transaction_validation.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_validation.md
@@ -16,16 +16,11 @@
 -  [Function `prologue_common`](#0x1_transaction_validation_prologue_common)
 -  [Function `check_for_replay_protection_regular_txn`](#0x1_transaction_validation_check_for_replay_protection_regular_txn)
 -  [Function `check_for_replay_protection_orderless_txn`](#0x1_transaction_validation_check_for_replay_protection_orderless_txn)
--  [Function `script_prologue`](#0x1_transaction_validation_script_prologue)
 -  [Function `script_prologue_extended`](#0x1_transaction_validation_script_prologue_extended)
--  [Function `multi_agent_script_prologue`](#0x1_transaction_validation_multi_agent_script_prologue)
 -  [Function `multi_agent_script_prologue_extended`](#0x1_transaction_validation_multi_agent_script_prologue_extended)
 -  [Function `multi_agent_common_prologue`](#0x1_transaction_validation_multi_agent_common_prologue)
--  [Function `fee_payer_script_prologue`](#0x1_transaction_validation_fee_payer_script_prologue)
 -  [Function `fee_payer_script_prologue_extended`](#0x1_transaction_validation_fee_payer_script_prologue_extended)
--  [Function `epilogue`](#0x1_transaction_validation_epilogue)
 -  [Function `epilogue_extended`](#0x1_transaction_validation_epilogue_extended)
--  [Function `epilogue_gas_payer`](#0x1_transaction_validation_epilogue_gas_payer)
 -  [Function `epilogue_gas_payer_extended`](#0x1_transaction_validation_epilogue_gas_payer_extended)
 -  [Function `skip_auth_key_check`](#0x1_transaction_validation_skip_auth_key_check)
 -  [Function `skip_gas_payment`](#0x1_transaction_validation_skip_gas_payment)
@@ -44,16 +39,11 @@
     -  [Function `prologue_common`](#@Specification_1_prologue_common)
     -  [Function `check_for_replay_protection_regular_txn`](#@Specification_1_check_for_replay_protection_regular_txn)
     -  [Function `check_for_replay_protection_orderless_txn`](#@Specification_1_check_for_replay_protection_orderless_txn)
-    -  [Function `script_prologue`](#@Specification_1_script_prologue)
     -  [Function `script_prologue_extended`](#@Specification_1_script_prologue_extended)
-    -  [Function `multi_agent_script_prologue`](#@Specification_1_multi_agent_script_prologue)
     -  [Function `multi_agent_script_prologue_extended`](#@Specification_1_multi_agent_script_prologue_extended)
     -  [Function `multi_agent_common_prologue`](#@Specification_1_multi_agent_common_prologue)
-    -  [Function `fee_payer_script_prologue`](#@Specification_1_fee_payer_script_prologue)
     -  [Function `fee_payer_script_prologue_extended`](#@Specification_1_fee_payer_script_prologue_extended)
-    -  [Function `epilogue`](#@Specification_1_epilogue)
     -  [Function `epilogue_extended`](#@Specification_1_epilogue_extended)
-    -  [Function `epilogue_gas_payer`](#@Specification_1_epilogue_gas_payer)
     -  [Function `epilogue_gas_payer_extended`](#@Specification_1_epilogue_gas_payer_extended)
     -  [Function `unified_prologue`](#@Specification_1_unified_prologue)
     -  [Function `unified_prologue_fee_payer`](#@Specification_1_unified_prologue_fee_payer)
@@ -714,50 +704,6 @@ Only called during genesis to initialize system resources for this module.
 
 </details>
 
-<a id="0x1_transaction_validation_script_prologue"></a>
-
-## Function `script_prologue`
-
-
-
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_script_prologue">script_prologue</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, _script_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_script_prologue">script_prologue</a>(
-    sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    txn_sequence_number: u64,
-    txn_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    txn_gas_price: u64,
-    txn_max_gas_units: u64,
-    txn_expiration_time: u64,
-    <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8,
-    _script_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-) {
-    // prologue_common <b>with</b> is_simulation set <b>to</b> <b>false</b> behaves identically <b>to</b> the original script_prologue function.
-    <a href="transaction_validation.md#0x1_transaction_validation_prologue_common">prologue_common</a>(
-        &sender,
-        &sender,
-        ReplayProtector::SequenceNumber(txn_sequence_number),
-        <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(txn_public_key),
-        txn_gas_price,
-        txn_max_gas_units,
-        txn_expiration_time,
-        <a href="chain_id.md#0x1_chain_id">chain_id</a>,
-        <b>false</b>,
-    )
-}
-</code></pre>
-
-
-
-</details>
-
 <a id="0x1_transaction_validation_script_prologue_extended"></a>
 
 ## Function `script_prologue_extended`
@@ -795,57 +741,6 @@ Only called during genesis to initialize system resources for this module.
         <a href="chain_id.md#0x1_chain_id">chain_id</a>,
         is_simulation,
     )
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_transaction_validation_multi_agent_script_prologue"></a>
-
-## Function `multi_agent_script_prologue`
-
-
-
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_multi_agent_script_prologue">multi_agent_script_prologue</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_sender_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, secondary_signer_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, secondary_signer_public_key_hashes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_multi_agent_script_prologue">multi_agent_script_prologue</a>(
-    sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    txn_sequence_number: u64,
-    txn_sender_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    secondary_signer_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;,
-    secondary_signer_public_key_hashes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
-    txn_gas_price: u64,
-    txn_max_gas_units: u64,
-    txn_expiration_time: u64,
-    <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8,
-) {
-    // prologue_common and multi_agent_common_prologue <b>with</b> is_simulation set <b>to</b> <b>false</b> behaves identically <b>to</b> the
-    // original multi_agent_script_prologue function.
-    <a href="transaction_validation.md#0x1_transaction_validation_prologue_common">prologue_common</a>(
-        &sender,
-        &sender,
-        ReplayProtector::SequenceNumber(txn_sequence_number),
-        <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(txn_sender_public_key),
-        txn_gas_price,
-        txn_max_gas_units,
-        txn_expiration_time,
-        <a href="chain_id.md#0x1_chain_id">chain_id</a>,
-        <b>false</b>,
-    );
-    <a href="transaction_validation.md#0x1_transaction_validation_multi_agent_common_prologue">multi_agent_common_prologue</a>(
-        secondary_signer_addresses,
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_map">vector::map</a>(secondary_signer_public_key_hashes, |x| <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(x)),
-        <b>false</b>
-    );
 }
 </code></pre>
 
@@ -983,64 +878,6 @@ Only called during genesis to initialize system resources for this module.
 
 </details>
 
-<a id="0x1_transaction_validation_fee_payer_script_prologue"></a>
-
-## Function `fee_payer_script_prologue`
-
-
-
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_fee_payer_script_prologue">fee_payer_script_prologue</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_sender_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, secondary_signer_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, secondary_signer_public_key_hashes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;, fee_payer_address: <b>address</b>, fee_payer_public_key_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_fee_payer_script_prologue">fee_payer_script_prologue</a>(
-    sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    txn_sequence_number: u64,
-    txn_sender_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    secondary_signer_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;,
-    secondary_signer_public_key_hashes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
-    fee_payer_address: <b>address</b>,
-    fee_payer_public_key_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    txn_gas_price: u64,
-    txn_max_gas_units: u64,
-    txn_expiration_time: u64,
-    <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8,
-) {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_fee_payer_enabled">features::fee_payer_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EFEE_PAYER_NOT_ENABLED">PROLOGUE_EFEE_PAYER_NOT_ENABLED</a>));
-    // prologue_common and multi_agent_common_prologue <b>with</b> is_simulation set <b>to</b> <b>false</b> behaves identically <b>to</b> the
-    // original fee_payer_script_prologue function.
-    <a href="transaction_validation.md#0x1_transaction_validation_prologue_common">prologue_common</a>(
-        &sender,
-        &<a href="create_signer.md#0x1_create_signer_create_signer">create_signer::create_signer</a>(fee_payer_address),
-        ReplayProtector::SequenceNumber(txn_sequence_number),
-        <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(txn_sender_public_key),
-        txn_gas_price,
-        txn_max_gas_units,
-        txn_expiration_time,
-        <a href="chain_id.md#0x1_chain_id">chain_id</a>,
-        <b>false</b>,
-    );
-    <a href="transaction_validation.md#0x1_transaction_validation_multi_agent_common_prologue">multi_agent_common_prologue</a>(
-        secondary_signer_addresses,
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_map">vector::map</a>(secondary_signer_public_key_hashes, |x| <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(x)),
-        <b>false</b>
-    );
-    <b>assert</b>!(
-        fee_payer_public_key_hash == <a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(fee_payer_address),
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>),
-    );
-}
-</code></pre>
-
-
-
-</details>
-
 <a id="0x1_transaction_validation_fee_payer_script_prologue_extended"></a>
 
 ## Function `fee_payer_script_prologue_extended`
@@ -1100,50 +937,12 @@ Only called during genesis to initialize system resources for this module.
 
 </details>
 
-<a id="0x1_transaction_validation_epilogue"></a>
-
-## Function `epilogue`
-
-Epilogue function is run after a transaction is successfully executed.
-Called by the Adapter
-
-
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_epilogue">epilogue</a>(<a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, storage_fee_refunded: u64, txn_gas_price: u64, txn_max_gas_units: u64, gas_units_remaining: u64)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_epilogue">epilogue</a>(
-    <a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    storage_fee_refunded: u64,
-    txn_gas_price: u64,
-    txn_max_gas_units: u64,
-    gas_units_remaining: u64,
-) {
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&<a href="account.md#0x1_account">account</a>);
-    <a href="transaction_validation.md#0x1_transaction_validation_epilogue_gas_payer">epilogue_gas_payer</a>(
-        <a href="account.md#0x1_account">account</a>,
-        addr,
-        storage_fee_refunded,
-        txn_gas_price,
-        txn_max_gas_units,
-        gas_units_remaining
-    );
-}
-</code></pre>
-
-
-
-</details>
-
 <a id="0x1_transaction_validation_epilogue_extended"></a>
 
 ## Function `epilogue_extended`
 
+Epilogue function is run after a transaction is successfully executed.
+Called by the Adapter
 
 
 <pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_epilogue_extended">epilogue_extended</a>(<a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, storage_fee_refunded: u64, txn_gas_price: u64, txn_max_gas_units: u64, gas_units_remaining: u64, is_simulation: bool)
@@ -1180,53 +979,12 @@ Called by the Adapter
 
 </details>
 
-<a id="0x1_transaction_validation_epilogue_gas_payer"></a>
-
-## Function `epilogue_gas_payer`
-
-Epilogue function with explicit gas payer specified, is run after a transaction is successfully executed.
-Called by the Adapter
-
-
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_epilogue_gas_payer">epilogue_gas_payer</a>(<a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, gas_payer: <b>address</b>, storage_fee_refunded: u64, txn_gas_price: u64, txn_max_gas_units: u64, gas_units_remaining: u64)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_epilogue_gas_payer">epilogue_gas_payer</a>(
-    <a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    gas_payer: <b>address</b>,
-    storage_fee_refunded: u64,
-    txn_gas_price: u64,
-    txn_max_gas_units: u64,
-    gas_units_remaining: u64
-) {
-    // epilogue_gas_payer_extended <b>with</b> is_simulation set <b>to</b> <b>false</b> behaves identically <b>to</b> the original
-    // epilogue_gas_payer function.
-    <a href="transaction_validation.md#0x1_transaction_validation_epilogue_gas_payer_extended">epilogue_gas_payer_extended</a>(
-        <a href="account.md#0x1_account">account</a>,
-        gas_payer,
-        storage_fee_refunded,
-        txn_gas_price,
-        txn_max_gas_units,
-        gas_units_remaining,
-        <b>false</b>,
-    );
-}
-</code></pre>
-
-
-
-</details>
-
 <a id="0x1_transaction_validation_epilogue_gas_payer_extended"></a>
 
 ## Function `epilogue_gas_payer_extended`
 
+Epilogue function with explicit gas payer specified, is run after a transaction is successfully executed.
+Called by the Adapter
 
 
 <pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_epilogue_gas_payer_extended">epilogue_gas_payer_extended</a>(<a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, gas_payer: <b>address</b>, storage_fee_refunded: u64, txn_gas_price: u64, txn_max_gas_units: u64, gas_units_remaining: u64, is_simulation: bool)
@@ -1881,18 +1639,23 @@ Give some constraints that may abort according to the conditions.
 
 
 
-<a id="@Specification_1_script_prologue"></a>
+<a id="@Specification_1_script_prologue_extended"></a>
 
-### Function `script_prologue`
+### Function `script_prologue_extended`
 
 
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_script_prologue">script_prologue</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, _script_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_script_prologue_extended">script_prologue_extended</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, _script_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, is_simulation: bool)
 </code></pre>
 
 
 
 
 <pre><code><b>pragma</b> verify = <b>false</b>;
+<b>include</b> <a href="transaction_validation.md#0x1_transaction_validation_PrologueCommonAbortsIf">PrologueCommonAbortsIf</a> {
+    gas_payer: sender,
+    txn_authentication_key: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_spec_some">option::spec_some</a>(txn_public_key),
+    replay_protector: ReplayProtector::SequenceNumber(txn_sequence_number),
+};
 </code></pre>
 
 
@@ -1940,43 +1703,6 @@ Give some constraints that may abort according to the conditions.
 
 
 
-<a id="@Specification_1_script_prologue_extended"></a>
-
-### Function `script_prologue_extended`
-
-
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_script_prologue_extended">script_prologue_extended</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, _script_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, is_simulation: bool)
-</code></pre>
-
-
-
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
-<b>include</b> <a href="transaction_validation.md#0x1_transaction_validation_PrologueCommonAbortsIf">PrologueCommonAbortsIf</a> {
-    gas_payer: sender,
-    txn_authentication_key: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_spec_some">option::spec_some</a>(txn_public_key),
-    replay_protector: ReplayProtector::SequenceNumber(txn_sequence_number),
-};
-</code></pre>
-
-
-
-<a id="@Specification_1_multi_agent_script_prologue"></a>
-
-### Function `multi_agent_script_prologue`
-
-
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_multi_agent_script_prologue">multi_agent_script_prologue</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_sender_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, secondary_signer_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, secondary_signer_public_key_hashes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8)
-</code></pre>
-
-
-
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
-</code></pre>
-
-
-
 <a id="@Specification_1_multi_agent_script_prologue_extended"></a>
 
 ### Function `multi_agent_script_prologue_extended`
@@ -2013,22 +1739,6 @@ not equal the number of singers.
 
 
 
-<a id="@Specification_1_fee_payer_script_prologue"></a>
-
-### Function `fee_payer_script_prologue`
-
-
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_fee_payer_script_prologue">fee_payer_script_prologue</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_sender_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, secondary_signer_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, secondary_signer_public_key_hashes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;, fee_payer_address: <b>address</b>, fee_payer_public_key_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8)
-</code></pre>
-
-
-
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
-</code></pre>
-
-
-
 <a id="@Specification_1_fee_payer_script_prologue_extended"></a>
 
 ### Function `fee_payer_script_prologue_extended`
@@ -2056,22 +1766,6 @@ not equal the number of singers.
 
 
 
-<a id="@Specification_1_epilogue"></a>
-
-### Function `epilogue`
-
-
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_epilogue">epilogue</a>(<a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, storage_fee_refunded: u64, txn_gas_price: u64, txn_max_gas_units: u64, gas_units_remaining: u64)
-</code></pre>
-
-
-
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
-</code></pre>
-
-
-
 <a id="@Specification_1_epilogue_extended"></a>
 
 ### Function `epilogue_extended`
@@ -2088,22 +1782,6 @@ Skip transaction_fee::burn_fee verification.
 
 <pre><code><b>pragma</b> verify = <b>false</b>;
 <b>include</b> <a href="transaction_validation.md#0x1_transaction_validation_EpilogueGasPayerAbortsIf">EpilogueGasPayerAbortsIf</a> { gas_payer: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>) };
-</code></pre>
-
-
-
-<a id="@Specification_1_epilogue_gas_payer"></a>
-
-### Function `epilogue_gas_payer`
-
-
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_epilogue_gas_payer">epilogue_gas_payer</a>(<a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, gas_payer: <b>address</b>, storage_fee_refunded: u64, txn_gas_price: u64, txn_max_gas_units: u64, gas_units_remaining: u64)
-</code></pre>
-
-
-
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.move
@@ -262,33 +262,6 @@ module aptos_framework::transaction_validation {
         assert!(nonce_validation::check_and_insert_nonce(sender, nonce, txn_expiration_time), error::invalid_argument(PROLOGUE_ENONCE_ALREADY_USED));
     }
 
-    fun script_prologue(
-        sender: signer,
-        txn_sequence_number: u64,
-        txn_public_key: vector<u8>,
-        txn_gas_price: u64,
-        txn_max_gas_units: u64,
-        txn_expiration_time: u64,
-        chain_id: u8,
-        _script_hash: vector<u8>,
-    ) {
-        // prologue_common with is_simulation set to false behaves identically to the original script_prologue function.
-        prologue_common(
-            &sender,
-            &sender,
-            ReplayProtector::SequenceNumber(txn_sequence_number),
-            option::some(txn_public_key),
-            txn_gas_price,
-            txn_max_gas_units,
-            txn_expiration_time,
-            chain_id,
-            false,
-        )
-    }
-
-    // This function extends the script_prologue by adding a parameter to indicate simulation mode.
-    // Once the transaction_simulation_enhancement feature is enabled, the Aptos VM will invoke this function instead.
-    // Eventually, this function will be consolidated with the original function once the feature is fully enabled.
     fun script_prologue_extended(
         sender: signer,
         txn_sequence_number: u64,
@@ -313,40 +286,6 @@ module aptos_framework::transaction_validation {
         )
     }
 
-    fun multi_agent_script_prologue(
-        sender: signer,
-        txn_sequence_number: u64,
-        txn_sender_public_key: vector<u8>,
-        secondary_signer_addresses: vector<address>,
-        secondary_signer_public_key_hashes: vector<vector<u8>>,
-        txn_gas_price: u64,
-        txn_max_gas_units: u64,
-        txn_expiration_time: u64,
-        chain_id: u8,
-    ) {
-        // prologue_common and multi_agent_common_prologue with is_simulation set to false behaves identically to the
-        // original multi_agent_script_prologue function.
-        prologue_common(
-            &sender,
-            &sender,
-            ReplayProtector::SequenceNumber(txn_sequence_number),
-            option::some(txn_sender_public_key),
-            txn_gas_price,
-            txn_max_gas_units,
-            txn_expiration_time,
-            chain_id,
-            false,
-        );
-        multi_agent_common_prologue(
-            secondary_signer_addresses,
-            vector::map(secondary_signer_public_key_hashes, |x| option::some(x)),
-            false
-        );
-    }
-
-    // This function extends the multi_agent_script_prologue by adding a parameter to indicate simulation mode.
-    // Once the transaction_simulation_enhancement feature is enabled, the Aptos VM will invoke this function instead.
-    // Eventually, this function will be consolidated with the original function once the feature is fully enabled.
     fun multi_agent_script_prologue_extended(
         sender: signer,
         txn_sequence_number: u64,
@@ -437,47 +376,6 @@ module aptos_framework::transaction_validation {
         }
     }
 
-    fun fee_payer_script_prologue(
-        sender: signer,
-        txn_sequence_number: u64,
-        txn_sender_public_key: vector<u8>,
-        secondary_signer_addresses: vector<address>,
-        secondary_signer_public_key_hashes: vector<vector<u8>>,
-        fee_payer_address: address,
-        fee_payer_public_key_hash: vector<u8>,
-        txn_gas_price: u64,
-        txn_max_gas_units: u64,
-        txn_expiration_time: u64,
-        chain_id: u8,
-    ) {
-        assert!(features::fee_payer_enabled(), error::invalid_state(PROLOGUE_EFEE_PAYER_NOT_ENABLED));
-        // prologue_common and multi_agent_common_prologue with is_simulation set to false behaves identically to the
-        // original fee_payer_script_prologue function.
-        prologue_common(
-            &sender,
-            &create_signer::create_signer(fee_payer_address),
-            ReplayProtector::SequenceNumber(txn_sequence_number),
-            option::some(txn_sender_public_key),
-            txn_gas_price,
-            txn_max_gas_units,
-            txn_expiration_time,
-            chain_id,
-            false,
-        );
-        multi_agent_common_prologue(
-            secondary_signer_addresses,
-            vector::map(secondary_signer_public_key_hashes, |x| option::some(x)),
-            false
-        );
-        assert!(
-            fee_payer_public_key_hash == account::get_authentication_key(fee_payer_address),
-            error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY),
-        );
-    }
-
-    // This function extends the fee_payer_script_prologue by adding a parameter to indicate simulation mode.
-    // Once the transaction_simulation_enhancement feature is enabled, the Aptos VM will invoke this function instead.
-    // Eventually, this function will be consolidated with the original function once the feature is fully enabled.
     fun fee_payer_script_prologue_extended(
         sender: signer,
         txn_sequence_number: u64,
@@ -519,27 +417,6 @@ module aptos_framework::transaction_validation {
 
     /// Epilogue function is run after a transaction is successfully executed.
     /// Called by the Adapter
-    fun epilogue(
-        account: signer,
-        storage_fee_refunded: u64,
-        txn_gas_price: u64,
-        txn_max_gas_units: u64,
-        gas_units_remaining: u64,
-    ) {
-        let addr = signer::address_of(&account);
-        epilogue_gas_payer(
-            account,
-            addr,
-            storage_fee_refunded,
-            txn_gas_price,
-            txn_max_gas_units,
-            gas_units_remaining
-        );
-    }
-
-    // This function extends the epilogue by adding a parameter to indicate simulation mode.
-    // Once the transaction_simulation_enhancement feature is enabled, the Aptos VM will invoke this function instead.
-    // Eventually, this function will be consolidated with the original function once the feature is fully enabled.
     fun epilogue_extended(
         account: signer,
         storage_fee_refunded: u64,
@@ -562,30 +439,6 @@ module aptos_framework::transaction_validation {
 
     /// Epilogue function with explicit gas payer specified, is run after a transaction is successfully executed.
     /// Called by the Adapter
-    fun epilogue_gas_payer(
-        account: signer,
-        gas_payer: address,
-        storage_fee_refunded: u64,
-        txn_gas_price: u64,
-        txn_max_gas_units: u64,
-        gas_units_remaining: u64
-    ) {
-        // epilogue_gas_payer_extended with is_simulation set to false behaves identically to the original
-        // epilogue_gas_payer function.
-        epilogue_gas_payer_extended(
-            account,
-            gas_payer,
-            storage_fee_refunded,
-            txn_gas_price,
-            txn_max_gas_units,
-            gas_units_remaining,
-            false,
-        );
-    }
-
-    // This function extends the epilogue_gas_payer by adding a parameter to indicate simulation mode.
-    // Once the transaction_simulation_enhancement feature is enabled, the Aptos VM will invoke this function instead.
-    // Eventually, this function will be consolidated with the original function once the feature is fully enabled.
     fun epilogue_gas_payer_extended(
         account: signer,
         gas_payer: address,

--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.spec.move
@@ -132,20 +132,6 @@ spec aptos_framework::transaction_validation {
         };
     }
 
-    spec script_prologue(
-        sender: signer,
-        txn_sequence_number: u64,
-        txn_public_key: vector<u8>,
-        txn_gas_price: u64,
-        txn_max_gas_units: u64,
-        txn_expiration_time: u64,
-        chain_id: u8,
-        _script_hash: vector<u8>,
-    ) {
-        // TODO: temporary mockup
-        pragma verify = false;
-    }
-
     spec schema MultiAgentPrologueCommonAbortsIf {
         secondary_signer_addresses: vector<address>;
         secondary_signer_public_key_hashes: vector<Option<vector<u8>>>;
@@ -224,21 +210,6 @@ spec aptos_framework::transaction_validation {
         // };
     }
 
-    spec multi_agent_script_prologue(
-        sender: signer,
-        txn_sequence_number: u64,
-        txn_sender_public_key: vector<u8>,
-        secondary_signer_addresses: vector<address>,
-        secondary_signer_public_key_hashes: vector<vector<u8>>,
-        txn_gas_price: u64,
-        txn_max_gas_units: u64,
-        txn_expiration_time: u64,
-        chain_id: u8,
-    ) {
-        // TODO: temporary mockup
-        pragma verify = false;
-    }
-
     spec fee_payer_script_prologue_extended(
         sender: signer,
         txn_sequence_number: u64,
@@ -274,23 +245,6 @@ spec aptos_framework::transaction_validation {
         aborts_if !features::spec_fee_payer_enabled();
     }
 
-    spec fee_payer_script_prologue(
-        sender: signer,
-        txn_sequence_number: u64,
-        txn_sender_public_key: vector<u8>,
-        secondary_signer_addresses: vector<address>,
-        secondary_signer_public_key_hashes: vector<vector<u8>>,
-        fee_payer_address: address,
-        fee_payer_public_key_hash: vector<u8>,
-        txn_gas_price: u64,
-        txn_max_gas_units: u64,
-        txn_expiration_time: u64,
-        chain_id: u8,
-    ) {
-        // TODO: temporary mockup
-        pragma verify = false;
-    }
-
     /// Abort according to the conditions.
     /// `AptosCoinCapabilities` and `CoinInfo` should exists.
     /// Skip transaction_fee::burn_fee verification.
@@ -305,17 +259,6 @@ spec aptos_framework::transaction_validation {
         // TODO(fa_migration)
         pragma verify = false;
         include EpilogueGasPayerAbortsIf { gas_payer: signer::address_of(account) };
-    }
-
-    spec epilogue(
-        account: signer,
-        storage_fee_refunded: u64,
-        txn_gas_price: u64,
-        txn_max_gas_units: u64,
-        gas_units_remaining: u64,
-    ) {
-        // TODO: temporary mockup
-        pragma verify = false;
     }
 
     /// Abort according to the conditions.
@@ -333,18 +276,6 @@ spec aptos_framework::transaction_validation {
         // TODO(fa_migration)
         pragma verify = false;
         include EpilogueGasPayerAbortsIf;
-    }
-
-    spec epilogue_gas_payer(
-        account: signer,
-        gas_payer: address,
-        storage_fee_refunded: u64,
-        txn_gas_price: u64,
-        txn_max_gas_units: u64,
-        gas_units_remaining: u64,
-    ) {
-        // TODO: temporary mockup
-        pragma verify = false;
     }
 
     spec unified_prologue(


### PR DESCRIPTION
## Description
The TRANSACTION_SIMULATION_ENHANCEMENT is enabled on mainnet and there is no reason to disable it. Remove the code paths from 

## How Has This Been Tested?
```
RUST_MIN_STACK=134217728 cargo test -p e2e-move-tests
RUST_MIN_STACK=134217728 cargo test -p aptos-vm
```

## Key Areas to Review
- aptos framework/vm

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/movementlabsxyz/codesmith/aptos-core/pr/403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787482790&installation_model_id=17568&pr_number=403&repository=movementlabsxyz%2Faptos-core&return_to=https%3A%2F%2Fgithub.com%2Fmovementlabsxyz%2Faptos-core%2Fpull%2F403&signature=d4e18af20a1cac95ead4f6893905cead96efa350f9d9250521b367568e1b218f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->