### PR TITLE
rename movementlabsxyz -> movement-network

### DIFF
--- a/.github/workflows/build-versions.yaml
+++ b/.github/workflows/build-versions.yaml
@@ -5,12 +5,12 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'The git ref to build (branch, tag, sha).'
+        description: "The git ref to build (branch, tag, sha)."
         required: true
-        default: 'main'
+        default: "main"
       build_profile:
-        description: 'The cargo build profile to use.'
-        default: 'release'
+        description: "The cargo build profile to use."
+        default: "release"
 
 jobs:
   setup:
@@ -72,7 +72,7 @@ jobs:
           echo "build_profile=${{ inputs.build_profile || 'release' }}" >> $GITHUB_OUTPUT
 
   binaries-aptos-node:
-    needs: 
+    needs:
       - setup
     runs-on: blacksmith-16vcpu-ubuntu-2204
     name: "Build ${{ matrix.binary.package }} with Nix"
@@ -90,14 +90,14 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha}}
       - name: Build binary ${{ matrix.binary.package }}
-        uses: movementlabsxyz/aptos-core/.github/actions/build-binary@m1
+        uses: movement-network/aptos-core/.github/actions/build-binary@m1
         with:
           binary_package: ${{ matrix.binary.package }}
           profile: ${{ needs.setup.outputs.build_profile }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_sha: ${{ needs.setup.outputs.git_sha }}
   container-aptos-node:
-    needs: 
+    needs:
       - setup
       - binaries-aptos-node
     runs-on: blacksmith-16vcpu-ubuntu-2204
@@ -130,11 +130,11 @@ jobs:
           path: ${{ env.TARGET_FOLDER }}
       - name: List binaries
         run: ls -la ${{ env.TARGET_FOLDER }}
-        
+
       - name: Build Container
-        uses: movementlabsxyz/aptos-core/.github/actions/build-container@m1
+        uses: movement-network/aptos-core/.github/actions/build-container@m1
         with:
-          image_name: ghcr.io/movementlabsxyz/aptos-node
+          image_name: ghcr.io/movement-network/aptos-node
           dockerfile_subdir: aptos-node
           build_args: |
             BINARY_PATH=${{ env.TARGET_FOLDER }}
@@ -170,9 +170,9 @@ jobs:
       - name: List binaries
         run: ls -la ${{ env.TARGET_FOLDER }}
       - name: Build Container
-        uses: movementlabsxyz/aptos-core/.github/actions/build-container@m1
+        uses: movement-network/aptos-core/.github/actions/build-container@m1
         with:
-          image_name: ghcr.io/movementlabsxyz/aptos-debugger
+          image_name: ghcr.io/movement-network/aptos-debugger
           dockerfile_subdir: aptos-debugger
           build_args: |
             BINARY_PATH=${{ env.TARGET_FOLDER }}
@@ -185,7 +185,7 @@ jobs:
           git_sha: ${{ needs.setup.outputs.git_sha }}
 
   binaries-aptos-faucet-service:
-    needs: 
+    needs:
       - setup
     runs-on: blacksmith-16vcpu-ubuntu-2204
     name: "Build ${{ matrix.binary.package }} with Nix"
@@ -200,14 +200,14 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha}}
       - name: Build binary ${{ matrix.binary.package }}
-        uses: movementlabsxyz/aptos-core/.github/actions/build-binary@m1
+        uses: movement-network/aptos-core/.github/actions/build-binary@m1
         with:
           binary_package: ${{ matrix.binary.package }}
           profile: ${{ needs.setup.outputs.build_profile }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_sha: ${{ needs.setup.outputs.git_sha }}
   container-aptos-faucet-service:
-    needs: 
+    needs:
       - setup
       - binaries-aptos-faucet-service
     runs-on: blacksmith-16vcpu-ubuntu-2204
@@ -230,11 +230,11 @@ jobs:
           path: ${{ env.TARGET_FOLDER }}
       - name: List binaries
         run: ls -la ${{ env.TARGET_FOLDER }}
-        
+
       - name: Build Container
-        uses: movementlabsxyz/aptos-core/.github/actions/build-container@m1
+        uses: movement-network/aptos-core/.github/actions/build-container@m1
         with:
-          image_name: ghcr.io/movementlabsxyz/aptos-faucet-service
+          image_name: ghcr.io/movement-network/aptos-faucet-service
           dockerfile_subdir: aptos-faucet-service
           build_args: |
             BINARY_PATH=${{ env.TARGET_FOLDER }}
@@ -247,7 +247,7 @@ jobs:
           git_sha: ${{ needs.setup.outputs.git_sha }}
 
   binaries-aptos-tools:
-    needs: 
+    needs:
       - setup
     runs-on: blacksmith-16vcpu-ubuntu-2204
     name: "Build ${{ matrix.binary.package }} with Nix"
@@ -262,7 +262,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha}}
       - name: Build binary ${{ matrix.binary.package }}
-        uses: movementlabsxyz/aptos-core/.github/actions/build-binary@m1
+        uses: movement-network/aptos-core/.github/actions/build-binary@m1
         with:
           binary_package: ${{ matrix.binary.package }}
           profile: ${{ needs.setup.outputs.build_profile }}

--- a/.github/workflows/claude-audit-pr.yml
+++ b/.github/workflows/claude-audit-pr.yml
@@ -13,7 +13,7 @@ name: Claude Audit PR
 # because that would expose repository secrets to untrusted code.
 #
 # Audit *content* (subagent definition, analyzers, prompt, settings) lives in
-# movementlabsxyz/claude-pr-reviewer and is checked out + staged at runtime.
+# movement-network/claude-pr-reviewer and is checked out + staged at runtime.
 # Bump REVIEWER_REF below to upgrade. See that repo's README for the consumer
 # contract.
 
@@ -43,7 +43,7 @@ concurrency:
 env:
   # Pin to a tag (e.g. v1, v0.1.0) or an immutable SHA. Rolling tags pick up
   # patches automatically; SHAs require a bump PR but are tamper-evident.
-  REVIEWER_REPO: movementlabsxyz/claude-pr-reviewer
+  REVIEWER_REPO: movement-network/claude-pr-reviewer
   REVIEWER_REF: v1
 
 jobs:

--- a/.github/workflows/publish-builder-images.yaml
+++ b/.github/workflows/publish-builder-images.yaml
@@ -30,7 +30,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAMESPACE: ghcr.io/movementlabsxyz
+  IMAGE_NAMESPACE: ghcr.io/movement-network
   DEBIAN_CONTEXT: docker-image://debian:bullseye@sha256:cf48c31af360e1c0a0aedd33aae4d928b68c2cdf093f1612650eb1ff434d1c34
   PROFILE: release
   FEATURES: ""

--- a/Justfile
+++ b/Justfile
@@ -110,14 +110,14 @@ container-build container="aptos-node" tag="latest" profile="release":
     docker build \
         --build-arg BINARY_PATH="$BINARY_PATH" \
         -f docker/{{container}}/Dockerfile \
-        -t ghcr.io/movementlabsxyz/{{container}}:{{tag}} .
+        -t ghcr.io/movement-network/{{container}}:{{tag}} .
     
     # Clean up the copied binary
     rm -f aptos-test
 
 # Push a container image to GHCR
 container-push container="aptos-node" tag="latest":
-    docker push ghcr.io/movementlabsxyz/{{container}}:{{tag}}
+    docker push ghcr.io/movement-network/{{container}}:{{tag}}
 
 # Build and push a container image
 container-release container="aptos-node" tag="latest" profile="release":

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -6,8 +6,8 @@ proposals:
     metadata:
       title: "Disable concurrent fungible balance"
       description: "This is for disabling concurrent fungible balance"
-      source_code_url: "https://github.com/movementlabsxyz/aptos-core"
-      discussion_url: "https://github.com/movementlabsxyz/aptos-core"
+      source_code_url: "https://github.com/movement-network/aptos-core"
+      discussion_url: "https://github.com/movement-network/aptos-core"
     execution_mode: RootSigner
     update_sequence:
       - Framework:

--- a/aptos-move/aptos-release-builder/src/components/framework.rs
+++ b/aptos-move/aptos-release-builder/src/components/framework.rs
@@ -30,7 +30,7 @@ pub fn generate_upgrade_proposals(
         "only multi-step proposals can have a next execution hash"
     );
 
-    const MVT_APTOS_GIT_PATH: &str = "https://github.com/movementlabsxyz/aptos-core.git";
+    const MVT_APTOS_GIT_PATH: &str = "https://github.com/movement-network/aptos-core.git";
 
     // NOTE: This is skipping 0x7 (aptos-experimental package) which is only meant to be released
     // to devnet (or local testnet) via the genesis process and never released/upgraded in testnet

--- a/consensus/consensus-types/src/pipelined_block.rs
+++ b/consensus/consensus-types/src/pipelined_block.rs
@@ -349,7 +349,7 @@ impl PipelinedBlock {
     //   https://github.com/aptos-labs/aptos-core/pull/18699  (upstream optimization that introduced the cycle)
     //   https://github.com/aptos-labs/aptos-core/pull/19359  (corrective patch)
     //   https://github.com/aptos-labs/aptos-core/commit/fefcfade3edf26f0396d63963f7ea04364f3666f
-    //   https://github.com/movementlabsxyz/aptos-core/pull/322  (full analysis with diagrams)
+    //   https://github.com/movement-network/aptos-core/pull/322  (full analysis with diagrams)
     //
     // If a similar change is ever introduced here — anything that makes
     // rand aggregation wait on a pipeline-derived future — this function

--- a/crates/aptos/homebrew/README.md
+++ b/crates/aptos/homebrew/README.md
@@ -3,14 +3,14 @@
 Homebrew is a package manager that works for MacOS Silicon and Intel chips as well as Linux distributions like Debian
 and Ubuntu.
 
-The [Movement command line interface (CLI)](https://github.com/movementlabsxyz/aptos-core/) may be installed
+The [Movement command line interface (CLI)](https://github.com/movement-network/aptos-core/) may be installed
 via [Homebrew](https://brew.sh/) for simplicity. This is an in-depth overview of Homebrew and the Movement formula. In this
 guide, we go over each section of the Homebrew formula and steps to implement changes in the future.
 
 ## Quick guide
 
 - [Formula in Homebrew GitHub](https://github.com/Homebrew/homebrew-core/blob/master/Formula/movement.rb)
-- [Movement <version-number> New Formula PR for GitHub](<link-to-PR>)
+- [Movement <version-number> New Formula PR for GitHub](link-to-PR)
 
 ## Getting started
 
@@ -178,9 +178,9 @@ brew livecheck --debug movement
   end
 
   # Currently must compile with the same rustc version specified in the
-  # root Cargo.toml file of aptos-core (currently it is pegged to Rust 
+  # root Cargo.toml file of aptos-core (currently it is pegged to Rust
   # v1.64). In the future if it becomes compatible with the latest Rust
-  # toolchain, we can remove the use of rustup-init, replacing it with a 
+  # toolchain, we can remove the use of rustup-init, replacing it with a
   # depends_on "rust" => :build
   # above and build the binary without rustup as a dependency
   #
@@ -221,7 +221,7 @@ key.
 - To view other Homebrew-related FAQs or ask questions yourself, visit
   the [discussions board](https://github.com/orgs/Homebrew/discussions).
 - For similar Rust-related build examples, we recommend:
-    - [`rustfmt.rb`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/rustfmt.rb)
+  - [`rustfmt.rb`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/rustfmt.rb)
 - Finally, note these key Homebew guides:
-    - [Homebrew Formula Cookbook](https://docs.brew.sh/Formula-Cookbook)
-    - [Creating and Running Your Own Homebrew Tap - Rust Runbook](https://publishing-project.rivendellweb.net/creating-and-running-your-own-homebrew-tap/)
+  - [Homebrew Formula Cookbook](https://docs.brew.sh/Formula-Cookbook)
+  - [Creating and Running Your Own Homebrew Tap - Rust Runbook](https://publishing-project.rivendellweb.net/creating-and-running-your-own-homebrew-tap/)

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -207,7 +207,7 @@ impl FrameworkPackageArgs {
         prompt_options: PromptOptions,
     ) -> CliTypedResult<()> {
         const APTOS_FRAMEWORK: &str = "AptosFramework";
-        const APTOS_GIT_PATH: &str = "https://github.com/movementlabsxyz/aptos-core.git";
+        const APTOS_GIT_PATH: &str = "https://github.com/movement-network/aptos-core.git";
         const SUBDIR_PATH: &str = "aptos-move/framework/aptos-framework";
         const DEFAULT_BRANCH: &str = "m1";
 
@@ -232,30 +232,24 @@ impl FrameworkPackageArgs {
         // Add the framework dependency if it's provided
         let mut dependencies = BTreeMap::new();
         if let Some(ref path) = self.framework_local_dir {
-            dependencies.insert(
-                APTOS_FRAMEWORK.to_string(),
-                Dependency {
-                    local: Some(path.display().to_string()),
-                    git: None,
-                    rev: None,
-                    subdir: None,
-                    aptos: None,
-                    address: None,
-                },
-            );
+            dependencies.insert(APTOS_FRAMEWORK.to_string(), Dependency {
+                local: Some(path.display().to_string()),
+                git: None,
+                rev: None,
+                subdir: None,
+                aptos: None,
+                address: None,
+            });
         } else {
             let git_rev = self.framework_git_rev.as_deref().unwrap_or(DEFAULT_BRANCH);
-            dependencies.insert(
-                APTOS_FRAMEWORK.to_string(),
-                Dependency {
-                    local: None,
-                    git: Some(APTOS_GIT_PATH.to_string()),
-                    rev: Some(git_rev.to_string()),
-                    subdir: Some(SUBDIR_PATH.to_string()),
-                    aptos: None,
-                    address: None,
-                },
-            );
+            dependencies.insert(APTOS_FRAMEWORK.to_string(), Dependency {
+                local: None,
+                git: Some(APTOS_GIT_PATH.to_string()),
+                rev: Some(git_rev.to_string()),
+                subdir: Some(SUBDIR_PATH.to_string()),
+                aptos: None,
+                address: None,
+            });
         }
 
         let manifest = MovePackageManifest {

--- a/devtools/aptos-cargo-cli/src/common.rs
+++ b/devtools/aptos-cargo-cli/src/common.rs
@@ -375,7 +375,7 @@ fn recompute_merge_base_metadata(
         .arg("clone")
         .arg("--depth")
         .arg("500") // Clone the last 500 commits to ensure the merge base is included
-        .arg("https://github.com/movementlabsxyz/aptos-core.git")
+        .arg("https://github.com/movement-network/aptos-core.git")
         .arg(clone_directory.clone())
         .output()
         .expect("failed to execute git clone");

--- a/docker/aptos-debugger/README.md
+++ b/docker/aptos-debugger/README.md
@@ -24,7 +24,7 @@ From the repository root:
 just container-build aptos-debugger latest release
 
 # Verify
-docker run --rm ghcr.io/movementlabsxyz/aptos-debugger:latest --version
+docker run --rm ghcr.io/movement-network/aptos-debugger:latest --version
 ```
 
 ## Pushing to GHCR
@@ -34,14 +34,14 @@ docker run --rm ghcr.io/movementlabsxyz/aptos-debugger:latest --version
 docker login ghcr.io -u <username>
 
 # Push
-docker push ghcr.io/movementlabsxyz/aptos-debugger:latest
+docker push ghcr.io/movement-network/aptos-debugger:latest
 ```
 
 ## CI
 
 The `build-versions.yaml` workflow automatically builds and pushes this image on
 every push to the default branch. The image is tagged with the short git SHA
-(e.g., `ghcr.io/movementlabsxyz/aptos-debugger:f24a5bc`).
+(e.g., `ghcr.io/movement-network/aptos-debugger:f24a5bc`).
 
 ## Runtime Dependencies
 

--- a/movement-migration/framework-upgrades/Move.toml
+++ b/movement-migration/framework-upgrades/Move.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 admin = "0x1"
 
 [dependencies.AptosFramework]
-git = "https://github.com/movementlabsxyz/aptos-core.git"
+git = "https://github.com/movement-network/aptos-core.git"
 rev = "movement"
 subdir = "aptos-move/framework/aptos-framework"

--- a/movement-migration/post-migration/Move.toml
+++ b/movement-migration/post-migration/Move.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 admin = "0x1"
 
 [dependencies.AptosFramework]
-git = "https://github.com/movementlabsxyz/aptos-core.git"
+git = "https://github.com/movement-network/aptos-core.git"
 rev = "l1-migration"
 subdir = "aptos-move/framework/aptos-framework"

--- a/movement-migration/post-move2-upgrade/Move.toml
+++ b/movement-migration/post-move2-upgrade/Move.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 admin = "0x1"
 
 [dependencies.AptosFramework]
-git = "https://github.com/movementlabsxyz/aptos-core.git"
+git = "https://github.com/movement-network/aptos-core.git"
 rev = "l1-migration"
 subdir = "aptos-move/framework/aptos-framework"

--- a/movement-migration/test-proposal/Move.toml
+++ b/movement-migration/test-proposal/Move.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 admin = "0x1"
 
 [dependencies.AptosFramework]
-git = "https://github.com/movementlabsxyz/aptos-core.git"
+git = "https://github.com/movement-network/aptos-core.git"
 rev = "l1-migration"
 subdir = "aptos-move/framework/aptos-framework"

--- a/movement-migration/update_reconfiguration/Move.toml
+++ b/movement-migration/update_reconfiguration/Move.toml
@@ -3,6 +3,6 @@ name = "UpdateReconfiguration"
 version = "0.0.0"
 
 [dependencies.AptosFramework]
-git = "https://github.com/movementlabsxyz/aptos-core.git"
+git = "https://github.com/movement-network/aptos-core.git"
 rev = "movement"
 subdir = "aptos-move/framework/aptos-framework"

--- a/movement-migration/update_recurring_lockup_duration/Move.toml
+++ b/movement-migration/update_recurring_lockup_duration/Move.toml
@@ -8,7 +8,7 @@ authors = []
 [dev-addresses]
 
 [dependencies.AptosFramework]
-git = "https://github.com/movementlabsxyz/aptos-core.git"
+git = "https://github.com/movement-network/aptos-core.git"
 rev = "l1-migration"
 subdir = "aptos-move/framework/aptos-framework"
 

--- a/proposals/2026-04-08-disable-feature-67/metadata/disable_concurrent_fungible_balance.json
+++ b/proposals/2026-04-08-disable-feature-67/metadata/disable_concurrent_fungible_balance.json
@@ -1,6 +1,6 @@
 {
   "title": "Disable concurrent fungible balance",
   "description": "This is for disabling concurrent fungible balance",
-  "source_code_url": "https://github.com/movementlabsxyz/aptos-core",
-  "discussion_url": "https://github.com/movementlabsxyz/aptos-core"
+  "source_code_url": "https://github.com/movement-network/aptos-core",
+  "discussion_url": "https://github.com/movement-network/aptos-core"
 }

--- a/scripts/cli/build_cli_release.sh
+++ b/scripts/cli/build_cli_release.sh
@@ -31,32 +31,32 @@ OS=$(uname -s)
 VERSION=$(sed -n '/^\w*version = /p' "$CARGO_PATH" | sed 's/^.*=[ ]*"//g' | sed 's/".*$//g')
 
 if [[ "$SKIP_CHECKS" != "true" ]]; then
-  # Check that the version is well-formed, note that it should already be correct, but this double checks it
-  if ! [[ "$EXPECTED_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "$EXPECTED_VERSION is malformed, must be of the form '^[0-9]+\.[0-9]+\.[0-9]+$'"
-    exit 1
-  fi
+	# Check that the version is well-formed, note that it should already be correct, but this double checks it
+	if ! [[ "$EXPECTED_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+		echo "$EXPECTED_VERSION is malformed, must be of the form '^[0-9]+\.[0-9]+\.[0-9]+$'"
+		exit 1
+	fi
 
-  # Check that the version matches the Cargo.toml
-  if [[ "$EXPECTED_VERSION" != "$VERSION" ]]; then
-    echo "Wanted to release for $EXPECTED_VERSION, but Cargo.toml says the version is $VERSION"
-    exit 2
-  fi
+	# Check that the version matches the Cargo.toml
+	if [[ "$EXPECTED_VERSION" != "$VERSION" ]]; then
+		echo "Wanted to release for $EXPECTED_VERSION, but Cargo.toml says the version is $VERSION"
+		exit 2
+	fi
 
-  # Check that the release doesn't already exist
-  if curl -s --stderr /dev/null --output /dev/null --head -f "https://github.com/movementlabsxyz/aptos-core/releases/download/movement-cli-v$EXPECTED_VERSION/movement-cli-$EXPECTED_VERSION-Linux-x86_64.zip"; then
-    echo "$EXPECTED_VERSION already released"
-    exit 3
-  fi
+	# Check that the release doesn't already exist
+	if curl -s --stderr /dev/null --output /dev/null --head -f "https://github.com/movement-network/aptos-core/releases/download/movement-cli-v$EXPECTED_VERSION/movement-cli-$EXPECTED_VERSION-Linux-x86_64.zip"; then
+		echo "$EXPECTED_VERSION already released"
+		exit 3
+	fi
 else
-  echo "WARNING: Skipping version checks!"
+	echo "WARNING: Skipping version checks!"
 fi
 
 echo "Building release $VERSION of $NAME for $OS-$PLATFORM_NAME on $ARCH"
 if [[ "$COMPATIBILITY_MODE" == "true" ]]; then
-  RUSTFLAGS="-C target-cpu=generic --cfg tokio_unstable -C target-feature=-sse4.2,-avx" cargo build -p "$CRATE_NAME" --profile cli
+	RUSTFLAGS="-C target-cpu=generic --cfg tokio_unstable -C target-feature=-sse4.2,-avx" cargo build -p "$CRATE_NAME" --profile cli
 else
-  cargo build -p "$CRATE_NAME" --profile cli
+	cargo build -p "$CRATE_NAME" --profile cli
 fi
 cd target/cli/
 


### PR DESCRIPTION
## Description

Renames the GitHub org reference `movementlabsxyz` → `movement-network` across the
repository, following the org rename. 33 occurrences in 19 files:

- **CI / release automation** — reusable-workflow refs
  (`movement-network/aptos-core/.github/actions/build-{binary,container}@m1`), the
  `IMAGE_NAMESPACE`/`image_name` values for the `aptos-node`, `aptos-debugger` and
  `aptos-faucet-service` GHCR images, the `Justfile` build/push targets, and the
  release-existence probe in `scripts/cli/build_cli_release.sh`.
- **Claude PR audit workflow** — `REVIEWER_REPO: movement-network/claude-pr-reviewer`
  (`REVIEWER_REF: v1` unchanged).
- **Code constants** — the framework git URL used by `aptos move init`
  (`crates/aptos/src/move_tool/mod.rs`) and the shallow-clone URL used for merge-base
  metadata in `devtools/aptos-cargo-cli/src/common.rs`.
- **Move manifests** — `AptosFramework` git dependency URLs in the
  `movement-migration/*` packages.
- **Release metadata** — `source_code_url` / `discussion_url` in
  `aptos-move/aptos-release-builder/data/release.yaml` and the generated
  `disable_concurrent_fungible_balance.json`.
- **Docs / comments** — homebrew README, `docker/aptos-debugger/README.md`, and the
  PR link in the `pipelined_block.rs` regression comment.

No functional or behavioral change. GitHub keeps redirects for renamed orgs, so nothing
was broken before this; the change makes the references match reality.

Incidental formatter noise is included in the same commit (no logic touched):
`crates/aptos/src/move_tool/mod.rs` struct literals reflowed by rustfmt,
`scripts/cli/build_cli_release.sh` re-indented to tabs, `build-versions.yaml` quote
style plus trailing-whitespace cleanup, and homebrew README list indentation.

## How Has This Been Tested?

- `grep -ril movementlabsxyz .` returns zero hits repo-wide.
- Reviewed every hunk by hand to confirm each change is either the org rename or
  formatter-only.
- CI on this PR exercises the renamed reusable workflows / GHCR namespace; the
  container publish paths must be confirmed green before merge.

## Key Areas to Review

- **`.github/workflows/build-versions.yaml`** — the `uses:` refs and `IMAGE_NAMESPACE`
  must resolve under the new org and the GH token must still have push rights to
  `ghcr.io/movement-network/*`. This is the one place a wrong value fails only at
  release time.
- **`.github/workflows/claude-audit-pr.yml`** — `movement-network/claude-pr-reviewer`
  must exist with tag `v1`.
- **`crates/aptos/src/move_tool/mod.rs` / `movement-migration/*/Move.toml`** — these URLs
  end up in user-facing generated manifests and in migration packages; a bad URL breaks
  `aptos move init` / package resolution for downstream users.
- **Formatter churn** — if you'd rather keep the rename diff surgical, say so and I'll
  split the reformatting into a separate commit.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [x] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (CI/CD workflows, container image namespace, release metadata, migration Move packages)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/movement-network/codesmith/aptos-core/pr/408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788029471&installation_model_id=17568&pr_number=408&repository=movement-network%2Faptos-core&return_to=https%3A%2F%2Fgithub.com%2Fmovement-network%2Faptos-core%2Fpull%2F408&signature=2ce870915e5068ab7d8ebd8c357e3d97b78e26add1dddbc4e13ae26842a85d3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->