### PR TITLE
fix: enforce type depth/size limits on PackClosure function types

### DIFF
--- a/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
@@ -108,11 +108,12 @@ pub fn verify_pack_closure(
         .iter()
         .map(|ret| with_owned_instantiation(ty_builder, func, ret, Ok))
         .collect::<PartialVMResult<Vec<_>>>()?;
-    operand_stack.push_ty(Type::Function {
-        args,
-        results,
-        abilities,
-    })?;
+    let function_ty = ty_builder
+        .create_function_ty(args, results, abilities)
+        .map_err(|e| {
+            e.append_message_with_separator('.', "Failed to pack closure: function type exceeds depth/size limits".to_string())
+        })?;
+    operand_stack.push_ty(function_ty)?;
 
     Ok(())
 }

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -1018,6 +1018,48 @@ impl TypeBuilder {
         })
     }
 
+    /// Creates a function type from the given argument and result types.
+    /// The function-type node itself is counted towards type size and depth limits,
+    /// with arguments and results treated as its children at depth 2. Returns an
+    /// error if the resulting type would exceed the configured limits.
+    pub fn create_function_ty(
+        &self,
+        args: Vec<Type>,
+        results: Vec<Type>,
+        abilities: AbilitySet,
+    ) -> PartialVMResult<Type> {
+        // Count 1 for the function-type node itself; children start at depth 2.
+        let mut count = 1;
+        let check = |c: &mut u64, d: u64| self.check(c, d);
+
+        let args = args
+            .iter()
+            .map(|ty| self.clone_impl(ty, &mut count, 2, check))
+            .collect::<PartialVMResult<Vec<_>>>()
+            .map_err(|e| {
+                e.append_message_with_separator(
+                    '.',
+                    "Failed to create function type: argument type exceeds limits".to_string(),
+                )
+            })?;
+        let results = results
+            .iter()
+            .map(|ty| self.clone_impl(ty, &mut count, 2, check))
+            .collect::<PartialVMResult<Vec<_>>>()
+            .map_err(|e| {
+                e.append_message_with_separator(
+                    '.',
+                    "Failed to create function type: result type exceeds limits".to_string(),
+                )
+            })?;
+
+        Ok(Type::Function {
+            args,
+            results,
+            abilities,
+        })
+    }
+
     /// Creates a type for a Move constant. Note that constant types can be
     /// more restrictive and therefore have their own creation API.
     pub fn create_constant_ty(&self, const_tok: &SignatureToken) -> PartialVMResult<Type> {
@@ -1860,6 +1902,53 @@ mod unit_tests {
 
         let (_, _, vec_tag) = nested_vec_for_test(max_ty_size + 1);
         let err = assert_err!(ty_builder.create_ty(&vec_tag, no_op));
+        assert_eq!(err.major_status(), StatusCode::TOO_MANY_TYPE_NODES);
+    }
+
+    #[test]
+    fn test_create_function_ty_depth() {
+        use Type::*;
+
+        let max_ty_depth = 5;
+        let ty_builder = TypeBuilder::with_limits(100, max_ty_depth);
+
+        // A function type with no args or results succeeds (depth = 1, the node itself).
+        assert_ok!(ty_builder.create_function_ty(vec![], vec![], AbilitySet::EMPTY));
+
+        // A result type max_ty_depth-1 levels deep is allowed: function node is at depth 1,
+        // result root at depth 2, deepest result node at depth max_ty_depth.
+        let (shallow_result, _, _) = nested_vec_for_test(max_ty_depth - 1);
+        assert_ok!(ty_builder.create_function_ty(vec![], vec![shallow_result], AbilitySet::EMPTY));
+
+        // A result type max_ty_depth levels deep is rejected: the function-type node occupies
+        // depth 1, pushing the deepest result node to depth max_ty_depth + 1.
+        let (deep_result, _, _) = nested_vec_for_test(max_ty_depth);
+        let err = assert_err!(
+            ty_builder.create_function_ty(vec![], vec![deep_result], AbilitySet::EMPTY)
+        );
+        assert_eq!(err.major_status(), StatusCode::VM_MAX_TYPE_DEPTH_REACHED);
+
+        // Confirm that the same deep result type passes create_ty_with_subst (which does not
+        // account for the enclosing function-type node), showing what the old code permitted.
+        let (deep_result_again, _, _) = nested_vec_for_test(max_ty_depth);
+        assert_ok!(ty_builder.create_ty_with_subst(&deep_result_again, &[]));
+    }
+
+    #[test]
+    fn test_create_function_ty_size() {
+        use Type::*;
+
+        let max_ty_size = 5;
+        let ty_builder = TypeBuilder::with_limits(max_ty_size, 100);
+
+        // max_ty_size - 1 Bool args: 1 (function node) + 4 = 5 total nodes, at the limit.
+        let at_limit = vec![Bool; (max_ty_size - 1) as usize];
+        assert_ok!(ty_builder.create_function_ty(at_limit, vec![], AbilitySet::EMPTY));
+
+        // max_ty_size Bool args: 1 (function node) + 5 = 6 total nodes, over the limit.
+        let over_limit = vec![Bool; max_ty_size as usize];
+        let err =
+            assert_err!(ty_builder.create_function_ty(over_limit, vec![], AbilitySet::EMPTY));
         assert_eq!(err.major_status(), StatusCode::TOO_MANY_TYPE_NODES);
     }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
PackClosure was constructing `Type::Function` directly, skipping the `TypeBuilder` depth and size checks that all other composite types go through. A deeply nested or oversized closure type could be pushed onto the operand stack unchecked.

Added `TypeBuilder::create_function_ty` and routed `PackClosure` through it. No version gate needed. Closures are already behind `ENABLE_FUNCTION_VALUES`

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
- test_create_function_ty_depth: verifies depth-5 result type is rejected, depth-4 passes
- test_create_function_ty_size: verifies 5 Bool args is rejected, 4 passes (node count = max)

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/movementlabsxyz/codesmith/aptos-core/pr/407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788017266&installation_model_id=17568&pr_number=407&repository=movementlabsxyz%2Faptos-core&return_to=https%3A%2F%2Fgithub.com%2Fmovementlabsxyz%2Faptos-core%2Fpull%2F407&signature=8587b6db1cea11932ba62da58eaba60bfcd8c99da976f66edbe113e87a75251e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->