### PR TITLE
chore: point GitHub org references at movement-network

### DIFF
--- a/.github/workflows/build-versions.yaml
+++ b/.github/workflows/build-versions.yaml
@@ -90,7 +90,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha}}
       - name: Build binary ${{ matrix.binary.package }}
-        uses: movementlabsxyz/aptos-core/.github/actions/build-binary@m1
+        uses: movement-network/aptos-core/.github/actions/build-binary@m1
         with:
           binary_package: ${{ matrix.binary.package }}
           profile: ${{ needs.setup.outputs.build_profile }}
@@ -132,9 +132,9 @@ jobs:
         run: ls -la ${{ env.TARGET_FOLDER }}
         
       - name: Build Container
-        uses: movementlabsxyz/aptos-core/.github/actions/build-container@m1
+        uses: movement-network/aptos-core/.github/actions/build-container@m1
         with:
-          image_name: ghcr.io/movementlabsxyz/aptos-node
+          image_name: ghcr.io/movement-network/aptos-node
           dockerfile_subdir: aptos-node
           build_args: |
             BINARY_PATH=${{ env.TARGET_FOLDER }}
@@ -170,9 +170,9 @@ jobs:
       - name: List binaries
         run: ls -la ${{ env.TARGET_FOLDER }}
       - name: Build Container
-        uses: movementlabsxyz/aptos-core/.github/actions/build-container@m1
+        uses: movement-network/aptos-core/.github/actions/build-container@m1
         with:
-          image_name: ghcr.io/movementlabsxyz/aptos-debugger
+          image_name: ghcr.io/movement-network/aptos-debugger
           dockerfile_subdir: aptos-debugger
           build_args: |
             BINARY_PATH=${{ env.TARGET_FOLDER }}
@@ -200,7 +200,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha}}
       - name: Build binary ${{ matrix.binary.package }}
-        uses: movementlabsxyz/aptos-core/.github/actions/build-binary@m1
+        uses: movement-network/aptos-core/.github/actions/build-binary@m1
         with:
           binary_package: ${{ matrix.binary.package }}
           profile: ${{ needs.setup.outputs.build_profile }}
@@ -232,9 +232,9 @@ jobs:
         run: ls -la ${{ env.TARGET_FOLDER }}
         
       - name: Build Container
-        uses: movementlabsxyz/aptos-core/.github/actions/build-container@m1
+        uses: movement-network/aptos-core/.github/actions/build-container@m1
         with:
-          image_name: ghcr.io/movementlabsxyz/aptos-faucet-service
+          image_name: ghcr.io/movement-network/aptos-faucet-service
           dockerfile_subdir: aptos-faucet-service
           build_args: |
             BINARY_PATH=${{ env.TARGET_FOLDER }}
@@ -262,7 +262,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha}}
       - name: Build binary ${{ matrix.binary.package }}
-        uses: movementlabsxyz/aptos-core/.github/actions/build-binary@m1
+        uses: movement-network/aptos-core/.github/actions/build-binary@m1
         with:
           binary_package: ${{ matrix.binary.package }}
           profile: ${{ needs.setup.outputs.build_profile }}

--- a/.github/workflows/claude-audit-pr.yml
+++ b/.github/workflows/claude-audit-pr.yml
@@ -13,7 +13,7 @@ name: Claude Audit PR
 # because that would expose repository secrets to untrusted code.
 #
 # Audit *content* (subagent definition, analyzers, prompt, settings) lives in
-# movementlabsxyz/claude-pr-reviewer and is checked out + staged at runtime.
+# movement-network/claude-pr-reviewer and is checked out + staged at runtime.
 # Bump REVIEWER_REF below to upgrade. See that repo's README for the consumer
 # contract.
 
@@ -43,7 +43,7 @@ concurrency:
 env:
   # Pin to a tag (e.g. v1, v0.1.0) or an immutable SHA. Rolling tags pick up
   # patches automatically; SHAs require a bump PR but are tamper-evident.
-  REVIEWER_REPO: movementlabsxyz/claude-pr-reviewer
+  REVIEWER_REPO: movement-network/claude-pr-reviewer
   REVIEWER_REF: v1
 
 jobs:

--- a/.github/workflows/publish-builder-images.yaml
+++ b/.github/workflows/publish-builder-images.yaml
@@ -30,7 +30,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAMESPACE: ghcr.io/movementlabsxyz
+  IMAGE_NAMESPACE: ghcr.io/movement-network
   DEBIAN_CONTEXT: docker-image://debian:bullseye@sha256:cf48c31af360e1c0a0aedd33aae4d928b68c2cdf093f1612650eb1ff434d1c34
   PROFILE: release
   FEATURES: ""

--- a/Justfile
+++ b/Justfile
@@ -110,14 +110,14 @@ container-build container="aptos-node" tag="latest" profile="release":
     docker build \
         --build-arg BINARY_PATH="$BINARY_PATH" \
         -f docker/{{container}}/Dockerfile \
-        -t ghcr.io/movementlabsxyz/{{container}}:{{tag}} .
+        -t ghcr.io/movement-network/{{container}}:{{tag}} .
     
     # Clean up the copied binary
     rm -f aptos-test
 
 # Push a container image to GHCR
 container-push container="aptos-node" tag="latest":
-    docker push ghcr.io/movementlabsxyz/{{container}}:{{tag}}
+    docker push ghcr.io/movement-network/{{container}}:{{tag}}
 
 # Build and push a container image
 container-release container="aptos-node" tag="latest" profile="release":

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -6,8 +6,8 @@ proposals:
     metadata:
       title: "Disable concurrent fungible balance"
       description: "This is for disabling concurrent fungible balance"
-      source_code_url: "https://github.com/movementlabsxyz/aptos-core"
-      discussion_url: "https://github.com/movementlabsxyz/aptos-core"
+      source_code_url: "https://github.com/movement-network/aptos-core"
+      discussion_url: "https://github.com/movement-network/aptos-core"
     execution_mode: RootSigner
     update_sequence:
       - Framework:

--- a/aptos-move/aptos-release-builder/src/components/framework.rs
+++ b/aptos-move/aptos-release-builder/src/components/framework.rs
@@ -30,7 +30,7 @@ pub fn generate_upgrade_proposals(
         "only multi-step proposals can have a next execution hash"
     );
 
-    const MVT_APTOS_GIT_PATH: &str = "https://github.com/movementlabsxyz/aptos-core.git";
+    const MVT_APTOS_GIT_PATH: &str = "https://github.com/movement-network/aptos-core.git";
 
     // NOTE: This is skipping 0x7 (aptos-experimental package) which is only meant to be released
     // to devnet (or local testnet) via the genesis process and never released/upgraded in testnet

--- a/consensus/consensus-types/src/pipelined_block.rs
+++ b/consensus/consensus-types/src/pipelined_block.rs
@@ -349,7 +349,7 @@ impl PipelinedBlock {
     //   https://github.com/aptos-labs/aptos-core/pull/18699  (upstream optimization that introduced the cycle)
     //   https://github.com/aptos-labs/aptos-core/pull/19359  (corrective patch)
     //   https://github.com/aptos-labs/aptos-core/commit/fefcfade3edf26f0396d63963f7ea04364f3666f
-    //   https://github.com/movementlabsxyz/aptos-core/pull/322  (full analysis with diagrams)
+    //   https://github.com/movement-network/aptos-core/pull/322  (full analysis with diagrams)
     //
     // If a similar change is ever introduced here — anything that makes
     // rand aggregation wait on a pipeline-derived future — this function

--- a/crates/aptos/homebrew/README.md
+++ b/crates/aptos/homebrew/README.md
@@ -3,7 +3,7 @@
 Homebrew is a package manager that works for MacOS Silicon and Intel chips as well as Linux distributions like Debian
 and Ubuntu.
 
-The [Movement command line interface (CLI)](https://github.com/movementlabsxyz/aptos-core/) may be installed
+The [Movement command line interface (CLI)](https://github.com/movement-network/aptos-core/) may be installed
 via [Homebrew](https://brew.sh/) for simplicity. This is an in-depth overview of Homebrew and the Movement formula. In this
 guide, we go over each section of the Homebrew formula and steps to implement changes in the future.
 

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -207,7 +207,7 @@ impl FrameworkPackageArgs {
         prompt_options: PromptOptions,
     ) -> CliTypedResult<()> {
         const APTOS_FRAMEWORK: &str = "AptosFramework";
-        const APTOS_GIT_PATH: &str = "https://github.com/movementlabsxyz/aptos-core.git";
+        const APTOS_GIT_PATH: &str = "https://github.com/movement-network/aptos-core.git";
         const SUBDIR_PATH: &str = "aptos-move/framework/aptos-framework";
         const DEFAULT_BRANCH: &str = "m1";
 

--- a/devtools/aptos-cargo-cli/src/common.rs
+++ b/devtools/aptos-cargo-cli/src/common.rs
@@ -375,7 +375,7 @@ fn recompute_merge_base_metadata(
         .arg("clone")
         .arg("--depth")
         .arg("500") // Clone the last 500 commits to ensure the merge base is included
-        .arg("https://github.com/movementlabsxyz/aptos-core.git")
+        .arg("https://github.com/movement-network/aptos-core.git")
         .arg(clone_directory.clone())
         .output()
         .expect("failed to execute git clone");

--- a/docker/aptos-debugger/README.md
+++ b/docker/aptos-debugger/README.md
@@ -24,7 +24,7 @@ From the repository root:
 just container-build aptos-debugger latest release
 
 # Verify
-docker run --rm ghcr.io/movementlabsxyz/aptos-debugger:latest --version
+docker run --rm ghcr.io/movement-network/aptos-debugger:latest --version
 ```
 
 ## Pushing to GHCR
@@ -34,14 +34,14 @@ docker run --rm ghcr.io/movementlabsxyz/aptos-debugger:latest --version
 docker login ghcr.io -u <username>
 
 # Push
-docker push ghcr.io/movementlabsxyz/aptos-debugger:latest
+docker push ghcr.io/movement-network/aptos-debugger:latest
 ```
 
 ## CI
 
 The `build-versions.yaml` workflow automatically builds and pushes this image on
 every push to the default branch. The image is tagged with the short git SHA
-(e.g., `ghcr.io/movementlabsxyz/aptos-debugger:f24a5bc`).
+(e.g., `ghcr.io/movement-network/aptos-debugger:f24a5bc`).
 
 ## Runtime Dependencies
 

--- a/movement-migration/framework-upgrades/Move.toml
+++ b/movement-migration/framework-upgrades/Move.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 admin = "0x1"
 
 [dependencies.AptosFramework]
-git = "https://github.com/movementlabsxyz/aptos-core.git"
+git = "https://github.com/movement-network/aptos-core.git"
 rev = "movement"
 subdir = "aptos-move/framework/aptos-framework"

--- a/movement-migration/post-migration/Move.toml
+++ b/movement-migration/post-migration/Move.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 admin = "0x1"
 
 [dependencies.AptosFramework]
-git = "https://github.com/movementlabsxyz/aptos-core.git"
+git = "https://github.com/movement-network/aptos-core.git"
 rev = "l1-migration"
 subdir = "aptos-move/framework/aptos-framework"

--- a/movement-migration/post-move2-upgrade/Move.toml
+++ b/movement-migration/post-move2-upgrade/Move.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 admin = "0x1"
 
 [dependencies.AptosFramework]
-git = "https://github.com/movementlabsxyz/aptos-core.git"
+git = "https://github.com/movement-network/aptos-core.git"
 rev = "l1-migration"
 subdir = "aptos-move/framework/aptos-framework"

--- a/movement-migration/test-proposal/Move.toml
+++ b/movement-migration/test-proposal/Move.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 admin = "0x1"
 
 [dependencies.AptosFramework]
-git = "https://github.com/movementlabsxyz/aptos-core.git"
+git = "https://github.com/movement-network/aptos-core.git"
 rev = "l1-migration"
 subdir = "aptos-move/framework/aptos-framework"

--- a/movement-migration/update_reconfiguration/Move.toml
+++ b/movement-migration/update_reconfiguration/Move.toml
@@ -3,6 +3,6 @@ name = "UpdateReconfiguration"
 version = "0.0.0"
 
 [dependencies.AptosFramework]
-git = "https://github.com/movementlabsxyz/aptos-core.git"
+git = "https://github.com/movement-network/aptos-core.git"
 rev = "movement"
 subdir = "aptos-move/framework/aptos-framework"

--- a/movement-migration/update_recurring_lockup_duration/Move.toml
+++ b/movement-migration/update_recurring_lockup_duration/Move.toml
@@ -8,7 +8,7 @@ authors = []
 [dev-addresses]
 
 [dependencies.AptosFramework]
-git = "https://github.com/movementlabsxyz/aptos-core.git"
+git = "https://github.com/movement-network/aptos-core.git"
 rev = "l1-migration"
 subdir = "aptos-move/framework/aptos-framework"
 

--- a/proposals/2026-04-08-disable-feature-67/metadata/disable_concurrent_fungible_balance.json
+++ b/proposals/2026-04-08-disable-feature-67/metadata/disable_concurrent_fungible_balance.json
@@ -1,6 +1,6 @@
 {
   "title": "Disable concurrent fungible balance",
   "description": "This is for disabling concurrent fungible balance",
-  "source_code_url": "https://github.com/movementlabsxyz/aptos-core",
-  "discussion_url": "https://github.com/movementlabsxyz/aptos-core"
+  "source_code_url": "https://github.com/movement-network/aptos-core",
+  "discussion_url": "https://github.com/movement-network/aptos-core"
 }

--- a/scripts/cli/build_cli_release.sh
+++ b/scripts/cli/build_cli_release.sh
@@ -44,7 +44,7 @@ if [[ "$SKIP_CHECKS" != "true" ]]; then
   fi
 
   # Check that the release doesn't already exist
-  if curl -s --stderr /dev/null --output /dev/null --head -f "https://github.com/movementlabsxyz/aptos-core/releases/download/movement-cli-v$EXPECTED_VERSION/movement-cli-$EXPECTED_VERSION-Linux-x86_64.zip"; then
+  if curl -s --stderr /dev/null --output /dev/null --head -f "https://github.com/movement-network/aptos-core/releases/download/movement-cli-v$EXPECTED_VERSION/movement-cli-$EXPECTED_VERSION-Linux-x86_64.zip"; then
     echo "$EXPECTED_VERSION already released"
     exit 3
   fi


### PR DESCRIPTION
> [!IMPORTANT]
> **Hold — merge and promote at the time of switching the repos to the `movement-network` org.** The `move init` template, migration-package deps, and CI `uses:`/`ghcr.io` references resolve against the new org name, so this lands with the rename.

## Summary

The `movementlabsxyz` GitHub org is being renamed to `movement-network`. This swaps the org name across all 33 references (19 files):

- **`crates/aptos/src/move_tool/mod.rs`** — `APTOS_GIT_PATH`, the constant `move init` writes into generated `Move.toml` files, so newly scaffolded packages depend on the new org.
- **`aptos-move/aptos-release-builder/src/components/framework.rs`** — `MVT_APTOS_GIT_PATH`, plus `data/release.yaml` source/discussion URLs.
- **`movement-migration/*/Move.toml`** (6 packages) — `AptosFramework` git deps.
- **CI/tooling** — workflow `uses: .../aptos-core/.github/actions/...` refs, `ghcr.io` image namespaces (`build-versions.yaml`, `publish-builder-images.yaml`, `Justfile`), the PR-audit reviewer repo ref, and `scripts/cli/build_cli_release.sh` release-URL check.
- **Docs/metadata** — homebrew README, aptos-debugger README, a source-citation comment, and proposal metadata URLs.

## Verification

- String/config-only diff (constants, comments, YAML/TOML/JSON/docs); no logic touched. `git grep movementlabsxyz` returns zero hits after the change.
- `cargo check` not run — the three touched `.rs` lines are string literals inside existing constants/comments; say the word if you want a workspace check run anyway.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/movementlabsxyz/codesmith/aptos-core/pr/405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787967748&installation_model_id=17568&pr_number=405&repository=movementlabsxyz%2Faptos-core&return_to=https%3A%2F%2Fgithub.com%2Fmovementlabsxyz%2Faptos-core%2Fpull%2F405&signature=b3fda50eb7f3034611584c937635e5e1a0f019e757806862a8b8f626e6ca8ffd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->