### PR TITLE
Pay gas fees in selected FAs

### DIFF
--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -360,8 +360,10 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
                 extra_config,
             }) => match extra_config {
                 aptos_types::transaction::TransactionExtraConfig::V1 {
-                    multisig_address,
-                    replay_protection_nonce: _,
+                    multisig_address, ..
+                }
+                | aptos_types::transaction::TransactionExtraConfig::V2 {
+                    multisig_address, ..
                 } => {
                     if let Some(multisig_address) = multisig_address {
                         match executable {

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
@@ -7,7 +7,7 @@ use crate::{
     gas_feature_versions::{RELEASE_V1_14, RELEASE_V1_8, RELEASE_V1_9_SKIPPED},
     gas_schedule::NativeGasParameters,
     ver::gas_feature_versions::{
-        RELEASE_V1_12, RELEASE_V1_13, RELEASE_V1_23, RELEASE_V1_26, RELEASE_V1_28,
+        RELEASE_V1_12, RELEASE_V1_13, RELEASE_V1_23, RELEASE_V1_26, RELEASE_V1_28, RELEASE_V1_32,
     },
 };
 use aptos_gas_algebra::{
@@ -314,6 +314,7 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [transaction_context_entry_function_payload_per_byte_in_str: InternalGasPerByte, {RELEASE_V1_12.. => "transaction_context.entry_function_payload.per_abstract_memory_unit"}, 18],
         [transaction_context_multisig_payload_base: InternalGas, {RELEASE_V1_12.. => "transaction_context.multisig_payload.base"}, 735],
         [transaction_context_multisig_payload_per_byte_in_str: InternalGasPerByte, {RELEASE_V1_12.. => "transaction_context.multisig_payload.per_abstract_memory_unit"}, 18],
+        [transaction_context_gas_payment_fa_metadata_base: InternalGas, {RELEASE_V1_32.. => "transaction_context.gas_payment_fa_metadata.base"}, 735],
 
         [code_request_publish_base: InternalGas, "code.request_publish.base", 1838],
         [code_request_publish_per_byte: InternalGasPerByte, "code.request_publish.per_byte", 7],

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -149,6 +149,7 @@ pub enum FeatureFlag {
     EnableLazyLoading,
     CalculateTransactionFeeForDistribution,
     DistributeTransactionFee,
+    GasPayableFa,
     GovernedGasPool,
     SteakRewardUsingTreasury,
     ExtractAbortInfoExactMatch,
@@ -398,6 +399,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
                 AptosFeatureFlag::CALCULATE_TRANSACTION_FEE_FOR_DISTRIBUTION
             },
             FeatureFlag::DistributeTransactionFee => AptosFeatureFlag::DISTRIBUTE_TRANSACTION_FEE,
+            FeatureFlag::GasPayableFa => AptosFeatureFlag::GAS_PAYABLE_FA,
             FeatureFlag::GovernedGasPool => AptosFeatureFlag::GOVERNED_GAS_POOL,
             FeatureFlag::SteakRewardUsingTreasury => AptosFeatureFlag::STAKE_REWARD_USING_TREASURY,
             FeatureFlag::ExtractAbortInfoExactMatch => {
@@ -576,6 +578,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
                 FeatureFlag::CalculateTransactionFeeForDistribution
             },
             AptosFeatureFlag::DISTRIBUTE_TRANSACTION_FEE => FeatureFlag::DistributeTransactionFee,
+            AptosFeatureFlag::GAS_PAYABLE_FA => FeatureFlag::GasPayableFa,
             AptosFeatureFlag::GOVERNED_GAS_POOL => FeatureFlag::GovernedGasPool,
             AptosFeatureFlag::STAKE_REWARD_USING_TREASURY => FeatureFlag::SteakRewardUsingTreasury,
             AptosFeatureFlag::EXTRACT_ABORT_INFO_EXACT_MATCH => {

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -1734,6 +1734,15 @@ impl AptosVM {
             }
         }
 
+        if !self.features().is_gas_payable_fa_enabled()
+            && transaction.extra_config().has_gas_fa_coin()
+        {
+            return Err(VMStatus::error(
+                StatusCode::FEATURE_UNDER_GATING,
+                Some("Paying gas in a fungible asset is not yet supported".to_string()),
+            ));
+        }
+
         // The prologue MUST be run AFTER any validation. Otherwise you may run prologue and hit
         // SEQUENCE_NUMBER_TOO_NEW if there is more than one transaction from the same sender and
         // end up skipping validation.

--- a/aptos-move/aptos-vm/src/transaction_metadata.rs
+++ b/aptos-move/aptos-vm/src/transaction_metadata.rs
@@ -36,6 +36,7 @@ pub struct TransactionMetadata {
     pub is_keyless: bool,
     pub entry_function_payload: Option<EntryFunction>,
     pub multisig_payload: Option<Multisig>,
+    pub gas_fa_coin: Option<AccountAddress>,
 }
 
 impl TransactionMetadata {
@@ -119,6 +120,7 @@ impl TransactionMetadata {
                 }),
                 _ => None,
             },
+            gas_fa_coin: txn.payload().extra_config().gas_fa_coin(),
         }
     }
 
@@ -213,6 +215,7 @@ impl TransactionMetadata {
                 .map(|entry_func| entry_func.as_entry_function_payload()),
             self.multisig_payload()
                 .map(|multisig| multisig.as_multisig_payload()),
+            self.gas_fa_coin,
         )
     }
 }

--- a/aptos-move/aptos-vm/src/transaction_metadata.rs
+++ b/aptos-move/aptos-vm/src/transaction_metadata.rs
@@ -102,6 +102,10 @@ impl TransactionMetadata {
                         TransactionExtraConfig::V1 {
                             multisig_address: Some(multisig_address),
                             ..
+                        }
+                        | TransactionExtraConfig::V2 {
+                            multisig_address: Some(multisig_address),
+                            ..
                         },
                 }) => Some(Multisig {
                     multisig_address: *multisig_address,

--- a/aptos-move/e2e-move-tests/src/tests/fee_payer.rs
+++ b/aptos-move/e2e-move-tests/src/tests/fee_payer.rs
@@ -66,6 +66,59 @@ fn test_existing_account_with_fee_payer() {
     assert!(bob_start > bob_after);
 }
 
+/// A fee-payer (sponsored) transaction with account abstraction disabled routes gas collection
+/// through the legacy `transaction_validation::epilogue_gas_payer_extended` Move function.
+///
+/// Per the VM dispatch in `run_epilogue`, that function is selected exactly when neither
+/// account-abstraction feature is enabled AND the transaction has a fee payer; with account
+/// abstraction on (the default), the unified epilogue is used instead. The gas is charged to the
+/// fee payer, not the sender.
+#[test]
+fn test_fee_payer_runs_epilogue_gas_payer_extended() {
+    let mut h = MoveHarness::new_with_features(
+        vec![
+            FeatureFlag::GAS_PAYER_ENABLED,
+            FeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_V1_CREATION,
+        ],
+        // Disabling account abstraction forces the non-unified (legacy) epilogue path.
+        vec![
+            FeatureFlag::DEFAULT_ACCOUNT_RESOURCE,
+            FeatureFlag::ACCOUNT_ABSTRACTION,
+            FeatureFlag::DERIVABLE_ACCOUNT_ABSTRACTION,
+        ],
+    );
+
+    let alice = h.new_account_at(AccountAddress::from_hex_literal("0xa11ce").unwrap());
+    let bob = h.new_account_at(AccountAddress::from_hex_literal("0xb0b").unwrap());
+
+    let alice_start = h.read_aptos_balance(alice.address());
+    let bob_start = h.read_aptos_balance(bob.address());
+
+    // A no-op self-transfer; bob sponsors the gas.
+    let payload = aptos_stdlib::aptos_coin_transfer(*alice.address(), 0);
+    let transaction = TransactionBuilder::new(alice.clone())
+        .fee_payer(bob.clone())
+        .payload(payload)
+        .sequence_number(h.sequence_number(alice.address()))
+        .max_gas_amount(1_000_000)
+        .gas_unit_price(1)
+        .sign_fee_payer();
+
+    let output = h.run_raw(transaction);
+    assert_success!(*output.status());
+
+    // The fee payer (bob) paid the gas via epilogue_gas_payer_extended; the sender (alice) did not.
+    let alice_after = h.read_aptos_balance(alice.address());
+    let bob_after = h.read_aptos_balance(bob.address());
+    assert_eq!(alice_start, alice_after);
+    assert!(
+        bob_start > bob_after,
+        "fee payer should have paid the gas: {} -> {}",
+        bob_start,
+        bob_after
+    );
+}
+
 #[test]
 fn test_existing_account_with_fee_payer_aborts() {
     let mut h = MoveHarness::new_with_features(

--- a/aptos-move/e2e-move-tests/src/tests/gas_fa_coin_feature_gating.rs
+++ b/aptos-move/e2e-move-tests/src/tests/gas_fa_coin_feature_gating.rs
@@ -1,0 +1,88 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::MoveHarness;
+use aptos_cached_packages::aptos_stdlib;
+use aptos_types::{
+    on_chain_config::FeatureFlag,
+    transaction::{
+        TransactionExecutable, TransactionExtraConfig, TransactionPayload,
+        TransactionPayloadInner, TransactionStatus,
+    },
+};
+use move_core_types::{account_address::AccountAddress, vm_status::StatusCode};
+
+/// Builds a transaction payload in the new (versioned) format carrying an optional `gas_fa_coin`,
+/// wrapping a simple APT transfer entry function as the executable.
+fn transfer_payload_with_gas_fa_coin(
+    recipient: AccountAddress,
+    gas_fa_coin: Option<AccountAddress>,
+) -> TransactionPayload {
+    let executable = match aptos_stdlib::aptos_account_transfer(recipient, 1) {
+        TransactionPayload::EntryFunction(entry_function) => {
+            TransactionExecutable::EntryFunction(entry_function)
+        },
+        _ => unreachable!("aptos_account_transfer builds an entry function payload"),
+    };
+    TransactionPayload::Payload(TransactionPayloadInner::V1 {
+        executable,
+        extra_config: TransactionExtraConfig::V2 {
+            multisig_address: None,
+            replay_protection_nonce: None,
+            gas_fa_coin,
+        },
+    })
+}
+
+/// A transaction that specifies a `gas_fa_coin` must be rejected while the `GAS_PAYABLE_FA` feature
+/// is disabled, even though the underlying (versioned) payload format itself is enabled.
+#[test]
+fn gas_fa_coin_is_rejected_when_feature_disabled() {
+    // TRANSACTION_PAYLOAD_V2 is on so the versioned payload format is not what triggers the gate;
+    // GAS_PAYABLE_FA is off so the `gas_fa_coin` field is the sole reason for rejection.
+    let mut h = MoveHarness::new_with_features(
+        vec![FeatureFlag::TRANSACTION_PAYLOAD_V2],
+        vec![FeatureFlag::GAS_PAYABLE_FA],
+    );
+    let alice = h.new_account_with_key_pair();
+    let bob = h.new_account_with_key_pair();
+
+    let payload = transfer_payload_with_gas_fa_coin(*bob.address(), Some(*bob.address()));
+    let txn = h.create_transaction_payload(&alice, payload);
+    let output = h.run_raw(txn);
+
+    match output.status() {
+        TransactionStatus::Discard(status) => assert_eq!(
+            *status,
+            StatusCode::FEATURE_UNDER_GATING,
+            "expected a FEATURE_UNDER_GATING discard, but got: {:?}",
+            status
+        ),
+        other => panic!(
+            "expected a transaction carrying gas_fa_coin to be discarded, but got: {:?}",
+            other
+        ),
+    }
+}
+
+/// Control: an identical transaction in the same feature configuration but *without* a
+/// `gas_fa_coin` is accepted. This proves the rejection above is caused by `gas_fa_coin`
+/// specifically, not by the versioned payload format.
+#[test]
+fn transaction_without_gas_fa_coin_is_not_gated() {
+    let mut h = MoveHarness::new_with_features(
+        vec![FeatureFlag::TRANSACTION_PAYLOAD_V2],
+        vec![FeatureFlag::GAS_PAYABLE_FA],
+    );
+    let alice = h.new_account_with_key_pair();
+    let bob = h.new_account_with_key_pair();
+
+    let payload = transfer_payload_with_gas_fa_coin(*bob.address(), None);
+    let status = h.run_transaction_payload(&alice, payload);
+
+    assert!(
+        matches!(status, TransactionStatus::Keep(_)),
+        "an identical transaction without gas_fa_coin must not be gated, but got: {:?}",
+        status
+    );
+}

--- a/aptos-move/e2e-move-tests/src/tests/gas_fa_coin_transaction_context.rs
+++ b/aptos-move/e2e-move-tests/src/tests/gas_fa_coin_transaction_context.rs
@@ -1,11 +1,13 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-//! End-to-end coverage that a transaction's `gas_fa_coin` (from the versioned payload's
-//! `TransactionExtraConfig::V2`) is surfaced to Move via
-//! `transaction_context::gas_payment_fungible_asset()`.
+//! End-to-end coverage for paying transaction gas in a selected fungible asset:
+//! the `gas_fa_coin` from the versioned payload's `TransactionExtraConfig::V2` is surfaced to Move
+//! via `transaction_context::gas_payment_fungible_asset()`, validated in the prologue, and routed
+//! into that FA's governed gas pool by the epilogue.
 
 use crate::{assert_abort, assert_success, tests::common, MoveHarness};
+use aptos_language_e2e_tests::account::{Account, TransactionBuilder};
 use aptos_types::{
     account_address::AccountAddress,
     on_chain_config::FeatureFlag,
@@ -16,8 +18,9 @@ use aptos_types::{
 };
 use move_core_types::{ident_str, language_storage::ModuleId};
 
-/// The transaction_context test pack publishes to `@admin` = 0x1.
-fn setup() -> (MoveHarness, AccountAddress) {
+/// The transaction_context test pack publishes to `@admin` = 0x1, which is also @aptos_framework, so
+/// the returned account doubles as the governance signer.
+fn setup() -> (MoveHarness, Account) {
     // `TRANSACTION_PAYLOAD_V2` so the versioned payload is accepted, and `GAS_PAYABLE_FA` so a
     // transaction carrying `gas_fa_coin` is not rejected by the VM gate.
     let mut h = MoveHarness::new_with_features(
@@ -30,7 +33,7 @@ fn setup() -> (MoveHarness, AccountAddress) {
     let admin = h.new_account_at(AccountAddress::ONE);
     let path = common::test_dir_path("transaction_context.data/pack");
     assert_success!(h.publish_package_cache_building(&admin, &path));
-    (h, *admin.address())
+    (h, admin)
 }
 
 fn entry(name: &'static str, args: Vec<Vec<u8>>) -> TransactionPayload {
@@ -53,17 +56,13 @@ fn entry(name: &'static str, args: Vec<Vec<u8>>) -> TransactionPayload {
     })
 }
 
-/// A versioned transaction that sets `gas_fa_coin = Some(fa)` makes
-/// `transaction_context::gas_payment_fungible_asset()` return `Some(fa)` during execution.
-#[test]
-fn gas_fa_coin_is_visible_in_transaction_context() {
-    let (mut h, _admin) = setup();
-    let sender = h.new_account_with_key_pair();
-    let fa = AccountAddress::from_hex_literal("0xfa").unwrap();
-
-    // Entry function aborts unless the accessor returns Some(fa).
-    let mut payload = entry("assert_gas_payment_fungible_asset", vec![bcs::to_bytes(&fa)
-        .unwrap()]);
+/// Same as `entry`, but the versioned payload elects to pay gas in the fungible asset `fa`.
+fn entry_paying_gas_in_fa(
+    name: &'static str,
+    args: Vec<Vec<u8>>,
+    fa: AccountAddress,
+) -> TransactionPayload {
+    let mut payload = entry(name, args);
     if let TransactionPayload::Payload(TransactionPayloadInner::V1 { extra_config, .. }) =
         &mut payload
     {
@@ -71,9 +70,260 @@ fn gas_fa_coin_is_visible_in_transaction_context() {
             *gas_fa_coin = Some(fa);
         }
     }
+    payload
+}
 
+fn fa_pool_balance(h: &mut MoveHarness, metadata: AccountAddress) -> u64 {
+    let out = h.execute_view_function(
+        str::parse("0x1::governed_gas_pool::get_fa_balance").unwrap(),
+        vec![],
+        vec![bcs::to_bytes(&metadata).unwrap()],
+    );
+    bcs::from_bytes::<u64>(&out.values.expect("view failed")[0]).unwrap()
+}
+
+fn account_fa_balance(h: &mut MoveHarness, owner: AccountAddress, metadata: AccountAddress) -> u64 {
+    let out = h.execute_view_function(
+        str::parse("0x1::transaction_context_test::fa_balance").unwrap(),
+        vec![],
+        vec![
+            bcs::to_bytes(&owner).unwrap(),
+            bcs::to_bytes(&metadata).unwrap(),
+        ],
+    );
+    bcs::from_bytes::<u64>(&out.values.expect("view failed")[0]).unwrap()
+}
+
+/// The metadata address of the FA created by `create_gas_fa` for `owner`.
+fn gas_fa_metadata_address(h: &mut MoveHarness, owner: AccountAddress) -> AccountAddress {
+    let out = h.execute_view_function(
+        str::parse("0x1::transaction_context_test::gas_fa_metadata_address").unwrap(),
+        vec![],
+        vec![bcs::to_bytes(&owner).unwrap()],
+    );
+    bcs::from_bytes::<AccountAddress>(&out.values.expect("view failed")[0]).unwrap()
+}
+
+/// Creates a gas FA owned by `who`, minting `amount` to it, and returns its metadata address.
+fn create_gas_fa(h: &mut MoveHarness, who: &Account, amount: u64) -> AccountAddress {
+    assert_success!(h.run_entry_function(
+        who,
+        str::parse("0x1::transaction_context_test::create_gas_fa").unwrap(),
+        vec![],
+        vec![bcs::to_bytes(&amount).unwrap()],
+    ));
+    gas_fa_metadata_address(h, *who.address())
+}
+
+/// Governance accepts `metadata` for gas payment at `gas_price` FA units per gas unit.
+fn accept_gas_fa(h: &mut MoveHarness, admin: &Account, metadata: AccountAddress, gas_price: u64) {
+    assert_success!(h.run_entry_function(
+        admin,
+        str::parse("0x1::governed_gas_pool::add_accepted_gas_fungible_asset").unwrap(),
+        vec![],
+        vec![bcs::to_bytes(&metadata).unwrap(), bcs::to_bytes(&gas_price).unwrap()],
+    ));
+}
+
+/// Full flow: a transaction electing to pay gas in an accepted fungible asset passes the prologue
+/// (accepted + sufficient FA balance), executes with the accessor reporting that FA, and has its gas
+/// fee collected into that FA's governed gas pool.
+#[test]
+fn gas_paid_in_accepted_fa_routes_to_its_pool() {
+    let (mut h, admin) = setup();
+    let sender = h.new_account_with_key_pair();
+
+    // 1. Sender creates a fungible asset and mints itself a large balance (this txn pays gas in APT).
+    assert_success!(h.run_entry_function(
+        &sender,
+        str::parse("0x1::transaction_context_test::create_gas_fa").unwrap(),
+        vec![],
+        vec![bcs::to_bytes(&1_000_000_000_000_000u64).unwrap()],
+    ));
+
+    // 2. Look up the created FA's metadata address.
+    let metadata = {
+        let out = h.execute_view_function(
+            str::parse("0x1::transaction_context_test::gas_fa_metadata_address").unwrap(),
+            vec![],
+            vec![bcs::to_bytes(sender.address()).unwrap()],
+        );
+        bcs::from_bytes::<AccountAddress>(&out.values.expect("view failed")[0]).unwrap()
+    };
+
+    // 3. Governance accepts the FA for gas payment with a gas price of 2 FA units per gas unit
+    //    (admin == 0x1 == @aptos_framework).
+    let fa_gas_price = 2u64;
+    assert_success!(h.run_entry_function(
+        &admin,
+        str::parse("0x1::governed_gas_pool::add_accepted_gas_fungible_asset").unwrap(),
+        vec![],
+        vec![bcs::to_bytes(&metadata).unwrap(), bcs::to_bytes(&fa_gas_price).unwrap()],
+    ));
+
+    let pool_before = fa_pool_balance(&mut h, metadata);
+
+    // 4. Sender submits a versioned txn paying gas in the FA. The entry function asserts the accessor
+    //    reports that FA (aborts otherwise), and the epilogue routes the gas fee into its pool.
+    let payload = entry_paying_gas_in_fa(
+        "assert_gas_payment_fungible_asset",
+        vec![bcs::to_bytes(&metadata).unwrap()],
+        metadata,
+    );
     let txn = h.create_transaction_payload(&sender, payload);
-    assert_success!(h.run_raw(txn).status().clone());
+    let output = h.run_raw(txn);
+    let gas_used = output.gas_used();
+    assert_success!(output.status().clone());
+
+    // 5. The FA's governed gas pool grew by exactly gas_used * the FA's gas price.
+    let pool_after = fa_pool_balance(&mut h, metadata);
+    assert_eq!(
+        pool_after - pool_before,
+        gas_used * fa_gas_price,
+        "FA pool should grow by gas_used ({}) * price ({})",
+        gas_used,
+        fa_gas_price
+    );
+    assert!(
+        pool_after > pool_before,
+        "expected the FA governed gas pool to grow, before={} after={}",
+        pool_before,
+        pool_after
+    );
+}
+
+/// A transaction electing to pay gas in a fungible asset that governance has NOT accepted is
+/// rejected by the prologue (discarded), so it never executes.
+#[test]
+fn gas_paid_in_unaccepted_fa_is_rejected() {
+    let (mut h, _admin) = setup();
+    let sender = h.new_account_with_key_pair();
+    assert_success!(h.run_entry_function(
+        &sender,
+        str::parse("0x1::transaction_context_test::create_gas_fa").unwrap(),
+        vec![],
+        vec![bcs::to_bytes(&1_000_000_000_000_000u64).unwrap()],
+    ));
+    let metadata = {
+        let out = h.execute_view_function(
+            str::parse("0x1::transaction_context_test::gas_fa_metadata_address").unwrap(),
+            vec![],
+            vec![bcs::to_bytes(sender.address()).unwrap()],
+        );
+        bcs::from_bytes::<AccountAddress>(&out.values.expect("view failed")[0]).unwrap()
+    };
+
+    // Not accepted by governance -> prologue discards the transaction.
+    let payload = entry_paying_gas_in_fa(
+        "assert_gas_payment_fungible_asset",
+        vec![bcs::to_bytes(&metadata).unwrap()],
+        metadata,
+    );
+    let txn = h.create_transaction_payload(&sender, payload);
+    let status = h.run_raw(txn).status().clone();
+    assert!(
+        matches!(
+            status,
+            aptos_types::transaction::TransactionStatus::Discard(_)
+        ),
+        "expected an unaccepted gas FA to be discarded, got: {:?}",
+        status
+    );
+}
+
+/// With account abstraction DISABLED, a versioned fee-payer transaction electing to pay gas in an FA
+/// takes the legacy `epilogue_gas_payer_extended` path (not the unified one). That path is now FA-
+/// aware: the fee payer is charged in the FA, the fee lands in the FA's governed gas pool, and the
+/// fee payer's APT is untouched.
+#[test]
+fn fa_fee_payer_gas_is_charged_in_fa_via_legacy_epilogue() {
+    // AA off -> epilogue dispatch uses the legacy epilogue_gas_payer_extended, not unified_epilogue_v2.
+    let mut h = MoveHarness::new_with_features(
+        vec![
+            FeatureFlag::TRANSACTION_PAYLOAD_V2,
+            FeatureFlag::GAS_PAYABLE_FA,
+            FeatureFlag::GAS_PAYER_ENABLED,
+        ],
+        vec![
+            FeatureFlag::ACCOUNT_ABSTRACTION,
+            FeatureFlag::DERIVABLE_ACCOUNT_ABSTRACTION,
+        ],
+    );
+    let admin = h.new_account_at(AccountAddress::ONE);
+    let path = common::test_dir_path("transaction_context.data/pack");
+    assert_success!(h.publish_package_cache_building(&admin, &path));
+
+    let alice = h.new_account_with_key_pair(); // sender
+    let bob = h.new_account_with_key_pair(); // fee payer, will hold + pay in the FA
+
+    // bob creates an FA and mints itself a large balance (APT-paid txn).
+    assert_success!(h.run_entry_function(
+        &bob,
+        str::parse("0x1::transaction_context_test::create_gas_fa").unwrap(),
+        vec![],
+        vec![bcs::to_bytes(&1_000_000_000_000_000u64).unwrap()],
+    ));
+    let metadata = {
+        let out = h.execute_view_function(
+            str::parse("0x1::transaction_context_test::gas_fa_metadata_address").unwrap(),
+            vec![],
+            vec![bcs::to_bytes(bob.address()).unwrap()],
+        );
+        bcs::from_bytes::<AccountAddress>(&out.values.expect("view failed")[0]).unwrap()
+    };
+    let fa_gas_price = 2u64;
+    assert_success!(h.run_entry_function(
+        &admin,
+        str::parse("0x1::governed_gas_pool::add_accepted_gas_fungible_asset").unwrap(),
+        vec![],
+        vec![bcs::to_bytes(&metadata).unwrap(), bcs::to_bytes(&fa_gas_price).unwrap()],
+    ));
+
+    let bob_fa_before = account_fa_balance(&mut h, *bob.address(), metadata);
+    let bob_apt_before = h.read_aptos_balance(bob.address());
+    let pool_before = fa_pool_balance(&mut h, metadata);
+
+    // alice sends a versioned txn; bob sponsors gas and elects to pay it in the FA.
+    let payload = entry_paying_gas_in_fa(
+        "assert_gas_payment_fungible_asset",
+        vec![bcs::to_bytes(&metadata).unwrap()],
+        metadata,
+    );
+    let txn = TransactionBuilder::new(alice.clone())
+        .fee_payer(bob.clone())
+        .payload(payload)
+        .sequence_number(h.sequence_number(alice.address()))
+        .max_gas_amount(1_000_000)
+        .gas_unit_price(1)
+        .sign_fee_payer();
+    let output = h.run_raw(txn);
+    let gas_used = output.gas_used();
+    let status = output.status().clone();
+
+    let bob_fa_after = account_fa_balance(&mut h, *bob.address(), metadata);
+    let bob_apt_after = h.read_aptos_balance(bob.address());
+    let pool_after = fa_pool_balance(&mut h, metadata);
+
+    assert_success!(status);
+    // The fee payer was charged in the FA at gas_used * the FA's gas price, and that exact amount
+    // landed in the FA's governed gas pool.
+    assert_eq!(
+        bob_fa_before - bob_fa_after,
+        gas_used * fa_gas_price,
+        "fee payer's FA charge should be gas_used ({}) * price ({})",
+        gas_used,
+        fa_gas_price
+    );
+    assert_eq!(
+        bob_fa_before - bob_fa_after,
+        pool_after - pool_before,
+        "the FA charged to the fee payer should equal the FA pool increase"
+    );
+    // APT was not used to pay this transaction's gas.
+    assert_eq!(
+        bob_apt_before, bob_apt_after,
+        "fee payer's APT should be untouched when paying gas in an FA"
+    );
 }
 
 /// A versioned transaction with no `gas_fa_coin` makes the accessor return `None`.
@@ -106,4 +356,130 @@ fn accessor_aborts_when_feature_disabled() {
         vec![],
     );
     assert_abort!(status, 196611);
+}
+
+/// A transaction electing to pay gas in an accepted FA the payer cannot afford (max fee exceeds the
+/// payer's FA balance) is discarded by the prologue.
+#[test]
+fn gas_fa_insufficient_balance_is_rejected() {
+    let (mut h, admin) = setup();
+    let sender = h.new_account_with_key_pair();
+    // Mint the sender only a tiny FA balance.
+    let metadata = create_gas_fa(&mut h, &sender, 100);
+    accept_gas_fa(&mut h, &admin, metadata, 1);
+
+    // max_gas 1000 at price 1 => max FA fee 1000 > balance 100 => prologue discard.
+    let payload = entry_paying_gas_in_fa(
+        "assert_gas_payment_fungible_asset",
+        vec![bcs::to_bytes(&metadata).unwrap()],
+        metadata,
+    );
+    let txn = TransactionBuilder::new(sender.clone())
+        .payload(payload)
+        .sequence_number(h.sequence_number(sender.address()))
+        .max_gas_amount(1000)
+        .gas_unit_price(1)
+        .sign();
+    let status = h.run_raw(txn).status().clone();
+    assert!(
+        matches!(
+            status,
+            aptos_types::transaction::TransactionStatus::Discard(_)
+        ),
+        "expected an underfunded FA gas payer to be discarded, got: {:?}",
+        status
+    );
+}
+
+/// With account abstraction DISABLED and no fee payer, a versioned transaction paying gas in an FA
+/// takes the legacy `epilogue_extended` -> `epilogue_gas_payer_extended` path, charging the sender
+/// (its own gas payer) in the FA at gas_used * price.
+#[test]
+fn fa_regular_sender_charged_via_legacy_epilogue_extended() {
+    let mut h = MoveHarness::new_with_features(
+        vec![
+            FeatureFlag::TRANSACTION_PAYLOAD_V2,
+            FeatureFlag::GAS_PAYABLE_FA,
+        ],
+        vec![
+            FeatureFlag::ACCOUNT_ABSTRACTION,
+            FeatureFlag::DERIVABLE_ACCOUNT_ABSTRACTION,
+        ],
+    );
+    let admin = h.new_account_at(AccountAddress::ONE);
+    let path = common::test_dir_path("transaction_context.data/pack");
+    assert_success!(h.publish_package_cache_building(&admin, &path));
+
+    let sender = h.new_account_with_key_pair();
+    let metadata = create_gas_fa(&mut h, &sender, 1_000_000_000_000_000);
+    let fa_gas_price = 2u64;
+    accept_gas_fa(&mut h, &admin, metadata, fa_gas_price);
+
+    let fa_before = account_fa_balance(&mut h, *sender.address(), metadata);
+    let apt_before = h.read_aptos_balance(sender.address());
+    let pool_before = fa_pool_balance(&mut h, metadata);
+
+    let payload = entry_paying_gas_in_fa(
+        "assert_gas_payment_fungible_asset",
+        vec![bcs::to_bytes(&metadata).unwrap()],
+        metadata,
+    );
+    let txn = h.create_transaction_payload(&sender, payload);
+    let output = h.run_raw(txn);
+    let gas_used = output.gas_used();
+    assert_success!(output.status().clone());
+
+    let fa_after = account_fa_balance(&mut h, *sender.address(), metadata);
+    let apt_after = h.read_aptos_balance(sender.address());
+    let pool_after = fa_pool_balance(&mut h, metadata);
+
+    assert_eq!(
+        fa_before - fa_after,
+        gas_used * fa_gas_price,
+        "regular sender's FA charge should be gas_used ({}) * price ({})",
+        gas_used,
+        fa_gas_price
+    );
+    assert_eq!(fa_before - fa_after, pool_after - pool_before);
+    assert_eq!(
+        apt_before, apt_after,
+        "sender's APT should be untouched when paying gas in an FA"
+    );
+}
+
+/// A transaction that aborts during execution but is kept still has its FA gas charged by the
+/// epilogue (gas is collected even on failure).
+#[test]
+fn aborted_transaction_still_charges_fa_gas() {
+    let (mut h, admin) = setup();
+    let sender = h.new_account_with_key_pair();
+    let metadata = create_gas_fa(&mut h, &sender, 1_000_000_000_000_000);
+    let fa_gas_price = 2u64;
+    accept_gas_fa(&mut h, &admin, metadata, fa_gas_price);
+
+    let fa_before = account_fa_balance(&mut h, *sender.address(), metadata);
+    let pool_before = fa_pool_balance(&mut h, metadata);
+
+    // gas_fa_coin is set correctly, but the entry function asserts the accessor equals a DIFFERENT
+    // address, so it aborts (code 1000) — while gas is still charged in the FA.
+    let wrong = AccountAddress::from_hex_literal("0xdead").unwrap();
+    let payload = entry_paying_gas_in_fa(
+        "assert_gas_payment_fungible_asset",
+        vec![bcs::to_bytes(&wrong).unwrap()],
+        metadata,
+    );
+    let txn = h.create_transaction_payload(&sender, payload);
+    let output = h.run_raw(txn);
+    let gas_used = output.gas_used();
+    let status = output.status().clone();
+
+    assert_abort!(status, 1000);
+    let fa_after = account_fa_balance(&mut h, *sender.address(), metadata);
+    let pool_after = fa_pool_balance(&mut h, metadata);
+    assert_eq!(
+        fa_before - fa_after,
+        gas_used * fa_gas_price,
+        "FA gas should be charged even though the transaction aborted"
+    );
+    assert_eq!(pool_after - pool_before, gas_used * fa_gas_price);
 }

--- a/aptos-move/e2e-move-tests/src/tests/gas_fa_coin_transaction_context.rs
+++ b/aptos-move/e2e-move-tests/src/tests/gas_fa_coin_transaction_context.rs
@@ -1,0 +1,109 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end coverage that a transaction's `gas_fa_coin` (from the versioned payload's
+//! `TransactionExtraConfig::V2`) is surfaced to Move via
+//! `transaction_context::gas_payment_fungible_asset()`.
+
+use crate::{assert_abort, assert_success, tests::common, MoveHarness};
+use aptos_types::{
+    account_address::AccountAddress,
+    on_chain_config::FeatureFlag,
+    transaction::{
+        EntryFunction, TransactionExecutable, TransactionExtraConfig, TransactionPayload,
+        TransactionPayloadInner,
+    },
+};
+use move_core_types::{ident_str, language_storage::ModuleId};
+
+/// The transaction_context test pack publishes to `@admin` = 0x1.
+fn setup() -> (MoveHarness, AccountAddress) {
+    // `TRANSACTION_PAYLOAD_V2` so the versioned payload is accepted, and `GAS_PAYABLE_FA` so a
+    // transaction carrying `gas_fa_coin` is not rejected by the VM gate.
+    let mut h = MoveHarness::new_with_features(
+        vec![
+            FeatureFlag::TRANSACTION_PAYLOAD_V2,
+            FeatureFlag::GAS_PAYABLE_FA,
+        ],
+        vec![],
+    );
+    let admin = h.new_account_at(AccountAddress::ONE);
+    let path = common::test_dir_path("transaction_context.data/pack");
+    assert_success!(h.publish_package_cache_building(&admin, &path));
+    (h, *admin.address())
+}
+
+fn entry(name: &'static str, args: Vec<Vec<u8>>) -> TransactionPayload {
+    let executable = TransactionExecutable::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::ONE,
+            ident_str!("transaction_context_test").to_owned(),
+        ),
+        ident_str!(name).to_owned(),
+        vec![],
+        args,
+    ));
+    TransactionPayload::Payload(TransactionPayloadInner::V1 {
+        executable,
+        extra_config: TransactionExtraConfig::V2 {
+            multisig_address: None,
+            replay_protection_nonce: None,
+            gas_fa_coin: None,
+        },
+    })
+}
+
+/// A versioned transaction that sets `gas_fa_coin = Some(fa)` makes
+/// `transaction_context::gas_payment_fungible_asset()` return `Some(fa)` during execution.
+#[test]
+fn gas_fa_coin_is_visible_in_transaction_context() {
+    let (mut h, _admin) = setup();
+    let sender = h.new_account_with_key_pair();
+    let fa = AccountAddress::from_hex_literal("0xfa").unwrap();
+
+    // Entry function aborts unless the accessor returns Some(fa).
+    let mut payload = entry("assert_gas_payment_fungible_asset", vec![bcs::to_bytes(&fa)
+        .unwrap()]);
+    if let TransactionPayload::Payload(TransactionPayloadInner::V1 { extra_config, .. }) =
+        &mut payload
+    {
+        if let TransactionExtraConfig::V2 { gas_fa_coin, .. } = extra_config {
+            *gas_fa_coin = Some(fa);
+        }
+    }
+
+    let txn = h.create_transaction_payload(&sender, payload);
+    assert_success!(h.run_raw(txn).status().clone());
+}
+
+/// A versioned transaction with no `gas_fa_coin` makes the accessor return `None`.
+#[test]
+fn absent_gas_fa_coin_reads_as_none_in_transaction_context() {
+    let (mut h, _admin) = setup();
+    let sender = h.new_account_with_key_pair();
+
+    // `gas_fa_coin` left as None by `entry`; entry function aborts unless the accessor is None.
+    let payload = entry("assert_no_gas_payment_fungible_asset", vec![]);
+    let txn = h.create_transaction_payload(&sender, payload);
+    assert_success!(h.run_raw(txn).status().clone());
+}
+
+/// With `GAS_PAYABLE_FA` disabled, `gas_payment_fungible_asset()` aborts at its feature gate with
+/// `invalid_state(EGAS_PAYABLE_FA_NOT_ENABLED)` (= 196611) rather than returning a value. A plain
+/// (legacy) entry-function call suffices, since the abort happens before the accessor returns.
+#[test]
+fn accessor_aborts_when_feature_disabled() {
+    let mut h = MoveHarness::new_with_features(vec![], vec![FeatureFlag::GAS_PAYABLE_FA]);
+    let admin = h.new_account_at(AccountAddress::ONE);
+    let path = common::test_dir_path("transaction_context.data/pack");
+    assert_success!(h.publish_package_cache_building(&admin, &path));
+
+    let sender = h.new_account_with_key_pair();
+    let status = h.run_entry_function(
+        &sender,
+        str::parse("0x1::transaction_context_test::assert_no_gas_payment_fungible_asset").unwrap(),
+        vec![],
+        vec![],
+    );
+    assert_abort!(status, 196611);
+}

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -27,6 +27,7 @@ mod function_values;
 mod fungible_asset;
 mod gas;
 mod gas_fa_coin_feature_gating;
+mod gas_fa_coin_transaction_context;
 mod generate_upgrade_script;
 mod governance_updates;
 mod infinite_loop;

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -26,6 +26,7 @@ mod function_value_depth;
 mod function_values;
 mod fungible_asset;
 mod gas;
+mod gas_fa_coin_feature_gating;
 mod generate_upgrade_script;
 mod governance_updates;
 mod infinite_loop;

--- a/aptos-move/e2e-move-tests/src/tests/transaction_context.data/pack/sources/transaction_context_test.move
+++ b/aptos-move/e2e-move-tests/src/tests/transaction_context.data/pack/sources/transaction_context_test.move
@@ -86,6 +86,17 @@ module admin::transaction_context_test {
         store.chain_id = transaction_context::chain_id();
     }
 
+    /// Aborts unless the current transaction elected to pay gas in the fungible asset whose metadata
+    /// object lives at `expected`.
+    public entry fun assert_gas_payment_fungible_asset(_s: &signer, expected: address) {
+        assert!(transaction_context::gas_payment_fungible_asset() == option::some(expected), 1000);
+    }
+
+    /// Aborts unless the current transaction did not elect to pay gas in a fungible asset.
+    public entry fun assert_no_gas_payment_fungible_asset(_s: &signer) {
+        assert!(option::is_none(&transaction_context::gas_payment_fungible_asset()), 1001);
+    }
+
     entry fun store_entry_function_payload_from_native_txn_context<T1, T2, T3>(
         _s: &signer,
         arg0: u64,

--- a/aptos-move/e2e-move-tests/src/tests/transaction_context.data/pack/sources/transaction_context_test.move
+++ b/aptos-move/e2e-move-tests/src/tests/transaction_context.data/pack/sources/transaction_context_test.move
@@ -7,6 +7,14 @@ module admin::transaction_context_test {
     use aptos_std::type_info;
     use aptos_framework::transaction_context;
     use aptos_framework::multisig_account;
+    use aptos_framework::fungible_asset::{Self, Metadata};
+    use aptos_framework::primary_fungible_store;
+    use aptos_framework::object::{Self, Object};
+
+    /// Records a fungible asset created by `create_gas_fa` so its metadata can be looked up.
+    struct GasFa has key {
+        metadata: Object<Metadata>,
+    }
 
     /// Since tests in e2e-move-tests/ can only call entry functions which don't have return values, we must store
     /// the results we are interested in inside this (rather-artificial) resource, which we can read back in our
@@ -95,6 +103,37 @@ module admin::transaction_context_test {
     /// Aborts unless the current transaction did not elect to pay gas in a fungible asset.
     public entry fun assert_no_gas_payment_fungible_asset(_s: &signer) {
         assert!(option::is_none(&transaction_context::gas_payment_fungible_asset()), 1001);
+    }
+
+    /// Creates a primary-store-enabled fungible asset owned by `s`, mints `amount` of it to `s`, and
+    /// records its metadata so a later transaction can elect to pay gas in it.
+    public entry fun create_gas_fa(s: &signer, amount: u64) {
+        let constructor_ref = object::create_named_object(s, b"GASFA");
+        primary_fungible_store::create_primary_store_enabled_fungible_asset(
+            &constructor_ref,
+            option::none(),
+            string::utf8(b"GasFA"),
+            string::utf8(b"GFA"),
+            8,
+            string::utf8(b""),
+            string::utf8(b""),
+        );
+        let mint_ref = fungible_asset::generate_mint_ref(&constructor_ref);
+        let metadata = object::object_from_constructor_ref<Metadata>(&constructor_ref);
+        primary_fungible_store::deposit(signer::address_of(s), fungible_asset::mint(&mint_ref, amount));
+        move_to(s, GasFa { metadata });
+    }
+
+    #[view]
+    /// The metadata object address of the fungible asset created by `create_gas_fa` for `owner`.
+    public fun gas_fa_metadata_address(owner: address): address acquires GasFa {
+        object::object_address(&borrow_global<GasFa>(owner).metadata)
+    }
+
+    #[view]
+    /// `owner`'s primary-store balance of the fungible asset identified by `metadata`.
+    public fun fa_balance(owner: address, metadata: address): u64 {
+        primary_fungible_store::balance(owner, object::address_to_object<Metadata>(metadata))
     }
 
     entry fun store_entry_function_payload_from_native_txn_context<T1, T2, T3>(

--- a/aptos-move/framework/aptos-framework/doc/aptos_governance.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_governance.md
@@ -37,6 +37,8 @@ on a proposal multiple times as long as the total voting power of these votes do
 -  [Function `initialize`](#0x1_aptos_governance_initialize)
 -  [Function `update_governance_config`](#0x1_aptos_governance_update_governance_config)
 -  [Function `initialize_partial_voting`](#0x1_aptos_governance_initialize_partial_voting)
+-  [Function `partial_voting_initialized`](#0x1_aptos_governance_partial_voting_initialized)
+-  [Function `initialize_partial_voting_if_needed`](#0x1_aptos_governance_initialize_partial_voting_if_needed)
 -  [Function `get_voting_duration_secs`](#0x1_aptos_governance_get_voting_duration_secs)
 -  [Function `get_min_voting_threshold`](#0x1_aptos_governance_get_min_voting_threshold)
 -  [Function `get_required_proposer_stake`](#0x1_aptos_governance_get_required_proposer_stake)
@@ -72,6 +74,8 @@ on a proposal multiple times as long as the total voting power of these votes do
     -  [Function `initialize`](#@Specification_1_initialize)
     -  [Function `update_governance_config`](#@Specification_1_update_governance_config)
     -  [Function `initialize_partial_voting`](#@Specification_1_initialize_partial_voting)
+    -  [Function `partial_voting_initialized`](#@Specification_1_partial_voting_initialized)
+    -  [Function `initialize_partial_voting_if_needed`](#@Specification_1_initialize_partial_voting_if_needed)
     -  [Function `get_voting_duration_secs`](#@Specification_1_get_voting_duration_secs)
     -  [Function `get_min_voting_threshold`](#@Specification_1_get_min_voting_threshold)
     -  [Function `get_required_proposer_stake`](#@Specification_1_get_required_proposer_stake)
@@ -1094,6 +1098,65 @@ proposals with a signer for the aptos_framework (0x1) account.
     <b>move_to</b>(aptos_framework, <a href="aptos_governance.md#0x1_aptos_governance_VotingRecordsV2">VotingRecordsV2</a> {
         votes: <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_new">smart_table::new</a>(),
     });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_aptos_governance_partial_voting_initialized"></a>
+
+## Function `partial_voting_initialized`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_partial_voting_initialized">partial_voting_initialized</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_partial_voting_initialized">partial_voting_initialized</a>(): bool {
+    <b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_VotingRecordsV2">VotingRecordsV2</a>&gt;(@aptos_framework)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_aptos_governance_initialize_partial_voting_if_needed"></a>
+
+## Function `initialize_partial_voting_if_needed`
+
+Initializes the state for Aptos Governance partial voting if it has not already been initialized.
+This can only be called with a signer for the aptos_framework (0x1) account.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_initialize_partial_voting_if_needed">initialize_partial_voting_if_needed</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_initialize_partial_voting_if_needed">initialize_partial_voting_if_needed</a>(
+    aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
+
+    <b>if</b> (!<a href="aptos_governance.md#0x1_aptos_governance_partial_voting_initialized">partial_voting_initialized</a>()) {
+        <b>move_to</b>(aptos_framework, <a href="aptos_governance.md#0x1_aptos_governance_VotingRecordsV2">VotingRecordsV2</a> {
+            votes: <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_new">smart_table::new</a>(),
+        });
+    }
 }
 </code></pre>
 
@@ -2314,6 +2377,44 @@ Abort if structs have already been created.
 <pre><code><b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
 <b>aborts_if</b> addr != @aptos_framework;
 <b>aborts_if</b> <b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_VotingRecordsV2">VotingRecordsV2</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_VotingRecordsV2">VotingRecordsV2</a>&gt;(@aptos_framework);
+</code></pre>
+
+
+
+<a id="@Specification_1_partial_voting_initialized"></a>
+
+### Function `partial_voting_initialized`
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_partial_voting_initialized">partial_voting_initialized</a>(): bool
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == <b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_VotingRecordsV2">VotingRecordsV2</a>&gt;(@aptos_framework);
+</code></pre>
+
+
+
+<a id="@Specification_1_initialize_partial_voting_if_needed"></a>
+
+### Function `initialize_partial_voting_if_needed`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_initialize_partial_voting_if_needed">initialize_partial_voting_if_needed</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+Signer address must be @aptos_framework.
+
+
+<pre><code><b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
+<b>aborts_if</b> addr != @aptos_framework;
 <b>ensures</b> <b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_VotingRecordsV2">VotingRecordsV2</a>&gt;(@aptos_framework);
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/delegation_pool.md
+++ b/aptos-move/framework/aptos-framework/doc/delegation_pool.md
@@ -152,6 +152,7 @@ transferred to A
 -  [Function `owner_cap_exists`](#0x1_delegation_pool_owner_cap_exists)
 -  [Function `get_owned_pool_address`](#0x1_delegation_pool_get_owned_pool_address)
 -  [Function `delegation_pool_exists`](#0x1_delegation_pool_delegation_pool_exists)
+-  [Function `governance_records_initialized`](#0x1_delegation_pool_governance_records_initialized)
 -  [Function `partial_governance_voting_enabled`](#0x1_delegation_pool_partial_governance_voting_enabled)
 -  [Function `observed_lockup_cycle`](#0x1_delegation_pool_observed_lockup_cycle)
 -  [Function `is_next_commission_percentage_effective`](#0x1_delegation_pool_is_next_commission_percentage_effective)
@@ -179,6 +180,7 @@ transferred to A
 -  [Function `initialize_delegation_pool`](#0x1_delegation_pool_initialize_delegation_pool)
 -  [Function `beneficiary_for_operator`](#0x1_delegation_pool_beneficiary_for_operator)
 -  [Function `enable_partial_governance_voting`](#0x1_delegation_pool_enable_partial_governance_voting)
+-  [Function `enable_partial_governance_voting_if_needed`](#0x1_delegation_pool_enable_partial_governance_voting_if_needed)
 -  [Function `vote`](#0x1_delegation_pool_vote)
 -  [Function `create_proposal`](#0x1_delegation_pool_create_proposal)
 -  [Function `assert_owner_cap_exists`](#0x1_delegation_pool_assert_owner_cap_exists)
@@ -2122,6 +2124,32 @@ Return whether a delegation pool exists at supplied address <code>addr</code>.
 
 </details>
 
+<a id="0x1_delegation_pool_governance_records_initialized"></a>
+
+## Function `governance_records_initialized`
+
+Return whether a delegation pool has governance records initialized.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_governance_records_initialized">governance_records_initialized</a>(pool_address: <b>address</b>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_governance_records_initialized">governance_records_initialized</a>(pool_address: <b>address</b>): bool {
+    <b>exists</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_GovernanceRecords">GovernanceRecords</a>&gt;(pool_address)
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_delegation_pool_partial_governance_voting_enabled"></a>
 
 ## Function `partial_governance_voting_enabled`
@@ -2140,7 +2168,7 @@ Return whether a delegation pool has already enabled partial governance voting.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_partial_governance_voting_enabled">partial_governance_voting_enabled</a>(pool_address: <b>address</b>): bool {
-    <b>exists</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_GovernanceRecords">GovernanceRecords</a>&gt;(pool_address) && <a href="stake.md#0x1_stake_get_delegated_voter">stake::get_delegated_voter</a>(pool_address) == pool_address
+    <a href="delegation_pool.md#0x1_delegation_pool_governance_records_initialized">governance_records_initialized</a>(pool_address) && <a href="stake.md#0x1_stake_get_delegated_voter">stake::get_delegated_voter</a>(pool_address) == pool_address
 }
 </code></pre>
 
@@ -3078,6 +3106,37 @@ The existing voter will be replaced. The function is permissionless.
         create_proposal_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="delegation_pool.md#0x1_delegation_pool_CreateProposalEvent">CreateProposalEvent</a>&gt;(&stake_pool_signer),
         delegate_voting_power_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegateVotingPowerEvent">DelegateVotingPowerEvent</a>&gt;(&stake_pool_signer),
     });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_delegation_pool_enable_partial_governance_voting_if_needed"></a>
+
+## Function `enable_partial_governance_voting_if_needed`
+
+Enable partial governance voting on a delegation pool if it has not already been initialized.
+This is intended for idempotent migration scripts over existing delegation pools.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_enable_partial_governance_voting_if_needed">enable_partial_governance_voting_if_needed</a>(pool_address: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_enable_partial_governance_voting_if_needed">enable_partial_governance_voting_if_needed</a>(
+    pool_address: <b>address</b>,
+) <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>, <a href="delegation_pool.md#0x1_delegation_pool_GovernanceRecords">GovernanceRecords</a>, <a href="delegation_pool.md#0x1_delegation_pool_BeneficiaryForOperator">BeneficiaryForOperator</a>, <a href="delegation_pool.md#0x1_delegation_pool_NextCommissionPercentage">NextCommissionPercentage</a> {
+    <a href="delegation_pool.md#0x1_delegation_pool_assert_delegation_pool_exists">assert_delegation_pool_exists</a>(pool_address);
+    <b>if</b> (!<a href="delegation_pool.md#0x1_delegation_pool_governance_records_initialized">governance_records_initialized</a>(pool_address)) {
+        <a href="delegation_pool.md#0x1_delegation_pool_enable_partial_governance_voting">enable_partial_governance_voting</a>(pool_address);
+    }
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/governed_gas_pool.md
+++ b/aptos-move/framework/aptos-framework/doc/governed_gas_pool.md
@@ -204,6 +204,10 @@ Registry of fungible assets accepted for gas payment. Each accepted FA is held i
 governed gas pool account's own primary store for that metadata object (a separate per-FA
 pool that shares the single pool resource account), and stores its gas price alongside.
 
+Note that vector does mean we have to iterate the list, but if we replace it with Table
+or SmartTable then we have access storage a lot more which is much more expensive than
+iterating a few items. Therefore if we only a few entries, vector<> is much faster.
+
 
 <pre><code><b>struct</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a> <b>has</b> key
 </code></pre>
@@ -753,9 +757,9 @@ Deposits some coin from an account to the governed gas pool.
 
 ## Function `deposit_from_fungible_store`
 
-Deposits APT from the fungible store into the governed gas pool.
-@param account The account from which the APT FA is to be deposited.
-@param amount The amount of APT FA to be deposited.
+Deposits FA from the fungible store into the governed gas pool.
+@param account The account from which the FA is to be deposited.
+@param amount The amount of FA to be deposited.
 
 
 <pre><code><b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_from_fungible_store">deposit_from_fungible_store</a>(<a href="account.md#0x1_account">account</a>: <b>address</b>, amount: u64)

--- a/aptos-move/framework/aptos-framework/doc/governed_gas_pool.md
+++ b/aptos-move/framework/aptos-framework/doc/governed_gas_pool.md
@@ -8,8 +8,13 @@
 -  [Struct `WithdrawStakingRewardEvent`](#0x1_governed_gas_pool_WithdrawStakingRewardEvent)
 -  [Resource `GovernedGasPool`](#0x1_governed_gas_pool_GovernedGasPool)
 -  [Resource `GovernedGasPoolExtension`](#0x1_governed_gas_pool_GovernedGasPoolExtension)
+-  [Struct `AcceptedGasFa`](#0x1_governed_gas_pool_AcceptedGasFa)
+-  [Resource `AcceptedGasFungibleAssets`](#0x1_governed_gas_pool_AcceptedGasFungibleAssets)
+-  [Struct `AcceptedGasFungibleAssetUpdate`](#0x1_governed_gas_pool_AcceptedGasFungibleAssetUpdate)
+-  [Struct `GasFungibleAssetPriceUpdate`](#0x1_governed_gas_pool_GasFungibleAssetPriceUpdate)
+-  [Struct `FungibleAssetGasFeeDeposit`](#0x1_governed_gas_pool_FungibleAssetGasFeeDeposit)
 -  [Constants](#@Constants_0)
--  [Function `primary_fungible_store_address`](#0x1_governed_gas_pool_primary_fungible_store_address)
+-  [Function `primary_fungible_store_address_for`](#0x1_governed_gas_pool_primary_fungible_store_address_for)
 -  [Function `create_resource_account_seed`](#0x1_governed_gas_pool_create_resource_account_seed)
 -  [Function `initialize`](#0x1_governed_gas_pool_initialize)
 -  [Function `initialize_governed_gas_pool_extension`](#0x1_governed_gas_pool_initialize_governed_gas_pool_extension)
@@ -21,8 +26,21 @@
 -  [Function `deposit`](#0x1_governed_gas_pool_deposit)
 -  [Function `deposit_from`](#0x1_governed_gas_pool_deposit_from)
 -  [Function `deposit_from_fungible_store`](#0x1_governed_gas_pool_deposit_from_fungible_store)
+-  [Function `deposit_from_fungible_store_for`](#0x1_governed_gas_pool_deposit_from_fungible_store_for)
 -  [Function `deposit_gas_fee`](#0x1_governed_gas_pool_deposit_gas_fee)
 -  [Function `deposit_gas_fee_v2`](#0x1_governed_gas_pool_deposit_gas_fee_v2)
+-  [Function `ensure_accepted_registry`](#0x1_governed_gas_pool_ensure_accepted_registry)
+-  [Function `find_accepted_index`](#0x1_governed_gas_pool_find_accepted_index)
+-  [Function `add_accepted_gas_fungible_asset`](#0x1_governed_gas_pool_add_accepted_gas_fungible_asset)
+-  [Function `set_gas_fungible_asset_price`](#0x1_governed_gas_pool_set_gas_fungible_asset_price)
+-  [Function `remove_accepted_gas_fungible_asset`](#0x1_governed_gas_pool_remove_accepted_gas_fungible_asset)
+-  [Function `is_accepted_gas_fungible_asset`](#0x1_governed_gas_pool_is_accepted_gas_fungible_asset)
+-  [Function `accepted_gas_fungible_assets`](#0x1_governed_gas_pool_accepted_gas_fungible_assets)
+-  [Function `get_gas_fungible_asset_price`](#0x1_governed_gas_pool_get_gas_fungible_asset_price)
+-  [Function `gas_fee_in_fa`](#0x1_governed_gas_pool_gas_fee_in_fa)
+-  [Function `get_fa_balance`](#0x1_governed_gas_pool_get_fa_balance)
+-  [Function `deposit_gas_fee_fa`](#0x1_governed_gas_pool_deposit_gas_fee_fa)
+-  [Function `fund_fa`](#0x1_governed_gas_pool_fund_fa)
 -  [Function `deposit_treasury`](#0x1_governed_gas_pool_deposit_treasury)
 -  [Function `get_balance`](#0x1_governed_gas_pool_get_balance)
 -  [Function `withdraw_staking_reward`](#0x1_governed_gas_pool_withdraw_staking_reward)
@@ -43,6 +61,7 @@
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
 <b>use</b> <a href="fungible_asset.md#0x1_fungible_asset">0x1::fungible_asset</a>;
 <b>use</b> <a href="object.md#0x1_object">0x1::object</a>;
+<b>use</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store">0x1::primary_fungible_store</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
 <b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
@@ -141,9 +160,227 @@ Contains added variable needed for the GovernedGasPool staking reward update.
 
 </details>
 
+<a id="0x1_governed_gas_pool_AcceptedGasFa"></a>
+
+## Struct `AcceptedGasFa`
+
+A fungible asset accepted for gas payment, together with its gas price: the number of FA base
+units charged per unit of gas consumed. The FA gas fee for a transaction is
+<code>gas_units_used * gas_price</code>.
+
+
+<pre><code><b>struct</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFa">AcceptedGasFa</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>metadata: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>gas_price: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_governed_gas_pool_AcceptedGasFungibleAssets"></a>
+
+## Resource `AcceptedGasFungibleAssets`
+
+Registry of fungible assets accepted for gas payment. Each accepted FA is held in the
+governed gas pool account's own primary store for that metadata object (a separate per-FA
+pool that shares the single pool resource account), and stores its gas price alongside.
+
+
+<pre><code><b>struct</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>entries: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFa">governed_gas_pool::AcceptedGasFa</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_governed_gas_pool_AcceptedGasFungibleAssetUpdate"></a>
+
+## Struct `AcceptedGasFungibleAssetUpdate`
+
+Emitted when a fungible asset is added to (<code>accepted = <b>true</b></code>) or removed from
+(<code>accepted = <b>false</b></code>) the set accepted for gas payment.
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssetUpdate">AcceptedGasFungibleAssetUpdate</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>metadata: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>accepted: bool</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_governed_gas_pool_GasFungibleAssetPriceUpdate"></a>
+
+## Struct `GasFungibleAssetPriceUpdate`
+
+Emitted when a fungible asset's gas price is set or updated.
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_GasFungibleAssetPriceUpdate">GasFungibleAssetPriceUpdate</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>metadata: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>gas_price: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_governed_gas_pool_FungibleAssetGasFeeDeposit"></a>
+
+## Struct `FungibleAssetGasFeeDeposit`
+
+Emitted when gas fees are deposited into a per-FA governed gas pool.
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_FungibleAssetGasFeeDeposit">FungibleAssetGasFeeDeposit</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>gas_payer: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>metadata: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>amount: u64</code>
+</dt>
+<dd>
+ Fungible asset base units deposited.
+</dd>
+</dl>
+
+
+</details>
+
 <a id="@Constants_0"></a>
 
 ## Constants
+
+
+<a id="0x1_governed_gas_pool_MAX_U64"></a>
+
+Maximum u64 value, used to guard fungible asset gas fee computation against overflow.
+
+
+<pre><code><b>const</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_MAX_U64">MAX_U64</a>: u128 = 18446744073709551615;
+</code></pre>
+
+
+
+<a id="0x1_governed_gas_pool_EFA_NOT_ACCEPTED"></a>
+
+The fungible asset is not accepted for gas payment.
+
+
+<pre><code><b>const</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_EFA_NOT_ACCEPTED">EFA_NOT_ACCEPTED</a>: u64 = 5;
+</code></pre>
+
+
+
+<a id="0x1_governed_gas_pool_EGAS_FA_FEE_OVERFLOW"></a>
+
+The computed fungible asset gas fee does not fit in a u64.
+
+
+<pre><code><b>const</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_EGAS_FA_FEE_OVERFLOW">EGAS_FA_FEE_OVERFLOW</a>: u64 = 7;
+</code></pre>
+
+
+
+<a id="0x1_governed_gas_pool_EINVALID_GAS_FA_PRICE"></a>
+
+A gas fungible asset's gas price must be non-zero.
+
+
+<pre><code><b>const</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_EINVALID_GAS_FA_PRICE">EINVALID_GAS_FA_PRICE</a>: u64 = 6;
+</code></pre>
+
 
 
 <a id="0x1_governed_gas_pool_ENO_LONGER_SUPPORTED"></a>
@@ -165,14 +402,14 @@ No longer supported.
 
 
 
-<a id="0x1_governed_gas_pool_primary_fungible_store_address"></a>
+<a id="0x1_governed_gas_pool_primary_fungible_store_address_for"></a>
 
-## Function `primary_fungible_store_address`
+## Function `primary_fungible_store_address_for`
 
-Address of APT Primary Fungible Store
+Address of <code><a href="account.md#0x1_account">account</a></code>'s primary fungible store for the FA identified by <code>metadata</code>.
 
 
-<pre><code><b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_primary_fungible_store_address">primary_fungible_store_address</a>(<a href="account.md#0x1_account">account</a>: <b>address</b>): <b>address</b>
+<pre><code><b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_primary_fungible_store_address_for">primary_fungible_store_address_for</a>(<a href="account.md#0x1_account">account</a>: <b>address</b>, metadata: <b>address</b>): <b>address</b>
 </code></pre>
 
 
@@ -181,8 +418,8 @@ Address of APT Primary Fungible Store
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_primary_fungible_store_address">primary_fungible_store_address</a>(<a href="account.md#0x1_account">account</a>: <b>address</b>): <b>address</b> {
-    <a href="object.md#0x1_object_create_user_derived_object_address">object::create_user_derived_object_address</a>(<a href="account.md#0x1_account">account</a>, @aptos_fungible_asset)
+<pre><code>inline <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_primary_fungible_store_address_for">primary_fungible_store_address_for</a>(<a href="account.md#0x1_account">account</a>: <b>address</b>, metadata: <b>address</b>): <b>address</b> {
+    <a href="object.md#0x1_object_create_user_derived_object_address">object::create_user_derived_object_address</a>(<a href="account.md#0x1_account">account</a>, metadata)
 }
 </code></pre>
 
@@ -516,10 +753,9 @@ Deposits some coin from an account to the governed gas pool.
 
 ## Function `deposit_from_fungible_store`
 
-Deposits some FA from the fungible store.
-@param aptos_framework The signer of the aptos_framework module.
-@param account The account from which the FA is to be deposited.
-@param amount The amount of FA to be deposited.
+Deposits APT from the fungible store into the governed gas pool.
+@param account The account from which the APT FA is to be deposited.
+@param amount The amount of APT FA to be deposited.
 
 
 <pre><code><b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_from_fungible_store">deposit_from_fungible_store</a>(<a href="account.md#0x1_account">account</a>: <b>address</b>, amount: u64)
@@ -532,19 +768,41 @@ Deposits some FA from the fungible store.
 
 
 <pre><code><b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_from_fungible_store">deposit_from_fungible_store</a>(<a href="account.md#0x1_account">account</a>: <b>address</b>, amount: u64) <b>acquires</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_GovernedGasPool">GovernedGasPool</a> {
-    <b>if</b> (amount &gt; 0){
-        // compute the governed gas pool store <b>address</b>
-        <b>let</b> governed_gas_pool_address = <a href="governed_gas_pool.md#0x1_governed_gas_pool_governed_gas_pool_address">governed_gas_pool_address</a>();
-        <b>let</b> governed_gas_pool_store_address = <a href="governed_gas_pool.md#0x1_governed_gas_pool_primary_fungible_store_address">primary_fungible_store_address</a>(governed_gas_pool_address);
+    <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_from_fungible_store_for">deposit_from_fungible_store_for</a>(<a href="account.md#0x1_account">account</a>, @aptos_fungible_asset, amount);
+}
+</code></pre>
 
-        // compute the <a href="account.md#0x1_account">account</a> store <b>address</b>
-        <b>let</b> account_store_address = <a href="governed_gas_pool.md#0x1_governed_gas_pool_primary_fungible_store_address">primary_fungible_store_address</a>(<a href="account.md#0x1_account">account</a>);
+
+
+</details>
+
+<a id="0x1_governed_gas_pool_deposit_from_fungible_store_for"></a>
+
+## Function `deposit_from_fungible_store_for`
+
+Deposits <code>amount</code> of the fungible asset identified by <code>metadata</code> from <code><a href="account.md#0x1_account">account</a></code>'s primary
+store into the governed gas pool account's own primary store for that FA (its per-FA pool).
+Uses the unchecked (VM-privileged) withdraw/deposit path, as gas collection is not authorized
+by the payer's signer.
+
+
+<pre><code><b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_from_fungible_store_for">deposit_from_fungible_store_for</a>(<a href="account.md#0x1_account">account</a>: <b>address</b>, metadata: <b>address</b>, amount: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_from_fungible_store_for">deposit_from_fungible_store_for</a>(<a href="account.md#0x1_account">account</a>: <b>address</b>, metadata: <b>address</b>, amount: u64) <b>acquires</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_GovernedGasPool">GovernedGasPool</a> {
+    <b>if</b> (amount &gt; 0) {
+        <b>let</b> pool_store_address =
+            <a href="governed_gas_pool.md#0x1_governed_gas_pool_primary_fungible_store_address_for">primary_fungible_store_address_for</a>(<a href="governed_gas_pool.md#0x1_governed_gas_pool_governed_gas_pool_address">governed_gas_pool_address</a>(), metadata);
+        <b>let</b> account_store_address = <a href="governed_gas_pool.md#0x1_governed_gas_pool_primary_fungible_store_address_for">primary_fungible_store_address_for</a>(<a href="account.md#0x1_account">account</a>, metadata);
         <a href="fungible_asset.md#0x1_fungible_asset_unchecked_deposit">fungible_asset::unchecked_deposit</a>(
-            governed_gas_pool_store_address,
-            <a href="fungible_asset.md#0x1_fungible_asset_unchecked_withdraw">fungible_asset::unchecked_withdraw</a>(
-                account_store_address,
-                amount
-            )
+            pool_store_address,
+            <a href="fungible_asset.md#0x1_fungible_asset_unchecked_withdraw">fungible_asset::unchecked_withdraw</a>(account_store_address, amount)
         );
     }
 }
@@ -605,6 +863,433 @@ Deposits gas fees into the governed gas pool.
     } <b>else</b> {
         <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_from">deposit_from</a>&lt;AptosCoin&gt;(gas_payer, gas_fee);
     };
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_governed_gas_pool_ensure_accepted_registry"></a>
+
+## Function `ensure_accepted_registry`
+
+Creates the accepted-FA registry under @aptos_framework if it does not yet exist. This lets
+the feature roll out onto an already-initialized governed gas pool without re-running
+<code>initialize</code>.
+
+
+<pre><code><b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_ensure_accepted_registry">ensure_accepted_registry</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_ensure_accepted_registry">ensure_accepted_registry</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+    <b>if</b> (!<b>exists</b>&lt;<a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework))) {
+        <b>move_to</b>(aptos_framework, <a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a> { entries: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;<a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFa">AcceptedGasFa</a>&gt;() });
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_governed_gas_pool_find_accepted_index"></a>
+
+## Function `find_accepted_index`
+
+Index of the accepted-FA entry for <code>metadata</code>, if present.
+
+
+<pre><code><b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_find_accepted_index">find_accepted_index</a>(entries: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFa">governed_gas_pool::AcceptedGasFa</a>&gt;, metadata: <b>address</b>): (bool, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_find_accepted_index">find_accepted_index</a>(entries: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFa">AcceptedGasFa</a>&gt;, metadata: <b>address</b>): (bool, u64) {
+    <b>let</b> len = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(entries);
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; len) {
+        <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(entries, i).metadata == metadata) {
+            <b>return</b> (<b>true</b>, i)
+        };
+        i = i + 1;
+    };
+    (<b>false</b>, 0)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_governed_gas_pool_add_accepted_gas_fungible_asset"></a>
+
+## Function `add_accepted_gas_fungible_asset`
+
+Adds a fungible asset to the set accepted for gas payment with its gas price (FA base units
+charged per unit of gas consumed), and ensures the pool has a primary store to hold it.
+Governance-gated (requires the @aptos_framework signer). Re-adding an existing FA updates its
+gas price.
+@param aptos_framework The signer of the aptos_framework module.
+@param metadata The metadata object of the fungible asset to accept.
+@param gas_price FA base units charged per unit of gas consumed; must be non-zero.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_add_accepted_gas_fungible_asset">add_accepted_gas_fungible_asset</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;, gas_price: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_add_accepted_gas_fungible_asset">add_accepted_gas_fungible_asset</a>(
+    aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    metadata: Object&lt;Metadata&gt;,
+    gas_price: u64,
+) <b>acquires</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_GovernedGasPool">GovernedGasPool</a>, <a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
+    <b>assert</b>!(gas_price &gt; 0, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="governed_gas_pool.md#0x1_governed_gas_pool_EINVALID_GAS_FA_PRICE">EINVALID_GAS_FA_PRICE</a>));
+    <a href="governed_gas_pool.md#0x1_governed_gas_pool_ensure_accepted_registry">ensure_accepted_registry</a>(aptos_framework);
+    <b>let</b> metadata_address = <a href="object.md#0x1_object_object_address">object::object_address</a>(&metadata);
+    <b>let</b> accepted = <b>borrow_global_mut</b>&lt;<a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a>&gt;(@aptos_framework);
+    <b>let</b> (found, i) = <a href="governed_gas_pool.md#0x1_governed_gas_pool_find_accepted_index">find_accepted_index</a>(&accepted.entries, metadata_address);
+    <b>if</b> (found) {
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> accepted.entries, i).gas_price = gas_price;
+    } <b>else</b> {
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> accepted.entries, <a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFa">AcceptedGasFa</a> { metadata: metadata_address, gas_price });
+        // Ensure the pool <b>has</b> a primary store for this FA so unchecked deposits succeed.
+        <a href="primary_fungible_store.md#0x1_primary_fungible_store_ensure_primary_store_exists">primary_fungible_store::ensure_primary_store_exists</a>(<a href="governed_gas_pool.md#0x1_governed_gas_pool_governed_gas_pool_address">governed_gas_pool_address</a>(), metadata);
+        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssetUpdate">AcceptedGasFungibleAssetUpdate</a> { metadata: metadata_address, accepted: <b>true</b> });
+    };
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="governed_gas_pool.md#0x1_governed_gas_pool_GasFungibleAssetPriceUpdate">GasFungibleAssetPriceUpdate</a> { metadata: metadata_address, gas_price });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_governed_gas_pool_set_gas_fungible_asset_price"></a>
+
+## Function `set_gas_fungible_asset_price`
+
+Sets (updates) the gas price of an already-accepted fungible asset. Governance-gated.
+@param aptos_framework The signer of the aptos_framework module.
+@param metadata The metadata object of the fungible asset.
+@param gas_price FA base units charged per unit of gas consumed; must be non-zero.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_set_gas_fungible_asset_price">set_gas_fungible_asset_price</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;, gas_price: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_set_gas_fungible_asset_price">set_gas_fungible_asset_price</a>(
+    aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    metadata: Object&lt;Metadata&gt;,
+    gas_price: u64,
+) <b>acquires</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
+    <b>assert</b>!(gas_price &gt; 0, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="governed_gas_pool.md#0x1_governed_gas_pool_EINVALID_GAS_FA_PRICE">EINVALID_GAS_FA_PRICE</a>));
+    <b>assert</b>!(<b>exists</b>&lt;<a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a>&gt;(@aptos_framework), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="governed_gas_pool.md#0x1_governed_gas_pool_EFA_NOT_ACCEPTED">EFA_NOT_ACCEPTED</a>));
+    <b>let</b> metadata_address = <a href="object.md#0x1_object_object_address">object::object_address</a>(&metadata);
+    <b>let</b> accepted = <b>borrow_global_mut</b>&lt;<a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a>&gt;(@aptos_framework);
+    <b>let</b> (found, i) = <a href="governed_gas_pool.md#0x1_governed_gas_pool_find_accepted_index">find_accepted_index</a>(&accepted.entries, metadata_address);
+    <b>assert</b>!(found, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="governed_gas_pool.md#0x1_governed_gas_pool_EFA_NOT_ACCEPTED">EFA_NOT_ACCEPTED</a>));
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> accepted.entries, i).gas_price = gas_price;
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="governed_gas_pool.md#0x1_governed_gas_pool_GasFungibleAssetPriceUpdate">GasFungibleAssetPriceUpdate</a> { metadata: metadata_address, gas_price });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_governed_gas_pool_remove_accepted_gas_fungible_asset"></a>
+
+## Function `remove_accepted_gas_fungible_asset`
+
+Removes a fungible asset from the set accepted for gas payment. Any balance already held in
+its pool remains and can still be withdrawn via <code>fund_fa</code>. Governance-gated.
+@param aptos_framework The signer of the aptos_framework module.
+@param metadata The metadata object of the fungible asset to stop accepting.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_remove_accepted_gas_fungible_asset">remove_accepted_gas_fungible_asset</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_remove_accepted_gas_fungible_asset">remove_accepted_gas_fungible_asset</a>(
+    aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    metadata: Object&lt;Metadata&gt;,
+) <b>acquires</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
+    <b>if</b> (!<b>exists</b>&lt;<a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a>&gt;(@aptos_framework)) {
+        <b>return</b>
+    };
+    <b>let</b> metadata_address = <a href="object.md#0x1_object_object_address">object::object_address</a>(&metadata);
+    <b>let</b> accepted = <b>borrow_global_mut</b>&lt;<a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a>&gt;(@aptos_framework);
+    <b>let</b> (found, i) = <a href="governed_gas_pool.md#0x1_governed_gas_pool_find_accepted_index">find_accepted_index</a>(&accepted.entries, metadata_address);
+    <b>if</b> (found) {
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_remove">vector::remove</a>(&<b>mut</b> accepted.entries, i);
+        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssetUpdate">AcceptedGasFungibleAssetUpdate</a> { metadata: metadata_address, accepted: <b>false</b> });
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_governed_gas_pool_is_accepted_gas_fungible_asset"></a>
+
+## Function `is_accepted_gas_fungible_asset`
+
+Whether the fungible asset identified by <code>metadata</code> is accepted for gas payment.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_is_accepted_gas_fungible_asset">is_accepted_gas_fungible_asset</a>(metadata: <b>address</b>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_is_accepted_gas_fungible_asset">is_accepted_gas_fungible_asset</a>(metadata: <b>address</b>): bool <b>acquires</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a> {
+    <b>if</b> (!<b>exists</b>&lt;<a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a>&gt;(@aptos_framework)) {
+        <b>return</b> <b>false</b>
+    };
+    <b>let</b> (found, _) = <a href="governed_gas_pool.md#0x1_governed_gas_pool_find_accepted_index">find_accepted_index</a>(&<b>borrow_global</b>&lt;<a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a>&gt;(@aptos_framework).entries, metadata);
+    found
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_governed_gas_pool_accepted_gas_fungible_assets"></a>
+
+## Function `accepted_gas_fungible_assets`
+
+The full set of fungible asset metadata addresses accepted for gas payment.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_accepted_gas_fungible_assets">accepted_gas_fungible_assets</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_accepted_gas_fungible_assets">accepted_gas_fungible_assets</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt; <b>acquires</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a> {
+    <b>let</b> result = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;<b>address</b>&gt;();
+    <b>if</b> (<b>exists</b>&lt;<a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a>&gt;(@aptos_framework)) {
+        <b>let</b> entries = &<b>borrow_global</b>&lt;<a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a>&gt;(@aptos_framework).entries;
+        <b>let</b> len = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(entries);
+        <b>let</b> i = 0;
+        <b>while</b> (i &lt; len) {
+            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> result, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(entries, i).metadata);
+            i = i + 1;
+        };
+    };
+    result
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_governed_gas_pool_get_gas_fungible_asset_price"></a>
+
+## Function `get_gas_fungible_asset_price`
+
+The gas price (FA base units per unit of gas) of an accepted fungible asset. Aborts if the
+fungible asset is not accepted for gas payment.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_get_gas_fungible_asset_price">get_gas_fungible_asset_price</a>(metadata: <b>address</b>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_get_gas_fungible_asset_price">get_gas_fungible_asset_price</a>(metadata: <b>address</b>): u64 <b>acquires</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a> {
+    <b>assert</b>!(<b>exists</b>&lt;<a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a>&gt;(@aptos_framework), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="governed_gas_pool.md#0x1_governed_gas_pool_EFA_NOT_ACCEPTED">EFA_NOT_ACCEPTED</a>));
+    <b>let</b> accepted = <b>borrow_global</b>&lt;<a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a>&gt;(@aptos_framework);
+    <b>let</b> (found, i) = <a href="governed_gas_pool.md#0x1_governed_gas_pool_find_accepted_index">find_accepted_index</a>(&accepted.entries, metadata);
+    <b>assert</b>!(found, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="governed_gas_pool.md#0x1_governed_gas_pool_EFA_NOT_ACCEPTED">EFA_NOT_ACCEPTED</a>));
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&accepted.entries, i).gas_price
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_governed_gas_pool_gas_fee_in_fa"></a>
+
+## Function `gas_fee_in_fa`
+
+The fungible asset gas fee for <code>gas_units</code> of gas consumed under <code>metadata</code>'s gas price, i.e.
+<code>gas_units * gas_price</code>. Aborts if the FA is not accepted or the fee overflows u64.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_gas_fee_in_fa">gas_fee_in_fa</a>(metadata: <b>address</b>, gas_units: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_gas_fee_in_fa">gas_fee_in_fa</a>(metadata: <b>address</b>, gas_units: u64): u64 <b>acquires</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a> {
+    <b>let</b> price = <a href="governed_gas_pool.md#0x1_governed_gas_pool_get_gas_fungible_asset_price">get_gas_fungible_asset_price</a>(metadata);
+    <b>let</b> fee = (gas_units <b>as</b> u128) * (price <b>as</b> u128);
+    <b>assert</b>!(fee &lt;= <a href="governed_gas_pool.md#0x1_governed_gas_pool_MAX_U64">MAX_U64</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="governed_gas_pool.md#0x1_governed_gas_pool_EGAS_FA_FEE_OVERFLOW">EGAS_FA_FEE_OVERFLOW</a>));
+    (fee <b>as</b> u64)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_governed_gas_pool_get_fa_balance"></a>
+
+## Function `get_fa_balance`
+
+The governed gas pool's balance of the fungible asset identified by <code>metadata</code>.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_get_fa_balance">get_fa_balance</a>(metadata: <b>address</b>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_get_fa_balance">get_fa_balance</a>(metadata: <b>address</b>): u64 <b>acquires</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_GovernedGasPool">GovernedGasPool</a> {
+    <a href="primary_fungible_store.md#0x1_primary_fungible_store_balance">primary_fungible_store::balance</a>(
+        <a href="governed_gas_pool.md#0x1_governed_gas_pool_governed_gas_pool_address">governed_gas_pool_address</a>(),
+        <a href="object.md#0x1_object_address_to_object">object::address_to_object</a>&lt;Metadata&gt;(metadata)
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_governed_gas_pool_deposit_gas_fee_fa"></a>
+
+## Function `deposit_gas_fee_fa`
+
+Deposits <code>fa_amount</code> base units of a selected gas fungible asset (already converted from gas
+via that FA's gas price) into its governed gas pool. Aborts if the FA is not accepted.
+@param gas_payer The address that paid the gas fees.
+@param metadata The metadata object address of the fungible asset.
+@param fa_amount The fungible asset base units to deposit.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_gas_fee_fa">deposit_gas_fee_fa</a>(gas_payer: <b>address</b>, metadata: <b>address</b>, fa_amount: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_gas_fee_fa">deposit_gas_fee_fa</a>(
+    gas_payer: <b>address</b>,
+    metadata: <b>address</b>,
+    fa_amount: u64,
+) <b>acquires</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_GovernedGasPool">GovernedGasPool</a>, <a href="governed_gas_pool.md#0x1_governed_gas_pool_AcceptedGasFungibleAssets">AcceptedGasFungibleAssets</a> {
+    <b>assert</b>!(<a href="governed_gas_pool.md#0x1_governed_gas_pool_is_accepted_gas_fungible_asset">is_accepted_gas_fungible_asset</a>(metadata), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="governed_gas_pool.md#0x1_governed_gas_pool_EFA_NOT_ACCEPTED">EFA_NOT_ACCEPTED</a>));
+    <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_from_fungible_store_for">deposit_from_fungible_store_for</a>(gas_payer, metadata, fa_amount);
+    <b>if</b> (fa_amount &gt; 0) {
+        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="governed_gas_pool.md#0x1_governed_gas_pool_FungibleAssetGasFeeDeposit">FungibleAssetGasFeeDeposit</a> { gas_payer, metadata, amount: fa_amount });
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_governed_gas_pool_fund_fa"></a>
+
+## Function `fund_fa`
+
+Withdraws <code>amount</code> of the fungible asset identified by <code>metadata</code> from its governed gas pool
+and deposits it to <code><a href="account.md#0x1_account">account</a></code>. Governance-gated; the mirror of <code>fund</code> for fungible assets.
+@param aptos_framework The signer of the aptos_framework module.
+@param account The recipient account.
+@param metadata The metadata object address of the fungible asset.
+@param amount The amount to withdraw from the pool.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_fund_fa">fund_fa</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="account.md#0x1_account">account</a>: <b>address</b>, metadata: <b>address</b>, amount: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_fund_fa">fund_fa</a>(
+    aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    <a href="account.md#0x1_account">account</a>: <b>address</b>,
+    metadata: <b>address</b>,
+    amount: u64,
+) <b>acquires</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_GovernedGasPool">GovernedGasPool</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
+    <b>let</b> pool_signer = <a href="governed_gas_pool.md#0x1_governed_gas_pool_governed_gas_signer">governed_gas_signer</a>();
+    <b>let</b> fa = <a href="primary_fungible_store.md#0x1_primary_fungible_store_withdraw">primary_fungible_store::withdraw</a>(
+        &pool_signer,
+        <a href="object.md#0x1_object_address_to_object">object::address_to_object</a>&lt;Metadata&gt;(metadata),
+        amount
+    );
+    <a href="primary_fungible_store.md#0x1_primary_fungible_store_deposit">primary_fungible_store::deposit</a>(<a href="account.md#0x1_account">account</a>, fa);
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/staking_contract.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_contract.md
@@ -1319,6 +1319,16 @@ Store amount must be at least the min stake required for a stake pool to join th
 
 
 
+<a id="0x1_staking_contract_EINVALID_BENEFICIARY_ADDRESS"></a>
+
+Beneficiary cannot be a reserved address that cannot receive coin distributions.
+
+
+<pre><code><b>const</b> <a href="staking_contract.md#0x1_staking_contract_EINVALID_BENEFICIARY_ADDRESS">EINVALID_BENEFICIARY_ADDRESS</a>: u64 = 10;
+</code></pre>
+
+
+
 <a id="0x1_staking_contract_ENOT_STAKER_OR_OPERATOR_OR_BENEFICIARY"></a>
 
 Caller must be either the staker, operator, or beneficiary.
@@ -2283,6 +2293,12 @@ the beneficiary. An operator can set one beneficiary for staking contract pools,
     <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operator_beneficiary_change_enabled">features::operator_beneficiary_change_enabled</a>(), std::error::invalid_state(
         <a href="staking_contract.md#0x1_staking_contract_EOPERATOR_BENEFICIARY_CHANGE_NOT_SUPPORTED">EOPERATOR_BENEFICIARY_CHANGE_NOT_SUPPORTED</a>
     ));
+    // @vm_reserved can never have an <a href="account.md#0x1_account">account</a> created for it, so it can't receive <a href="coin.md#0x1_coin">coin</a> distributions.
+    // Allowing it <b>as</b> a beneficiary would permanently brick distribution for the staking contract.
+    <b>assert</b>!(
+        new_beneficiary != @vm_reserved,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_contract.md#0x1_staking_contract_EINVALID_BENEFICIARY_ADDRESS">EINVALID_BENEFICIARY_ADDRESS</a>),
+    );
     // The beneficiay <b>address</b> of an operator is stored under the operator's <b>address</b>.
     // So, the operator does not need <b>to</b> be validated <b>with</b> respect <b>to</b> a staking pool.
     <b>let</b> operator_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(operator);

--- a/aptos-move/framework/aptos-framework/doc/transaction_context.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_context.md
@@ -28,6 +28,8 @@
 -  [Function `gas_unit_price_internal`](#0x1_transaction_context_gas_unit_price_internal)
 -  [Function `chain_id`](#0x1_transaction_context_chain_id)
 -  [Function `chain_id_internal`](#0x1_transaction_context_chain_id_internal)
+-  [Function `gas_payment_fungible_asset`](#0x1_transaction_context_gas_payment_fungible_asset)
+-  [Function `gas_payment_fa_metadata_internal`](#0x1_transaction_context_gas_payment_fa_metadata_internal)
 -  [Function `entry_function_payload`](#0x1_transaction_context_entry_function_payload)
 -  [Function `entry_function_payload_internal`](#0x1_transaction_context_entry_function_payload_internal)
 -  [Function `account_address`](#0x1_transaction_context_account_address)
@@ -184,6 +186,16 @@ Represents the multisig payload.
 <a id="@Constants_0"></a>
 
 ## Constants
+
+
+<a id="0x1_transaction_context_EGAS_PAYABLE_FA_NOT_ENABLED"></a>
+
+Paying gas in a fungible asset (the <code>GAS_PAYABLE_FA</code> feature) is not enabled.
+
+
+<pre><code><b>const</b> <a href="transaction_context.md#0x1_transaction_context_EGAS_PAYABLE_FA_NOT_ENABLED">EGAS_PAYABLE_FA_NOT_ENABLED</a>: u64 = 3;
+</code></pre>
+
 
 
 <a id="0x1_transaction_context_ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED"></a>
@@ -679,6 +691,56 @@ This function aborts if called outside of the transaction prologue, execution, o
 
 
 <pre><code><b>native</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_chain_id_internal">chain_id_internal</a>(): u8;
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_transaction_context_gas_payment_fungible_asset"></a>
+
+## Function `gas_payment_fungible_asset`
+
+Returns the fungible asset metadata address that the current transaction elected to pay gas in,
+or <code>None</code> if gas is paid in the default currency (APT).
+This function aborts if called outside of the transaction prologue, execution, or epilogue phases.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_gas_payment_fungible_asset">gas_payment_fungible_asset</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_gas_payment_fungible_asset">gas_payment_fungible_asset</a>(): Option&lt;<b>address</b>&gt; {
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_gas_payable_fa_enabled">features::is_gas_payable_fa_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="transaction_context.md#0x1_transaction_context_EGAS_PAYABLE_FA_NOT_ENABLED">EGAS_PAYABLE_FA_NOT_ENABLED</a>));
+    <a href="transaction_context.md#0x1_transaction_context_gas_payment_fa_metadata_internal">gas_payment_fa_metadata_internal</a>()
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_transaction_context_gas_payment_fa_metadata_internal"></a>
+
+## Function `gas_payment_fa_metadata_internal`
+
+
+
+<pre><code><b>fun</b> <a href="transaction_context.md#0x1_transaction_context_gas_payment_fa_metadata_internal">gas_payment_fa_metadata_internal</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_gas_payment_fa_metadata_internal">gas_payment_fa_metadata_internal</a>(): Option&lt;<b>address</b>&gt;;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/transaction_validation.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_validation.md
@@ -13,6 +13,7 @@
 -  [Function `revoke_gas_permission`](#0x1_transaction_validation_revoke_gas_permission)
 -  [Function `initialize`](#0x1_transaction_validation_initialize)
 -  [Function `allow_missing_txn_authentication_key`](#0x1_transaction_validation_allow_missing_txn_authentication_key)
+-  [Function `gas_fa_metadata`](#0x1_transaction_validation_gas_fa_metadata)
 -  [Function `prologue_common`](#0x1_transaction_validation_prologue_common)
 -  [Function `check_for_replay_protection_regular_txn`](#0x1_transaction_validation_check_for_replay_protection_regular_txn)
 -  [Function `check_for_replay_protection_orderless_txn`](#0x1_transaction_validation_check_for_replay_protection_orderless_txn)
@@ -62,13 +63,17 @@
 <b>use</b> <a href="create_signer.md#0x1_create_signer">0x1::create_signer</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
+<b>use</b> <a href="fungible_asset.md#0x1_fungible_asset">0x1::fungible_asset</a>;
 <b>use</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool">0x1::governed_gas_pool</a>;
 <b>use</b> <a href="nonce_validation.md#0x1_nonce_validation">0x1::nonce_validation</a>;
+<b>use</b> <a href="object.md#0x1_object">0x1::object</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
 <b>use</b> <a href="permissioned_signer.md#0x1_permissioned_signer">0x1::permissioned_signer</a>;
+<b>use</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store">0x1::primary_fungible_store</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
 <b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
 <b>use</b> <a href="timestamp.md#0x1_timestamp">0x1::timestamp</a>;
+<b>use</b> <a href="transaction_context.md#0x1_transaction_context">0x1::transaction_context</a>;
 <b>use</b> <a href="transaction_fee.md#0x1_transaction_fee">0x1::transaction_fee</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
 </code></pre>
@@ -505,6 +510,37 @@ Only called during genesis to initialize system resources for this module.
 
 </details>
 
+<a id="0x1_transaction_validation_gas_fa_metadata"></a>
+
+## Function `gas_fa_metadata`
+
+The fungible asset metadata address this transaction elected to pay gas in, or <code>None</code> if it
+pays in the default currency (APT). Returns <code>None</code> when the <code>GAS_PAYABLE_FA</code> feature is off,
+so the accessor (which is gated on that feature) is only called when it is enabled.
+
+
+<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_gas_fa_metadata">gas_fa_metadata</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code>inline <b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_gas_fa_metadata">gas_fa_metadata</a>(): Option&lt;<b>address</b>&gt; {
+    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_gas_payable_fa_enabled">features::is_gas_payable_fa_enabled</a>()) {
+        <a href="transaction_context.md#0x1_transaction_context_gas_payment_fungible_asset">transaction_context::gas_payment_fungible_asset</a>()
+    } <b>else</b> {
+        <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>&lt;<b>address</b>&gt;()
+    }
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_transaction_validation_prologue_common"></a>
 
 ## Function `prologue_common`
@@ -595,7 +631,27 @@ Only called during genesis to initialize system resources for this module.
             ),
             <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_PERMISSIONED_GAS_LIMIT_INSUFFICIENT">PROLOGUE_PERMISSIONED_GAS_LIMIT_INSUFFICIENT</a>)
         );
-        <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operations_default_to_fa_apt_store_enabled">features::operations_default_to_fa_apt_store_enabled</a>()) {
+        <b>let</b> gas_fa_metadata = <a href="transaction_validation.md#0x1_transaction_validation_gas_fa_metadata">gas_fa_metadata</a>();
+        <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&gas_fa_metadata)) {
+            // Gas is paid in a selected fungible asset: it must be accepted by the governed gas
+            // pool and the payer must hold enough of it.
+            <b>let</b> metadata = *<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&gas_fa_metadata);
+            <b>assert</b>!(
+                <a href="governed_gas_pool.md#0x1_governed_gas_pool_is_accepted_gas_fungible_asset">governed_gas_pool::is_accepted_gas_fungible_asset</a>(metadata),
+                <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>)
+            );
+            // The FA gas fee is charged <b>as</b> gas_used * per-FA gas price; check the payer can
+            // cover the maximum (all of txn_max_gas_units).
+            <b>let</b> max_fa_fee = <a href="governed_gas_pool.md#0x1_governed_gas_pool_gas_fee_in_fa">governed_gas_pool::gas_fee_in_fa</a>(metadata, txn_max_gas_units);
+            <b>assert</b>!(
+                <a href="primary_fungible_store.md#0x1_primary_fungible_store_is_balance_at_least">primary_fungible_store::is_balance_at_least</a>(
+                    gas_payer_address,
+                    <a href="object.md#0x1_object_address_to_object">object::address_to_object</a>&lt;Metadata&gt;(metadata),
+                    max_fa_fee
+                ),
+                <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>)
+            );
+        } <b>else</b> <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operations_default_to_fa_apt_store_enabled">features::operations_default_to_fa_apt_store_enabled</a>()) {
             <b>assert</b>!(
                 <a href="aptos_account.md#0x1_aptos_account_is_fungible_balance_at_least">aptos_account::is_fungible_balance_at_least</a>(gas_payer_address, max_transaction_fee),
                 <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>)
@@ -1017,38 +1073,56 @@ Called by the Adapter
     // it's important <b>to</b> maintain the <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">error</a> <a href="code.md#0x1_code">code</a> consistent <b>with</b> vm
     // <b>to</b> do failed transaction cleanup.
     <b>if</b> (!<a href="transaction_validation.md#0x1_transaction_validation_skip_gas_payment">skip_gas_payment</a>(is_simulation, gas_payer)) {
-        <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operations_default_to_fa_apt_store_enabled">features::operations_default_to_fa_apt_store_enabled</a>()) {
+        <b>let</b> gas_fa_metadata = <a href="transaction_validation.md#0x1_transaction_validation_gas_fa_metadata">gas_fa_metadata</a>();
+        <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&gas_fa_metadata)) {
+            // Gas paid in a selected fungible asset is charged <b>as</b> gas_used * the FA's gas price
+            // and collected into that FA's governed gas pool. NOTE: the storage-fee refund is
+            // not netted for FA payers; that is a follow-up.
+            <b>let</b> metadata = *<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&gas_fa_metadata);
+            <b>let</b> fa_fee = <a href="governed_gas_pool.md#0x1_governed_gas_pool_gas_fee_in_fa">governed_gas_pool::gas_fee_in_fa</a>(metadata, gas_used);
             <b>assert</b>!(
-                <a href="aptos_account.md#0x1_aptos_account_is_fungible_balance_at_least">aptos_account::is_fungible_balance_at_least</a>(gas_payer, transaction_fee_amount),
+                <a href="primary_fungible_store.md#0x1_primary_fungible_store_is_balance_at_least">primary_fungible_store::is_balance_at_least</a>(
+                    gas_payer,
+                    <a href="object.md#0x1_object_address_to_object">object::address_to_object</a>&lt;Metadata&gt;(metadata),
+                    fa_fee
+                ),
                 <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>),
             );
+            <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_gas_fee_fa">governed_gas_pool::deposit_gas_fee_fa</a>(gas_payer, metadata, fa_fee);
         } <b>else</b> {
-            <b>assert</b>!(
-                <a href="coin.md#0x1_coin_is_balance_at_least">coin::is_balance_at_least</a>&lt;AptosCoin&gt;(gas_payer, transaction_fee_amount),
-                <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>),
-            );
-        };
-
-        <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_storage_deletion_refund_enabled">features::storage_deletion_refund_enabled</a>()){
-            <b>if</b> (transaction_fee_amount &gt; storage_fee_refunded) {
-                <b>let</b> burn_amount = transaction_fee_amount - storage_fee_refunded;
-                <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_governed_gas_pool_enabled">features::governed_gas_pool_enabled</a>()){
-                    <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_gas_fee_v2">governed_gas_pool::deposit_gas_fee_v2</a>(gas_payer, burn_amount);
-                } <b>else</b> {
-                    <a href="transaction_fee.md#0x1_transaction_fee_burn_fee">transaction_fee::burn_fee</a>(gas_payer, burn_amount);
-                }
-            } <b>else</b> <b>if</b> (transaction_fee_amount &lt; storage_fee_refunded) {
-                <b>let</b> mint_amount = storage_fee_refunded - transaction_fee_amount;
-                // TODO: we cannot mint <b>to</b> do storage refund. We need <b>to</b> have a storage refund pool
-                <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_governed_gas_pool_enabled">features::governed_gas_pool_enabled</a>()){
-                    <a href="transaction_fee.md#0x1_transaction_fee_mint_and_refund">transaction_fee::mint_and_refund</a>(gas_payer, mint_amount);
-                }
-            };
-        } <b>else</b> {
-            <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_governed_gas_pool_enabled">features::governed_gas_pool_enabled</a>()){
-                <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_gas_fee_v2">governed_gas_pool::deposit_gas_fee_v2</a>(gas_payer, transaction_fee_amount);
+            <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operations_default_to_fa_apt_store_enabled">features::operations_default_to_fa_apt_store_enabled</a>()) {
+                <b>assert</b>!(
+                    <a href="aptos_account.md#0x1_aptos_account_is_fungible_balance_at_least">aptos_account::is_fungible_balance_at_least</a>(gas_payer, transaction_fee_amount),
+                    <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>),
+                );
             } <b>else</b> {
-                <a href="transaction_fee.md#0x1_transaction_fee_burn_fee">transaction_fee::burn_fee</a>(gas_payer, transaction_fee_amount);
+                <b>assert</b>!(
+                    <a href="coin.md#0x1_coin_is_balance_at_least">coin::is_balance_at_least</a>&lt;AptosCoin&gt;(gas_payer, transaction_fee_amount),
+                    <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>),
+                );
+            };
+
+            <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_storage_deletion_refund_enabled">features::storage_deletion_refund_enabled</a>()){
+                <b>if</b> (transaction_fee_amount &gt; storage_fee_refunded) {
+                    <b>let</b> burn_amount = transaction_fee_amount - storage_fee_refunded;
+                    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_governed_gas_pool_enabled">features::governed_gas_pool_enabled</a>()){
+                        <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_gas_fee_v2">governed_gas_pool::deposit_gas_fee_v2</a>(gas_payer, burn_amount);
+                    } <b>else</b> {
+                        <a href="transaction_fee.md#0x1_transaction_fee_burn_fee">transaction_fee::burn_fee</a>(gas_payer, burn_amount);
+                    }
+                } <b>else</b> <b>if</b> (transaction_fee_amount &lt; storage_fee_refunded) {
+                    <b>let</b> mint_amount = storage_fee_refunded - transaction_fee_amount;
+                    // TODO: we cannot mint <b>to</b> do storage refund. We need <b>to</b> have a storage refund pool
+                    <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_governed_gas_pool_enabled">features::governed_gas_pool_enabled</a>()){
+                        <a href="transaction_fee.md#0x1_transaction_fee_mint_and_refund">transaction_fee::mint_and_refund</a>(gas_payer, mint_amount);
+                    }
+                };
+            } <b>else</b> {
+                <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_governed_gas_pool_enabled">features::governed_gas_pool_enabled</a>()){
+                    <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_gas_fee_v2">governed_gas_pool::deposit_gas_fee_v2</a>(gas_payer, transaction_fee_amount);
+                } <b>else</b> {
+                    <a href="transaction_fee.md#0x1_transaction_fee_burn_fee">transaction_fee::burn_fee</a>(gas_payer, transaction_fee_amount);
+                }
             }
         }
     };
@@ -1405,41 +1479,64 @@ If there is no fee_payer, fee_payer = sender
         is_simulation,
         gas_payer_address
     )) {
-        <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operations_default_to_fa_apt_store_enabled">features::operations_default_to_fa_apt_store_enabled</a>()) {
+        <b>let</b> gas_fa_metadata = <a href="transaction_validation.md#0x1_transaction_validation_gas_fa_metadata">gas_fa_metadata</a>();
+        <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&gas_fa_metadata)) {
+            // Gas paid in a selected fungible asset is charged <b>as</b> gas_used * the FA's gas price
+            // and collected into that FA's governed gas pool. NOTE: the storage-fee refund is
+            // not netted for FA payers; that is a follow-up.
+            <b>let</b> metadata = *<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&gas_fa_metadata);
+            <b>let</b> fa_fee = <a href="governed_gas_pool.md#0x1_governed_gas_pool_gas_fee_in_fa">governed_gas_pool::gas_fee_in_fa</a>(metadata, gas_used);
             <b>assert</b>!(
-                <a href="aptos_account.md#0x1_aptos_account_is_fungible_balance_at_least">aptos_account::is_fungible_balance_at_least</a>(gas_payer_address, transaction_fee_amount),
+                <a href="primary_fungible_store.md#0x1_primary_fungible_store_is_balance_at_least">primary_fungible_store::is_balance_at_least</a>(
+                    gas_payer_address,
+                    <a href="object.md#0x1_object_address_to_object">object::address_to_object</a>&lt;Metadata&gt;(metadata),
+                    fa_fee
+                ),
                 <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>),
             );
-        } <b>else</b> {
-            <b>assert</b>!(
-                <a href="coin.md#0x1_coin_is_balance_at_least">coin::is_balance_at_least</a>&lt;AptosCoin&gt;(gas_payer_address, transaction_fee_amount),
-                <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>),
-            );
-        };
-
-        <b>if</b> (transaction_fee_amount &gt; storage_fee_refunded) {
-            <b>let</b> burn_amount = transaction_fee_amount - storage_fee_refunded;
-            <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_governed_gas_pool_enabled">features::governed_gas_pool_enabled</a>()){
-                <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_gas_fee_v2">governed_gas_pool::deposit_gas_fee_v2</a>(gas_payer_address, burn_amount);
-            } <b>else</b> {
-                <a href="transaction_fee.md#0x1_transaction_fee_burn_fee">transaction_fee::burn_fee</a>(gas_payer_address, burn_amount);
-            };
+            <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_gas_fee_fa">governed_gas_pool::deposit_gas_fee_fa</a>(gas_payer_address, metadata, fa_fee);
             <a href="permissioned_signer.md#0x1_permissioned_signer_check_permission_consume">permissioned_signer::check_permission_consume</a>(
                 &gas_payer,
-                (burn_amount <b>as</b> u256),
+                (transaction_fee_amount <b>as</b> u256),
                 <a href="transaction_validation.md#0x1_transaction_validation_GasPermission">GasPermission</a> {}
             );
         } <b>else</b> {
-            <b>let</b> mint_amount = storage_fee_refunded - transaction_fee_amount;
-            // TODO: we cannot mint <b>to</b> do storage refund. We need <b>to</b> have a storage refund pool
-            <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_governed_gas_pool_enabled">features::governed_gas_pool_enabled</a>()){
-                <a href="transaction_fee.md#0x1_transaction_fee_mint_and_refund">transaction_fee::mint_and_refund</a>(gas_payer_address, mint_amount);
+            <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operations_default_to_fa_apt_store_enabled">features::operations_default_to_fa_apt_store_enabled</a>()) {
+                <b>assert</b>!(
+                    <a href="aptos_account.md#0x1_aptos_account_is_fungible_balance_at_least">aptos_account::is_fungible_balance_at_least</a>(gas_payer_address, transaction_fee_amount),
+                    <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>),
+                );
+            } <b>else</b> {
+                <b>assert</b>!(
+                    <a href="coin.md#0x1_coin_is_balance_at_least">coin::is_balance_at_least</a>&lt;AptosCoin&gt;(gas_payer_address, transaction_fee_amount),
+                    <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>),
+                );
             };
-            <a href="permissioned_signer.md#0x1_permissioned_signer_increase_limit">permissioned_signer::increase_limit</a>(
-                &gas_payer,
-                (mint_amount <b>as</b> u256),
-                <a href="transaction_validation.md#0x1_transaction_validation_GasPermission">GasPermission</a> {}
-            );
+
+            <b>if</b> (transaction_fee_amount &gt; storage_fee_refunded) {
+                <b>let</b> burn_amount = transaction_fee_amount - storage_fee_refunded;
+                <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_governed_gas_pool_enabled">features::governed_gas_pool_enabled</a>()){
+                    <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_gas_fee_v2">governed_gas_pool::deposit_gas_fee_v2</a>(gas_payer_address, burn_amount);
+                } <b>else</b> {
+                    <a href="transaction_fee.md#0x1_transaction_fee_burn_fee">transaction_fee::burn_fee</a>(gas_payer_address, burn_amount);
+                };
+                <a href="permissioned_signer.md#0x1_permissioned_signer_check_permission_consume">permissioned_signer::check_permission_consume</a>(
+                    &gas_payer,
+                    (burn_amount <b>as</b> u256),
+                    <a href="transaction_validation.md#0x1_transaction_validation_GasPermission">GasPermission</a> {}
+                );
+            } <b>else</b> {
+                <b>let</b> mint_amount = storage_fee_refunded - transaction_fee_amount;
+                // TODO: we cannot mint <b>to</b> do storage refund. We need <b>to</b> have a storage refund pool
+                <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_governed_gas_pool_enabled">features::governed_gas_pool_enabled</a>()){
+                    <a href="transaction_fee.md#0x1_transaction_fee_mint_and_refund">transaction_fee::mint_and_refund</a>(gas_payer_address, mint_amount);
+                };
+                <a href="permissioned_signer.md#0x1_permissioned_signer_increase_limit">permissioned_signer::increase_limit</a>(
+                    &gas_payer,
+                    (mint_amount <b>as</b> u256),
+                    <a href="transaction_validation.md#0x1_transaction_validation_GasPermission">GasPermission</a> {}
+                );
+            };
         };
     };
 

--- a/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
+++ b/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
@@ -225,9 +225,9 @@ module aptos_framework::governed_gas_pool {
        deposit(asset);
     }
 
-    /// Deposits APT from the fungible store into the governed gas pool.
-    /// @param account The account from which the APT FA is to be deposited.
-    /// @param amount The amount of APT FA to be deposited.
+    /// Deposits FA from the fungible store into the governed gas pool.
+    /// @param account The account from which the FA is to be deposited.
+    /// @param amount The amount of FA to be deposited.
     fun deposit_from_fungible_store(account: address, amount: u64) acquires GovernedGasPool {
         deposit_from_fungible_store_for(account, @aptos_fungible_asset, amount);
     }
@@ -766,11 +766,11 @@ module aptos_framework::governed_gas_pool {
         assert!(get_gas_fungible_asset_price(metadata_address) == 3, 13);
         assert!(gas_fee_in_fa(metadata_address, 5) == 15, 14);
 
-        // Pay gas in the FA -> goes into that FA's pool, separate from the APT pool.
+        // Pay gas in the FA -> goes into that FA's pool, separate from the MOVE pool.
         deposit_gas_fee_fa(payer_address, metadata_address, 30);
         assert!(primary_fungible_store::balance(payer_address, metadata) == 70, 4);
         assert!(get_fa_balance(metadata_address) == 30, 5);
-        // The APT pool is untouched.
+        // The MOVE pool is untouched.
         assert!(coin::balance<AptosCoin>(governed_gas_pool_address()) == 0, 6);
 
         // Governance withdraws from the FA pool back to an account.

--- a/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
+++ b/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
@@ -5,9 +5,9 @@ module aptos_framework::governed_gas_pool {
     use std::vector;
     use aptos_framework::account::{Self, SignerCapability, create_signer_with_capability};
     use aptos_framework::system_addresses::{Self};
-    // use aptos_framework::primary_fungible_store::{Self};
-    use aptos_framework::fungible_asset::{Self};
-    use aptos_framework::object::{Self};
+    use aptos_framework::primary_fungible_store::{Self};
+    use aptos_framework::fungible_asset::{Self, Metadata};
+    use aptos_framework::object::{Self, Object};
     use aptos_framework::aptos_coin::AptosCoin;
     use aptos_framework::coin::{Self, Coin};
     use aptos_framework::event::{Self, EventHandle};
@@ -26,6 +26,18 @@ module aptos_framework::governed_gas_pool {
 
     /// No longer supported.
     const ENO_LONGER_SUPPORTED: u64 = 4;
+
+    /// The fungible asset is not accepted for gas payment.
+    const EFA_NOT_ACCEPTED: u64 = 5;
+
+    /// A gas fungible asset's gas price must be non-zero.
+    const EINVALID_GAS_FA_PRICE: u64 = 6;
+
+    /// The computed fungible asset gas fee does not fit in a u64.
+    const EGAS_FA_FEE_OVERFLOW: u64 = 7;
+
+    /// Maximum u64 value, used to guard fungible asset gas fee computation against overflow.
+    const MAX_U64: u128 = 18446744073709551615;
 
     const MODULE_SALT: vector<u8> = b"aptos_framework::governed_gas_pool";
 
@@ -47,9 +59,48 @@ module aptos_framework::governed_gas_pool {
         withdraw_staking_reward_events: EventHandle<WithdrawStakingRewardEvent>,
     }
 
-    /// Address of APT Primary Fungible Store
-    inline fun primary_fungible_store_address(account: address): address {
-        object::create_user_derived_object_address(account, @aptos_fungible_asset)
+    /// A fungible asset accepted for gas payment, together with its gas price: the number of FA base
+    /// units charged per unit of gas consumed. The FA gas fee for a transaction is
+    /// `gas_units_used * gas_price`.
+    struct AcceptedGasFa has store, drop {
+        metadata: address,
+        gas_price: u64,
+    }
+
+    /// Registry of fungible assets accepted for gas payment. Each accepted FA is held in the
+    /// governed gas pool account's own primary store for that metadata object (a separate per-FA
+    /// pool that shares the single pool resource account), and stores its gas price alongside.
+    struct AcceptedGasFungibleAssets has key {
+        entries: vector<AcceptedGasFa>,
+    }
+
+    #[event]
+    /// Emitted when a fungible asset is added to (`accepted = true`) or removed from
+    /// (`accepted = false`) the set accepted for gas payment.
+    struct AcceptedGasFungibleAssetUpdate has drop, store {
+        metadata: address,
+        accepted: bool,
+    }
+
+    #[event]
+    /// Emitted when a fungible asset's gas price is set or updated.
+    struct GasFungibleAssetPriceUpdate has drop, store {
+        metadata: address,
+        gas_price: u64,
+    }
+
+    #[event]
+    /// Emitted when gas fees are deposited into a per-FA governed gas pool.
+    struct FungibleAssetGasFeeDeposit has drop, store {
+        gas_payer: address,
+        metadata: address,
+        /// Fungible asset base units deposited.
+        amount: u64,
+    }
+
+    /// Address of `account`'s primary fungible store for the FA identified by `metadata`.
+    inline fun primary_fungible_store_address_for(account: address, metadata: address): address {
+        object::create_user_derived_object_address(account, metadata)
     }
 
     /// Create the seed to derive the resource account address.
@@ -174,24 +225,25 @@ module aptos_framework::governed_gas_pool {
        deposit(asset);
     }
 
-    /// Deposits some FA from the fungible store.
-    /// @param aptos_framework The signer of the aptos_framework module.
-    /// @param account The account from which the FA is to be deposited.
-    /// @param amount The amount of FA to be deposited.
+    /// Deposits APT from the fungible store into the governed gas pool.
+    /// @param account The account from which the APT FA is to be deposited.
+    /// @param amount The amount of APT FA to be deposited.
     fun deposit_from_fungible_store(account: address, amount: u64) acquires GovernedGasPool {
-        if (amount > 0){
-            // compute the governed gas pool store address
-            let governed_gas_pool_address = governed_gas_pool_address();
-            let governed_gas_pool_store_address = primary_fungible_store_address(governed_gas_pool_address);
+        deposit_from_fungible_store_for(account, @aptos_fungible_asset, amount);
+    }
 
-            // compute the account store address
-            let account_store_address = primary_fungible_store_address(account);
+    /// Deposits `amount` of the fungible asset identified by `metadata` from `account`'s primary
+    /// store into the governed gas pool account's own primary store for that FA (its per-FA pool).
+    /// Uses the unchecked (VM-privileged) withdraw/deposit path, as gas collection is not authorized
+    /// by the payer's signer.
+    fun deposit_from_fungible_store_for(account: address, metadata: address, amount: u64) acquires GovernedGasPool {
+        if (amount > 0) {
+            let pool_store_address =
+                primary_fungible_store_address_for(governed_gas_pool_address(), metadata);
+            let account_store_address = primary_fungible_store_address_for(account, metadata);
             fungible_asset::unchecked_deposit(
-                governed_gas_pool_store_address,
-                fungible_asset::unchecked_withdraw(
-                    account_store_address,
-                    amount
-                )
+                pool_store_address,
+                fungible_asset::unchecked_withdraw(account_store_address, amount)
             );
         }
     }
@@ -212,6 +264,193 @@ module aptos_framework::governed_gas_pool {
         } else {
             deposit_from<AptosCoin>(gas_payer, gas_fee);
         };
+    }
+
+    /// Creates the accepted-FA registry under @aptos_framework if it does not yet exist. This lets
+    /// the feature roll out onto an already-initialized governed gas pool without re-running
+    /// `initialize`.
+    fun ensure_accepted_registry(aptos_framework: &signer) {
+        if (!exists<AcceptedGasFungibleAssets>(signer::address_of(aptos_framework))) {
+            move_to(aptos_framework, AcceptedGasFungibleAssets { entries: vector::empty<AcceptedGasFa>() });
+        };
+    }
+
+    /// Index of the accepted-FA entry for `metadata`, if present.
+    fun find_accepted_index(entries: &vector<AcceptedGasFa>, metadata: address): (bool, u64) {
+        let len = vector::length(entries);
+        let i = 0;
+        while (i < len) {
+            if (vector::borrow(entries, i).metadata == metadata) {
+                return (true, i)
+            };
+            i = i + 1;
+        };
+        (false, 0)
+    }
+
+    /// Adds a fungible asset to the set accepted for gas payment with its gas price (FA base units
+    /// charged per unit of gas consumed), and ensures the pool has a primary store to hold it.
+    /// Governance-gated (requires the @aptos_framework signer). Re-adding an existing FA updates its
+    /// gas price.
+    /// @param aptos_framework The signer of the aptos_framework module.
+    /// @param metadata The metadata object of the fungible asset to accept.
+    /// @param gas_price FA base units charged per unit of gas consumed; must be non-zero.
+    public entry fun add_accepted_gas_fungible_asset(
+        aptos_framework: &signer,
+        metadata: Object<Metadata>,
+        gas_price: u64,
+    ) acquires GovernedGasPool, AcceptedGasFungibleAssets {
+        system_addresses::assert_aptos_framework(aptos_framework);
+        assert!(gas_price > 0, error::invalid_argument(EINVALID_GAS_FA_PRICE));
+        ensure_accepted_registry(aptos_framework);
+        let metadata_address = object::object_address(&metadata);
+        let accepted = borrow_global_mut<AcceptedGasFungibleAssets>(@aptos_framework);
+        let (found, i) = find_accepted_index(&accepted.entries, metadata_address);
+        if (found) {
+            vector::borrow_mut(&mut accepted.entries, i).gas_price = gas_price;
+        } else {
+            vector::push_back(&mut accepted.entries, AcceptedGasFa { metadata: metadata_address, gas_price });
+            // Ensure the pool has a primary store for this FA so unchecked deposits succeed.
+            primary_fungible_store::ensure_primary_store_exists(governed_gas_pool_address(), metadata);
+            event::emit(AcceptedGasFungibleAssetUpdate { metadata: metadata_address, accepted: true });
+        };
+        event::emit(GasFungibleAssetPriceUpdate { metadata: metadata_address, gas_price });
+    }
+
+    /// Sets (updates) the gas price of an already-accepted fungible asset. Governance-gated.
+    /// @param aptos_framework The signer of the aptos_framework module.
+    /// @param metadata The metadata object of the fungible asset.
+    /// @param gas_price FA base units charged per unit of gas consumed; must be non-zero.
+    public entry fun set_gas_fungible_asset_price(
+        aptos_framework: &signer,
+        metadata: Object<Metadata>,
+        gas_price: u64,
+    ) acquires AcceptedGasFungibleAssets {
+        system_addresses::assert_aptos_framework(aptos_framework);
+        assert!(gas_price > 0, error::invalid_argument(EINVALID_GAS_FA_PRICE));
+        assert!(exists<AcceptedGasFungibleAssets>(@aptos_framework), error::invalid_argument(EFA_NOT_ACCEPTED));
+        let metadata_address = object::object_address(&metadata);
+        let accepted = borrow_global_mut<AcceptedGasFungibleAssets>(@aptos_framework);
+        let (found, i) = find_accepted_index(&accepted.entries, metadata_address);
+        assert!(found, error::invalid_argument(EFA_NOT_ACCEPTED));
+        vector::borrow_mut(&mut accepted.entries, i).gas_price = gas_price;
+        event::emit(GasFungibleAssetPriceUpdate { metadata: metadata_address, gas_price });
+    }
+
+    /// Removes a fungible asset from the set accepted for gas payment. Any balance already held in
+    /// its pool remains and can still be withdrawn via `fund_fa`. Governance-gated.
+    /// @param aptos_framework The signer of the aptos_framework module.
+    /// @param metadata The metadata object of the fungible asset to stop accepting.
+    public entry fun remove_accepted_gas_fungible_asset(
+        aptos_framework: &signer,
+        metadata: Object<Metadata>,
+    ) acquires AcceptedGasFungibleAssets {
+        system_addresses::assert_aptos_framework(aptos_framework);
+        if (!exists<AcceptedGasFungibleAssets>(@aptos_framework)) {
+            return
+        };
+        let metadata_address = object::object_address(&metadata);
+        let accepted = borrow_global_mut<AcceptedGasFungibleAssets>(@aptos_framework);
+        let (found, i) = find_accepted_index(&accepted.entries, metadata_address);
+        if (found) {
+            vector::remove(&mut accepted.entries, i);
+            event::emit(AcceptedGasFungibleAssetUpdate { metadata: metadata_address, accepted: false });
+        };
+    }
+
+    #[view]
+    /// Whether the fungible asset identified by `metadata` is accepted for gas payment.
+    public fun is_accepted_gas_fungible_asset(metadata: address): bool acquires AcceptedGasFungibleAssets {
+        if (!exists<AcceptedGasFungibleAssets>(@aptos_framework)) {
+            return false
+        };
+        let (found, _) = find_accepted_index(&borrow_global<AcceptedGasFungibleAssets>(@aptos_framework).entries, metadata);
+        found
+    }
+
+    #[view]
+    /// The full set of fungible asset metadata addresses accepted for gas payment.
+    public fun accepted_gas_fungible_assets(): vector<address> acquires AcceptedGasFungibleAssets {
+        let result = vector::empty<address>();
+        if (exists<AcceptedGasFungibleAssets>(@aptos_framework)) {
+            let entries = &borrow_global<AcceptedGasFungibleAssets>(@aptos_framework).entries;
+            let len = vector::length(entries);
+            let i = 0;
+            while (i < len) {
+                vector::push_back(&mut result, vector::borrow(entries, i).metadata);
+                i = i + 1;
+            };
+        };
+        result
+    }
+
+    #[view]
+    /// The gas price (FA base units per unit of gas) of an accepted fungible asset. Aborts if the
+    /// fungible asset is not accepted for gas payment.
+    public fun get_gas_fungible_asset_price(metadata: address): u64 acquires AcceptedGasFungibleAssets {
+        assert!(exists<AcceptedGasFungibleAssets>(@aptos_framework), error::invalid_argument(EFA_NOT_ACCEPTED));
+        let accepted = borrow_global<AcceptedGasFungibleAssets>(@aptos_framework);
+        let (found, i) = find_accepted_index(&accepted.entries, metadata);
+        assert!(found, error::invalid_argument(EFA_NOT_ACCEPTED));
+        vector::borrow(&accepted.entries, i).gas_price
+    }
+
+    #[view]
+    /// The fungible asset gas fee for `gas_units` of gas consumed under `metadata`'s gas price, i.e.
+    /// `gas_units * gas_price`. Aborts if the FA is not accepted or the fee overflows u64.
+    public fun gas_fee_in_fa(metadata: address, gas_units: u64): u64 acquires AcceptedGasFungibleAssets {
+        let price = get_gas_fungible_asset_price(metadata);
+        let fee = (gas_units as u128) * (price as u128);
+        assert!(fee <= MAX_U64, error::out_of_range(EGAS_FA_FEE_OVERFLOW));
+        (fee as u64)
+    }
+
+    #[view]
+    /// The governed gas pool's balance of the fungible asset identified by `metadata`.
+    public fun get_fa_balance(metadata: address): u64 acquires GovernedGasPool {
+        primary_fungible_store::balance(
+            governed_gas_pool_address(),
+            object::address_to_object<Metadata>(metadata)
+        )
+    }
+
+    /// Deposits `fa_amount` base units of a selected gas fungible asset (already converted from gas
+    /// via that FA's gas price) into its governed gas pool. Aborts if the FA is not accepted.
+    /// @param gas_payer The address that paid the gas fees.
+    /// @param metadata The metadata object address of the fungible asset.
+    /// @param fa_amount The fungible asset base units to deposit.
+    public(friend) fun deposit_gas_fee_fa(
+        gas_payer: address,
+        metadata: address,
+        fa_amount: u64,
+    ) acquires GovernedGasPool, AcceptedGasFungibleAssets {
+        assert!(is_accepted_gas_fungible_asset(metadata), error::invalid_argument(EFA_NOT_ACCEPTED));
+        deposit_from_fungible_store_for(gas_payer, metadata, fa_amount);
+        if (fa_amount > 0) {
+            event::emit(FungibleAssetGasFeeDeposit { gas_payer, metadata, amount: fa_amount });
+        };
+    }
+
+    /// Withdraws `amount` of the fungible asset identified by `metadata` from its governed gas pool
+    /// and deposits it to `account`. Governance-gated; the mirror of `fund` for fungible assets.
+    /// @param aptos_framework The signer of the aptos_framework module.
+    /// @param account The recipient account.
+    /// @param metadata The metadata object address of the fungible asset.
+    /// @param amount The amount to withdraw from the pool.
+    public fun fund_fa(
+        aptos_framework: &signer,
+        account: address,
+        metadata: address,
+        amount: u64,
+    ) acquires GovernedGasPool {
+        system_addresses::assert_aptos_framework(aptos_framework);
+        let pool_signer = governed_gas_signer();
+        let fa = primary_fungible_store::withdraw(
+            &pool_signer,
+            object::address_to_object<Metadata>(metadata),
+            amount
+        );
+        primary_fungible_store::deposit(account, fa);
     }
 
     /// Deposits from the treasury account. Treasury deposit are recorded.
@@ -492,6 +731,168 @@ module aptos_framework::governed_gas_pool {
         assert!(coin::value(&withdraw) == 10, 6);
 
         coin::deposit(@0xdddd, withdraw);
+    }
+
+    #[test(aptos_framework = @aptos_framework, payer = @0xcafe)]
+    /// A selected fungible asset gets its own pool: gas paid in it is collected separately from APT,
+    /// and can be funded back out by governance.
+    fun test_per_fa_gas_pool(aptos_framework: &signer, payer: &signer)
+        acquires GovernedGasPool, AcceptedGasFungibleAssets {
+        initialize_for_test(aptos_framework);
+
+        // Create a test fungible asset and mint some to the payer.
+        let (creator_ref, token) = fungible_asset::create_test_token(payer);
+        let (mint_ref, _transfer_ref, _burn_ref) =
+            primary_fungible_store::init_test_metadata_with_primary_store_enabled(&creator_ref);
+        let payer_address = signer::address_of(payer);
+        // The test FA has a max supply of 100.
+        primary_fungible_store::mint(&mint_ref, payer_address, 100);
+        let metadata_address = object::object_address(&token);
+        let metadata = object::address_to_object<Metadata>(metadata_address);
+
+        // Not accepted yet.
+        assert!(!is_accepted_gas_fungible_asset(metadata_address), 1);
+
+        // Accept it with a gas price of 2 FA units per gas unit (governance).
+        add_accepted_gas_fungible_asset(aptos_framework, metadata, 2);
+        assert!(is_accepted_gas_fungible_asset(metadata_address), 2);
+        assert!(vector::contains(&accepted_gas_fungible_assets(), &metadata_address), 3);
+        assert!(get_gas_fungible_asset_price(metadata_address) == 2, 11);
+        // gas_used * price: 5 gas units at price 2 = 10 FA units.
+        assert!(gas_fee_in_fa(metadata_address, 5) == 10, 12);
+
+        // Governance can update the gas price via a function.
+        set_gas_fungible_asset_price(aptos_framework, metadata, 3);
+        assert!(get_gas_fungible_asset_price(metadata_address) == 3, 13);
+        assert!(gas_fee_in_fa(metadata_address, 5) == 15, 14);
+
+        // Pay gas in the FA -> goes into that FA's pool, separate from the APT pool.
+        deposit_gas_fee_fa(payer_address, metadata_address, 30);
+        assert!(primary_fungible_store::balance(payer_address, metadata) == 70, 4);
+        assert!(get_fa_balance(metadata_address) == 30, 5);
+        // The APT pool is untouched.
+        assert!(coin::balance<AptosCoin>(governed_gas_pool_address()) == 0, 6);
+
+        // Governance withdraws from the FA pool back to an account.
+        fund_fa(aptos_framework, payer_address, metadata_address, 10);
+        assert!(get_fa_balance(metadata_address) == 20, 7);
+        assert!(primary_fungible_store::balance(payer_address, metadata) == 80, 8);
+
+        // Removing it from the accepted set leaves the residual balance intact.
+        remove_accepted_gas_fungible_asset(aptos_framework, metadata);
+        assert!(!is_accepted_gas_fungible_asset(metadata_address), 9);
+        assert!(get_fa_balance(metadata_address) == 20, 10);
+    }
+
+    #[test(aptos_framework = @aptos_framework, payer = @0xcafe)]
+    #[expected_failure(abort_code = 65541, location = Self)]
+    /// Depositing gas in a fungible asset that is not accepted aborts with EFA_NOT_ACCEPTED.
+    fun test_deposit_gas_fee_fa_aborts_when_not_accepted(aptos_framework: &signer, payer: &signer)
+        acquires GovernedGasPool, AcceptedGasFungibleAssets {
+        initialize_for_test(aptos_framework);
+        let (creator_ref, token) = fungible_asset::create_test_token(payer);
+        let (mint_ref, _transfer_ref, _burn_ref) =
+            primary_fungible_store::init_test_metadata_with_primary_store_enabled(&creator_ref);
+        primary_fungible_store::mint(&mint_ref, signer::address_of(payer), 100);
+        // Never accepted -> abort.
+        deposit_gas_fee_fa(signer::address_of(payer), object::object_address(&token), 30);
+    }
+
+    #[test(aptos_framework = @aptos_framework, intruder = @0xbad)]
+    #[expected_failure(abort_code = 327683, location = aptos_framework::system_addresses)]
+    /// Accepting a gas FA requires the @aptos_framework (governance) signer.
+    fun test_add_accepted_requires_framework(aptos_framework: &signer, intruder: &signer)
+        acquires GovernedGasPool, AcceptedGasFungibleAssets {
+        initialize_for_test(aptos_framework);
+        let (creator_ref, token) = fungible_asset::create_test_token(intruder);
+        let (_m, _t, _b) = primary_fungible_store::init_test_metadata_with_primary_store_enabled(&creator_ref);
+        add_accepted_gas_fungible_asset(
+            intruder,
+            object::address_to_object<Metadata>(object::object_address(&token)),
+            1,
+        );
+    }
+
+    #[test(aptos_framework = @aptos_framework, intruder = @0xbad)]
+    #[expected_failure(abort_code = 327683, location = aptos_framework::system_addresses)]
+    /// Updating a gas FA's price requires the @aptos_framework (governance) signer.
+    fun test_set_price_requires_framework(aptos_framework: &signer, intruder: &signer)
+        acquires GovernedGasPool, AcceptedGasFungibleAssets {
+        initialize_for_test(aptos_framework);
+        let (creator_ref, token) = fungible_asset::create_test_token(intruder);
+        let (_m, _t, _b) = primary_fungible_store::init_test_metadata_with_primary_store_enabled(&creator_ref);
+        let metadata = object::address_to_object<Metadata>(object::object_address(&token));
+        add_accepted_gas_fungible_asset(aptos_framework, metadata, 1);
+        // Non-governance caller -> abort.
+        set_gas_fungible_asset_price(intruder, metadata, 2);
+    }
+
+    #[test(aptos_framework = @aptos_framework, creator = @0xcafe)]
+    #[expected_failure(abort_code = 65542, location = Self)]
+    /// A gas FA cannot be accepted with a zero gas price (would make gas free).
+    fun test_add_rejects_zero_price(aptos_framework: &signer, creator: &signer)
+        acquires GovernedGasPool, AcceptedGasFungibleAssets {
+        initialize_for_test(aptos_framework);
+        let (creator_ref, token) = fungible_asset::create_test_token(creator);
+        let (_m, _t, _b) = primary_fungible_store::init_test_metadata_with_primary_store_enabled(&creator_ref);
+        add_accepted_gas_fungible_asset(
+            aptos_framework,
+            object::address_to_object<Metadata>(object::object_address(&token)),
+            0,
+        );
+    }
+
+    #[test(aptos_framework = @aptos_framework, creator = @0xcafe)]
+    #[expected_failure(abort_code = 65542, location = Self)]
+    /// A gas FA's price cannot be set to zero.
+    fun test_set_rejects_zero_price(aptos_framework: &signer, creator: &signer)
+        acquires GovernedGasPool, AcceptedGasFungibleAssets {
+        initialize_for_test(aptos_framework);
+        let (creator_ref, token) = fungible_asset::create_test_token(creator);
+        let (_m, _t, _b) = primary_fungible_store::init_test_metadata_with_primary_store_enabled(&creator_ref);
+        let metadata = object::address_to_object<Metadata>(object::object_address(&token));
+        add_accepted_gas_fungible_asset(aptos_framework, metadata, 5);
+        set_gas_fungible_asset_price(aptos_framework, metadata, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, payer = @0xcafe, creator_b = @0xd00d)]
+    /// Each accepted FA is a separate pool with its own price: depositing into one FA's pool does
+    /// not touch another's, and their prices/fees are independent.
+    fun test_multiple_fa_pools_are_independent(
+        aptos_framework: &signer,
+        payer: &signer,
+        creator_b: &signer,
+    ) acquires GovernedGasPool, AcceptedGasFungibleAssets {
+        initialize_for_test(aptos_framework);
+        let payer_addr = signer::address_of(payer);
+
+        // FA A (created by payer) and FA B (created by creator_b), each minted to the payer.
+        let (a_ref, a_token) = fungible_asset::create_test_token(payer);
+        let (a_mint, _at, _ab) = primary_fungible_store::init_test_metadata_with_primary_store_enabled(&a_ref);
+        primary_fungible_store::mint(&a_mint, payer_addr, 100);
+        let a = object::object_address(&a_token);
+
+        let (b_ref, b_token) = fungible_asset::create_test_token(creator_b);
+        let (b_mint, _bt, _bb) = primary_fungible_store::init_test_metadata_with_primary_store_enabled(&b_ref);
+        primary_fungible_store::mint(&b_mint, payer_addr, 100);
+        let b = object::object_address(&b_token);
+
+        // Accept both with different gas prices.
+        add_accepted_gas_fungible_asset(aptos_framework, object::address_to_object<Metadata>(a), 2);
+        add_accepted_gas_fungible_asset(aptos_framework, object::address_to_object<Metadata>(b), 5);
+
+        // Prices and fees are independent per FA.
+        assert!(get_gas_fungible_asset_price(a) == 2, 1);
+        assert!(get_gas_fungible_asset_price(b) == 5, 2);
+        assert!(gas_fee_in_fa(a, 10) == 20, 3);
+        assert!(gas_fee_in_fa(b, 10) == 50, 4);
+
+        // Depositing into A's pool leaves B's pool (and the payer's B balance) untouched.
+        deposit_gas_fee_fa(payer_addr, a, 30);
+        assert!(get_fa_balance(a) == 30, 5);
+        assert!(get_fa_balance(b) == 0, 6);
+        assert!(primary_fungible_store::balance(payer_addr, object::address_to_object<Metadata>(a)) == 70, 7);
+        assert!(primary_fungible_store::balance(payer_addr, object::address_to_object<Metadata>(b)) == 100, 8);
     }
 
 }

--- a/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
+++ b/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
@@ -497,7 +497,7 @@ module aptos_framework::governed_gas_pool {
                 amount,
             },
         );
-        
+
         // Withdraw reward coin.
         coin::withdraw<CoinType>(&governed_gas_signer(), amount)
     }
@@ -709,10 +709,10 @@ module aptos_framework::governed_gas_pool {
     ///
     /// @param aptos_framework is the signer of the aptos_framework module.
     fun test_deposite_treasury_and_counter(aptos_framework: &signer, treasury: &signer) acquires GovernedGasPool, GovernedGasPoolExtension, AptosCoinMintCapability {
-       
+
         // initialize the modules
         initialize_for_test(aptos_framework);
-    
+
         // create the depositor account and fund it
         aptos_account::create_account(signer::address_of(treasury));
         mint_for_test(signer::address_of(treasury), 1000);

--- a/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
+++ b/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
@@ -70,6 +70,10 @@ module aptos_framework::governed_gas_pool {
     /// Registry of fungible assets accepted for gas payment. Each accepted FA is held in the
     /// governed gas pool account's own primary store for that metadata object (a separate per-FA
     /// pool that shares the single pool resource account), and stores its gas price alongside.
+    ///
+    /// Note that vector does mean we have to iterate the list, but if we replace it with Table
+    /// or SmartTable then we have access storage a lot more which is much more expensive than
+    /// iterating a few items. Therefore if we only a few entries, vector<> is much faster.
     struct AcceptedGasFungibleAssets has key {
         entries: vector<AcceptedGasFa>,
     }

--- a/aptos-move/framework/aptos-framework/sources/transaction_context.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_context.move
@@ -10,6 +10,9 @@ module aptos_framework::transaction_context {
     /// The transaction context extension feature is not enabled.
     const ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED: u64 = 2;
 
+    /// Paying gas in a fungible asset (the `GAS_PAYABLE_FA` feature) is not enabled.
+    const EGAS_PAYABLE_FA_NOT_ENABLED: u64 = 3;
+
     /// A wrapper denoting aptos unique identifer (AUID)
     /// for storing an address
     struct AUID has drop, store {
@@ -123,6 +126,15 @@ module aptos_framework::transaction_context {
         chain_id_internal()
     }
     native fun chain_id_internal(): u8;
+
+    /// Returns the fungible asset metadata address that the current transaction elected to pay gas in,
+    /// or `None` if gas is paid in the default currency (APT).
+    /// This function aborts if called outside of the transaction prologue, execution, or epilogue phases.
+    public fun gas_payment_fungible_asset(): Option<address> {
+        assert!(features::is_gas_payable_fa_enabled(), error::invalid_state(EGAS_PAYABLE_FA_NOT_ENABLED));
+        gas_payment_fa_metadata_internal()
+    }
+    native fun gas_payment_fa_metadata_internal(): Option<address>;
 
     /// Returns the entry function payload if the current transaction has such a payload. Otherwise, return `None`.
     /// This function aborts if called outside of the transaction prologue, execution, or epilogue phases.
@@ -275,5 +287,18 @@ module aptos_framework::transaction_context {
     fun test_call_multisig_payload() {
         // expected to fail with the error code of `invalid_state(E_TRANSACTION_CONTEXT_NOT_AVAILABLE)`
         let _multisig = multisig_payload();
+    }
+
+    #[test(framework = @std)]
+    #[expected_failure(abort_code=196611, location = Self)]
+    fun test_gas_payment_fungible_asset_aborts_when_feature_disabled(framework: signer) {
+        // With `GAS_PAYABLE_FA` disabled, the accessor must abort at the feature gate with
+        // `invalid_state(EGAS_PAYABLE_FA_NOT_ENABLED)` before ever reaching the native.
+        features::change_feature_flags_for_testing(
+            &framework,
+            vector[],
+            vector[features::get_gas_payable_fa_feature()],
+        );
+        let _fa = gas_payment_fungible_asset();
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.move
@@ -13,10 +13,14 @@ module aptos_framework::transaction_validation {
     use aptos_framework::chain_id;
     use aptos_framework::coin;
     use aptos_framework::create_signer;
+    use aptos_framework::fungible_asset::Metadata;
     use aptos_framework::governed_gas_pool;
+    use aptos_framework::object;
     use aptos_framework::permissioned_signer;
+    use aptos_framework::primary_fungible_store;
     use aptos_framework::system_addresses;
     use aptos_framework::timestamp;
+    use aptos_framework::transaction_context;
     use aptos_framework::transaction_fee;
     use aptos_framework::nonce_validation;
 
@@ -123,6 +127,17 @@ module aptos_framework::transaction_validation {
             || (features::is_account_abstraction_enabled() && account_abstraction::using_dispatchable_authenticator(transaction_sender))
     }
 
+    /// The fungible asset metadata address this transaction elected to pay gas in, or `None` if it
+    /// pays in the default currency (APT). Returns `None` when the `GAS_PAYABLE_FA` feature is off,
+    /// so the accessor (which is gated on that feature) is only called when it is enabled.
+    inline fun gas_fa_metadata(): Option<address> {
+        if (features::is_gas_payable_fa_enabled()) {
+            transaction_context::gas_payment_fungible_asset()
+        } else {
+            option::none<address>()
+        }
+    }
+
     fun prologue_common(
         sender: &signer,
         gas_payer: &signer,
@@ -198,7 +213,27 @@ module aptos_framework::transaction_validation {
                 ),
                 error::permission_denied(PROLOGUE_PERMISSIONED_GAS_LIMIT_INSUFFICIENT)
             );
-            if (features::operations_default_to_fa_apt_store_enabled()) {
+            let gas_fa_metadata = gas_fa_metadata();
+            if (option::is_some(&gas_fa_metadata)) {
+                // Gas is paid in a selected fungible asset: it must be accepted by the governed gas
+                // pool and the payer must hold enough of it.
+                let metadata = *option::borrow(&gas_fa_metadata);
+                assert!(
+                    governed_gas_pool::is_accepted_gas_fungible_asset(metadata),
+                    error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
+                );
+                // The FA gas fee is charged as gas_used * per-FA gas price; check the payer can
+                // cover the maximum (all of txn_max_gas_units).
+                let max_fa_fee = governed_gas_pool::gas_fee_in_fa(metadata, txn_max_gas_units);
+                assert!(
+                    primary_fungible_store::is_balance_at_least(
+                        gas_payer_address,
+                        object::address_to_object<Metadata>(metadata),
+                        max_fa_fee
+                    ),
+                    error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
+                );
+            } else if (features::operations_default_to_fa_apt_store_enabled()) {
                 assert!(
                     aptos_account::is_fungible_balance_at_least(gas_payer_address, max_transaction_fee),
                     error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
@@ -460,38 +495,56 @@ module aptos_framework::transaction_validation {
         // it's important to maintain the error code consistent with vm
         // to do failed transaction cleanup.
         if (!skip_gas_payment(is_simulation, gas_payer)) {
-            if (features::operations_default_to_fa_apt_store_enabled()) {
+            let gas_fa_metadata = gas_fa_metadata();
+            if (option::is_some(&gas_fa_metadata)) {
+                // Gas paid in a selected fungible asset is charged as gas_used * the FA's gas price
+                // and collected into that FA's governed gas pool. NOTE: the storage-fee refund is
+                // not netted for FA payers; that is a follow-up.
+                let metadata = *option::borrow(&gas_fa_metadata);
+                let fa_fee = governed_gas_pool::gas_fee_in_fa(metadata, gas_used);
                 assert!(
-                    aptos_account::is_fungible_balance_at_least(gas_payer, transaction_fee_amount),
+                    primary_fungible_store::is_balance_at_least(
+                        gas_payer,
+                        object::address_to_object<Metadata>(metadata),
+                        fa_fee
+                    ),
                     error::out_of_range(PROLOGUE_ECANT_PAY_GAS_DEPOSIT),
                 );
+                governed_gas_pool::deposit_gas_fee_fa(gas_payer, metadata, fa_fee);
             } else {
-                assert!(
-                    coin::is_balance_at_least<AptosCoin>(gas_payer, transaction_fee_amount),
-                    error::out_of_range(PROLOGUE_ECANT_PAY_GAS_DEPOSIT),
-                );
-            };
-
-            if (features::storage_deletion_refund_enabled()){
-                if (transaction_fee_amount > storage_fee_refunded) {
-                    let burn_amount = transaction_fee_amount - storage_fee_refunded;
-                    if (features::governed_gas_pool_enabled()){
-                        governed_gas_pool::deposit_gas_fee_v2(gas_payer, burn_amount);
-                    } else {
-                        transaction_fee::burn_fee(gas_payer, burn_amount);
-                    }
-                } else if (transaction_fee_amount < storage_fee_refunded) {
-                    let mint_amount = storage_fee_refunded - transaction_fee_amount;
-                    // TODO: we cannot mint to do storage refund. We need to have a storage refund pool
-                    if (!features::governed_gas_pool_enabled()){
-                        transaction_fee::mint_and_refund(gas_payer, mint_amount);
-                    }
-                };
-            } else {
-                if (features::governed_gas_pool_enabled()){
-                    governed_gas_pool::deposit_gas_fee_v2(gas_payer, transaction_fee_amount);
+                if (features::operations_default_to_fa_apt_store_enabled()) {
+                    assert!(
+                        aptos_account::is_fungible_balance_at_least(gas_payer, transaction_fee_amount),
+                        error::out_of_range(PROLOGUE_ECANT_PAY_GAS_DEPOSIT),
+                    );
                 } else {
-                    transaction_fee::burn_fee(gas_payer, transaction_fee_amount);
+                    assert!(
+                        coin::is_balance_at_least<AptosCoin>(gas_payer, transaction_fee_amount),
+                        error::out_of_range(PROLOGUE_ECANT_PAY_GAS_DEPOSIT),
+                    );
+                };
+
+                if (features::storage_deletion_refund_enabled()){
+                    if (transaction_fee_amount > storage_fee_refunded) {
+                        let burn_amount = transaction_fee_amount - storage_fee_refunded;
+                        if (features::governed_gas_pool_enabled()){
+                            governed_gas_pool::deposit_gas_fee_v2(gas_payer, burn_amount);
+                        } else {
+                            transaction_fee::burn_fee(gas_payer, burn_amount);
+                        }
+                    } else if (transaction_fee_amount < storage_fee_refunded) {
+                        let mint_amount = storage_fee_refunded - transaction_fee_amount;
+                        // TODO: we cannot mint to do storage refund. We need to have a storage refund pool
+                        if (!features::governed_gas_pool_enabled()){
+                            transaction_fee::mint_and_refund(gas_payer, mint_amount);
+                        }
+                    };
+                } else {
+                    if (features::governed_gas_pool_enabled()){
+                        governed_gas_pool::deposit_gas_fee_v2(gas_payer, transaction_fee_amount);
+                    } else {
+                        transaction_fee::burn_fee(gas_payer, transaction_fee_amount);
+                    }
                 }
             }
         };
@@ -695,41 +748,64 @@ module aptos_framework::transaction_validation {
             is_simulation,
             gas_payer_address
         )) {
-            if (features::operations_default_to_fa_apt_store_enabled()) {
+            let gas_fa_metadata = gas_fa_metadata();
+            if (option::is_some(&gas_fa_metadata)) {
+                // Gas paid in a selected fungible asset is charged as gas_used * the FA's gas price
+                // and collected into that FA's governed gas pool. NOTE: the storage-fee refund is
+                // not netted for FA payers; that is a follow-up.
+                let metadata = *option::borrow(&gas_fa_metadata);
+                let fa_fee = governed_gas_pool::gas_fee_in_fa(metadata, gas_used);
                 assert!(
-                    aptos_account::is_fungible_balance_at_least(gas_payer_address, transaction_fee_amount),
+                    primary_fungible_store::is_balance_at_least(
+                        gas_payer_address,
+                        object::address_to_object<Metadata>(metadata),
+                        fa_fee
+                    ),
                     error::out_of_range(PROLOGUE_ECANT_PAY_GAS_DEPOSIT),
                 );
-            } else {
-                assert!(
-                    coin::is_balance_at_least<AptosCoin>(gas_payer_address, transaction_fee_amount),
-                    error::out_of_range(PROLOGUE_ECANT_PAY_GAS_DEPOSIT),
-                );
-            };
-
-            if (transaction_fee_amount > storage_fee_refunded) {
-                let burn_amount = transaction_fee_amount - storage_fee_refunded;
-                if (features::governed_gas_pool_enabled()){
-                    governed_gas_pool::deposit_gas_fee_v2(gas_payer_address, burn_amount);
-                } else {
-                    transaction_fee::burn_fee(gas_payer_address, burn_amount);
-                };
+                governed_gas_pool::deposit_gas_fee_fa(gas_payer_address, metadata, fa_fee);
                 permissioned_signer::check_permission_consume(
                     &gas_payer,
-                    (burn_amount as u256),
+                    (transaction_fee_amount as u256),
                     GasPermission {}
                 );
             } else {
-                let mint_amount = storage_fee_refunded - transaction_fee_amount;
-                // TODO: we cannot mint to do storage refund. We need to have a storage refund pool
-                if (!features::governed_gas_pool_enabled()){
-                    transaction_fee::mint_and_refund(gas_payer_address, mint_amount);
+                if (features::operations_default_to_fa_apt_store_enabled()) {
+                    assert!(
+                        aptos_account::is_fungible_balance_at_least(gas_payer_address, transaction_fee_amount),
+                        error::out_of_range(PROLOGUE_ECANT_PAY_GAS_DEPOSIT),
+                    );
+                } else {
+                    assert!(
+                        coin::is_balance_at_least<AptosCoin>(gas_payer_address, transaction_fee_amount),
+                        error::out_of_range(PROLOGUE_ECANT_PAY_GAS_DEPOSIT),
+                    );
                 };
-                permissioned_signer::increase_limit(
-                    &gas_payer,
-                    (mint_amount as u256),
-                    GasPermission {}
-                );
+
+                if (transaction_fee_amount > storage_fee_refunded) {
+                    let burn_amount = transaction_fee_amount - storage_fee_refunded;
+                    if (features::governed_gas_pool_enabled()){
+                        governed_gas_pool::deposit_gas_fee_v2(gas_payer_address, burn_amount);
+                    } else {
+                        transaction_fee::burn_fee(gas_payer_address, burn_amount);
+                    };
+                    permissioned_signer::check_permission_consume(
+                        &gas_payer,
+                        (burn_amount as u256),
+                        GasPermission {}
+                    );
+                } else {
+                    let mint_amount = storage_fee_refunded - transaction_fee_amount;
+                    // TODO: we cannot mint to do storage refund. We need to have a storage refund pool
+                    if (!features::governed_gas_pool_enabled()){
+                        transaction_fee::mint_and_refund(gas_payer_address, mint_amount);
+                    };
+                    permissioned_signer::increase_limit(
+                        &gas_payer,
+                        (mint_amount as u256),
+                        GasPermission {}
+                    );
+                };
             };
         };
 

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -525,6 +525,12 @@ pub enum EntryFunctionCall {
         pool_address: AccountAddress,
     },
 
+    /// Enable partial governance voting on a delegation pool if it has not already been initialized.
+    /// This is intended for idempotent migration scripts over existing delegation pools.
+    DelegationPoolEnablePartialGovernanceVotingIfNeeded {
+        pool_address: AccountAddress,
+    },
+
     /// Evict a delegator that is not allowlisted by unlocking their entire stake.
     DelegationPoolEvictDelegator {
         delegator_address: AccountAddress,
@@ -1656,6 +1662,9 @@ impl EntryFunctionCall {
             },
             DelegationPoolEnablePartialGovernanceVoting { pool_address } => {
                 delegation_pool_enable_partial_governance_voting(pool_address)
+            },
+            DelegationPoolEnablePartialGovernanceVotingIfNeeded { pool_address } => {
+                delegation_pool_enable_partial_governance_voting_if_needed(pool_address)
             },
             DelegationPoolEvictDelegator { delegator_address } => {
                 delegation_pool_evict_delegator(delegator_address)
@@ -3493,6 +3502,25 @@ pub fn delegation_pool_enable_partial_governance_voting(
             ident_str!("delegation_pool").to_owned(),
         ),
         ident_str!("enable_partial_governance_voting").to_owned(),
+        vec![],
+        vec![bcs::to_bytes(&pool_address).unwrap()],
+    ))
+}
+
+/// Enable partial governance voting on a delegation pool if it has not already been initialized.
+/// This is intended for idempotent migration scripts over existing delegation pools.
+pub fn delegation_pool_enable_partial_governance_voting_if_needed(
+    pool_address: AccountAddress,
+) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("delegation_pool").to_owned(),
+        ),
+        ident_str!("enable_partial_governance_voting_if_needed").to_owned(),
         vec![],
         vec![bcs::to_bytes(&pool_address).unwrap()],
     ))
@@ -6722,6 +6750,20 @@ mod decoder {
         }
     }
 
+    pub fn delegation_pool_enable_partial_governance_voting_if_needed(
+        payload: &TransactionPayload,
+    ) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(
+                EntryFunctionCall::DelegationPoolEnablePartialGovernanceVotingIfNeeded {
+                    pool_address: bcs::from_bytes(script.args().get(0)?).ok()?,
+                },
+            )
+        } else {
+            None
+        }
+    }
+
     pub fn delegation_pool_evict_delegator(
         payload: &TransactionPayload,
     ) -> Option<EntryFunctionCall> {
@@ -8389,6 +8431,10 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<EntryFunctionDecoderMa
         map.insert(
             "delegation_pool_enable_partial_governance_voting".to_string(),
             Box::new(decoder::delegation_pool_enable_partial_governance_voting),
+        );
+        map.insert(
+            "delegation_pool_enable_partial_governance_voting_if_needed".to_string(),
+            Box::new(decoder::delegation_pool_enable_partial_governance_voting_if_needed),
         );
         map.insert(
             "delegation_pool_evict_delegator".to_string(),

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -848,6 +848,7 @@ Lifetime: transient
 
 Whether the Atomic bridge is available
 Lifetime: transient
+Deprecated in favor of <code><a href="features.md#0x1_features_ALLOW_SERIALIZED_SCRIPT_ARGS">ALLOW_SERIALIZED_SCRIPT_ARGS</a></code> as feature flag 72
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_NATIVE_BRIDGE">NATIVE_BRIDGE</a>: u64 = 72;

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -166,6 +166,8 @@ return true.
 -  [Function `is_calculate_transaction_fee_for_distribution_enabled`](#0x1_features_is_calculate_transaction_fee_for_distribution_enabled)
 -  [Function `get_distribute_transaction_fee_feature`](#0x1_features_get_distribute_transaction_fee_feature)
 -  [Function `is_distribute_transaction_fee_enabled`](#0x1_features_is_distribute_transaction_fee_enabled)
+-  [Function `get_gas_payable_fa_feature`](#0x1_features_get_gas_payable_fa_feature)
+-  [Function `is_gas_payable_fa_enabled`](#0x1_features_is_gas_payable_fa_enabled)
 -  [Function `get_stake_reward_using_treasury_feature`](#0x1_features_get_stake_reward_using_treasury_feature)
 -  [Function `stake_reward_using_treasury_enabled`](#0x1_features_stake_reward_using_treasury_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
@@ -689,6 +691,18 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_FEE_PAYER_ENABLED">FEE_PAYER_ENABLED</a>: u64 = 22;
+</code></pre>
+
+
+
+<a id="0x1_features_GAS_PAYABLE_FA"></a>
+
+Whether a transaction may pay for gas in a fungible asset other than APT,
+specified via the <code>gas_fa_coin</code> field of the transaction's extra config.
+Lifetime: transient
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_GAS_PAYABLE_FA">GAS_PAYABLE_FA</a>: u64 = 98;
 </code></pre>
 
 
@@ -4296,6 +4310,52 @@ Whether the Governed Gas Pool is enabled.
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_distribute_transaction_fee_enabled">is_distribute_transaction_fee_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_DISTRIBUTE_TRANSACTION_FEE">DISTRIBUTE_TRANSACTION_FEE</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_get_gas_payable_fa_feature"></a>
+
+## Function `get_gas_payable_fa_feature`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_gas_payable_fa_feature">get_gas_payable_fa_feature</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_gas_payable_fa_feature">get_gas_payable_fa_feature</a>(): u64 { <a href="features.md#0x1_features_GAS_PAYABLE_FA">GAS_PAYABLE_FA</a> }
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_is_gas_payable_fa_enabled"></a>
+
+## Function `is_gas_payable_fa_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_gas_payable_fa_enabled">is_gas_payable_fa_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_gas_payable_fa_enabled">is_gas_payable_fa_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_GAS_PAYABLE_FA">GAS_PAYABLE_FA</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -793,6 +793,17 @@ module std::features {
         is_enabled(DISTRIBUTE_TRANSACTION_FEE)
     }
 
+    /// Whether a transaction may pay for gas in a fungible asset other than APT,
+    /// specified via the `gas_fa_coin` field of the transaction's extra config.
+    /// Lifetime: transient
+    const GAS_PAYABLE_FA: u64 = 98;
+
+    public fun get_gas_payable_fa_feature(): u64 { GAS_PAYABLE_FA }
+
+    public fun is_gas_payable_fa_enabled(): bool acquires Features {
+        is_enabled(GAS_PAYABLE_FA)
+    }
+
     /// Whether the staking rewards are mint (diseable) or withdraw from the gouverned gas pool treasury (enable).
     ///
     /// Lifetime: permanent

--- a/aptos-move/framework/src/natives/transaction_context.rs
+++ b/aptos-move/framework/src/natives/transaction_context.rs
@@ -368,6 +368,30 @@ fn native_multisig_payload_internal(
     }
 }
 
+fn native_gas_payment_fa_metadata_internal(
+    context: &mut SafeNativeContext,
+    _ty_args: Vec<Type>,
+    _args: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    context.charge(TRANSACTION_CONTEXT_GAS_PAYMENT_FA_METADATA_BASE)?;
+
+    let user_transaction_context_opt = get_user_transaction_context_opt_from_context(context);
+    if let Some(transaction_context) = user_transaction_context_opt {
+        // `Option<address>` is `struct { vec: vector<address> }`: a singleton vector for `Some`,
+        // an empty one for `None`. Build the inner vector with `vector_address` so it carries the
+        // proper element type (the testing-only vector helpers do not, which fails type checks).
+        let inner = match transaction_context.gas_fa_coin() {
+            Some(metadata_address) => Value::vector_address(vec![metadata_address]),
+            None => Value::vector_address(vec![]),
+        };
+        Ok(smallvec![Value::struct_(Struct::pack(vec![inner]))])
+    } else {
+        Err(SafeNativeError::Abort {
+            abort_code: error::invalid_state(abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE),
+        })
+    }
+}
+
 fn get_user_transaction_context_opt_from_context<'a>(
     context: &'a SafeNativeContext,
 ) -> &'a Option<UserTransactionContext> {
@@ -404,6 +428,10 @@ pub fn make_all(
         (
             "multisig_payload_internal",
             native_multisig_payload_internal,
+        ),
+        (
+            "gas_payment_fa_metadata_internal",
+            native_gas_payment_fa_metadata_internal,
         ),
     ];
 

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -739,6 +739,17 @@ TransactionExtraConfig:
                 TYPENAME: AccountAddress
           - replay_protection_nonce:
               OPTION: U64
+    1:
+      V2:
+        STRUCT:
+          - multisig_address:
+              OPTION:
+                TYPENAME: AccountAddress
+          - replay_protection_nonce:
+              OPTION: U64
+          - gas_fa_coin:
+              OPTION:
+                TYPENAME: AccountAddress
 TransactionInfo:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/aptos.yaml
+++ b/testsuite/generate-format/tests/staged/aptos.yaml
@@ -661,6 +661,17 @@ TransactionExtraConfig:
                 TYPENAME: AccountAddress
           - replay_protection_nonce:
               OPTION: U64
+    1:
+      V2:
+        STRUCT:
+          - multisig_address:
+              OPTION:
+                TYPENAME: AccountAddress
+          - replay_protection_nonce:
+              OPTION: U64
+          - gas_fa_coin:
+              OPTION:
+                TYPENAME: AccountAddress
 TransactionPayload:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -1170,6 +1170,17 @@ TransactionExtraConfig:
                 TYPENAME: AccountAddress
           - replay_protection_nonce:
               OPTION: U64
+    1:
+      V2:
+        STRUCT:
+          - multisig_address:
+              OPTION:
+                TYPENAME: AccountAddress
+          - replay_protection_nonce:
+              OPTION: U64
+          - gas_fa_coin:
+              OPTION:
+                TYPENAME: AccountAddress
 TransactionPayload:
   ENUM:
     0:

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -143,6 +143,9 @@ pub enum FeatureFlag {
 
     CALCULATE_TRANSACTION_FEE_FOR_DISTRIBUTION = 96,
     DISTRIBUTE_TRANSACTION_FEE = 97,
+    /// Whether a transaction may pay for gas in a fungible asset other than APT,
+    /// specified via the `gas_fa_coin` field of the transaction's extra config.
+    GAS_PAYABLE_FA = 98,
     GOVERNED_GAS_POOL = 223,
     STAKE_REWARD_USING_TREASURY = 224,
     /// Use the fixed `extract_abort_info` lookup that does not spuriously match
@@ -431,6 +434,10 @@ impl Features {
 
     pub fn is_distribute_transaction_fee_enabled(&self) -> bool {
         self.is_enabled(FeatureFlag::DISTRIBUTE_TRANSACTION_FEE)
+    }
+
+    pub fn is_gas_payable_fa_enabled(&self) -> bool {
+        self.is_enabled(FeatureFlag::GAS_PAYABLE_FA)
     }
 
     pub fn get_max_identifier_size(&self) -> u64 {

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -741,6 +741,13 @@ pub enum TransactionExtraConfig {
         // Some(nonce) for orderless transactions
         replay_protection_nonce: Option<u64>,
     },
+    V2 {
+        multisig_address: Option<AccountAddress>,
+        // None for regular transactions
+        // Some(nonce) for orderless transactions
+        replay_protection_nonce: Option<u64>,
+        gas_fa_coin: Option<AccountAddress>,
+    },
 }
 
 impl TransactionPayload {
@@ -863,6 +870,18 @@ impl TransactionPayload {
                             Some(rng.gen())
                         }),
                     },
+                    TransactionExtraConfig::V2 {
+                        multisig_address,
+                        replay_protection_nonce,
+                        gas_fa_coin,
+                    } => TransactionExtraConfig::V2 {
+                        multisig_address,
+                        replay_protection_nonce: replay_protection_nonce.or_else(|| {
+                            let mut rng = rand::thread_rng();
+                            Some(rng.gen())
+                        }),
+                        gas_fa_coin,
+                    },
                 }
             }
             TransactionPayload::Payload(TransactionPayloadInner::V1 {
@@ -885,6 +904,10 @@ impl TransactionExtraConfig {
             Self::V1 {
                 replay_protection_nonce,
                 ..
+            }
+            | Self::V2 {
+                replay_protection_nonce,
+                ..
             } => *replay_protection_nonce,
         }
     }
@@ -898,6 +921,9 @@ impl TransactionExtraConfig {
             Self::V1 {
                 multisig_address,
                 replay_protection_nonce: _,
+            }
+            | Self::V2 {
+                multisig_address, ..
             } => *multisig_address,
         }
     }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -815,13 +815,15 @@ impl TransactionPayload {
         match self {
             TransactionPayload::Script(_)
             | TransactionPayload::EntryFunction(_)
-            | TransactionPayload::ModuleBundle(_) => TransactionExtraConfig::V1 {
+            | TransactionPayload::ModuleBundle(_) => TransactionExtraConfig::V2 {
                 multisig_address: None,
                 replay_protection_nonce: None,
+                gas_fa_coin: None,
             },
-            TransactionPayload::Multisig(multisig) => TransactionExtraConfig::V1 {
+            TransactionPayload::Multisig(multisig) => TransactionExtraConfig::V2 {
                 multisig_address: Some(multisig.multisig_address),
                 replay_protection_nonce: None,
+                gas_fa_coin: None,
             },
             TransactionPayload::Payload(TransactionPayloadInner::V1 { extra_config, .. }) => {
                 extra_config.clone()
@@ -926,6 +928,18 @@ impl TransactionExtraConfig {
                 multisig_address, ..
             } => *multisig_address,
         }
+    }
+
+    pub fn gas_fa_coin(&self) -> Option<AccountAddress> {
+        match self {
+            Self::V1 { .. } => None,
+            Self::V2 {  gas_fa_coin, .. } => *gas_fa_coin
+        }
+    }
+
+    pub fn has_gas_fa_coin(&self) -> bool {
+        self.gas_fa_coin().is_some()
+
     }
 }
 

--- a/types/src/transaction/user_transaction_context.rs
+++ b/types/src/transaction/user_transaction_context.rs
@@ -13,6 +13,7 @@ pub struct UserTransactionContext {
     chain_id: u8,
     entry_function_payload: Option<EntryFunctionPayload>,
     multisig_payload: Option<MultisigPayload>,
+    gas_fa_coin: Option<AccountAddress>,
 }
 
 impl UserTransactionContext {
@@ -25,6 +26,7 @@ impl UserTransactionContext {
         chain_id: u8,
         entry_function_payload: Option<EntryFunctionPayload>,
         multisig_payload: Option<MultisigPayload>,
+        gas_fa_coin: Option<AccountAddress>,
     ) -> Self {
         Self {
             sender,
@@ -35,6 +37,7 @@ impl UserTransactionContext {
             chain_id,
             entry_function_payload,
             multisig_payload,
+            gas_fa_coin,
         }
     }
 
@@ -68,6 +71,12 @@ impl UserTransactionContext {
 
     pub fn multisig_payload(&self) -> Option<MultisigPayload> {
         self.multisig_payload.clone()
+    }
+
+    /// The fungible asset metadata address the transaction elected to pay gas in, if any.
+    /// `None` means gas is paid in the default currency (APT).
+    pub fn gas_fa_coin(&self) -> Option<AccountAddress> {
+        self.gas_fa_coin
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the ability for a transaction to pay its gas in a selected **fungible asset** instead of the native token, governed end-to-end by on-chain configuration. A transaction opts in by naming an FA in the new versioned payload; the VM validates it in the prologue, charges the fee in that FA in the epilogue, and routes it into a per-FA **governed gas pool**. Fully gated behind a new feature flag and inert until governance enables it, so it's a no-op for existing traffic.

## What's included

**Transaction format**
- New `TransactionExtraConfig::V2` variant carrying `gas_fa_coin: Option<AccountAddress>` (the FA metadata object address to pay gas in), plus accessors (`gas_fa_coin()`, `has_gas_fa_coin()`) and handling in `api/types` conversion and `TransactionMetadata`.

**Feature gate**
- New `GAS_PAYABLE_FA` feature flag (Rust `FeatureFlag`, Move `features.move`, release-builder mapping). The VM (`validate_signed_transaction`) rejects any transaction carrying `gas_fa_coin` with `FEATURE_UNDER_GATING` unless the flag is enabled.

**Surfacing the choice to Move**
- New `transaction_context::gas_payment_fungible_asset(): Option<address>` accessor + native, with `gas_fa_coin` threaded through `UserTransactionContext` and a gas-schedule entry for the native.

**Governed gas pool (per-FA pools + pricing)**
- `governed_gas_pool` now holds a governance-managed registry of accepted gas FAs, each with its **own gas price** (FA base units per gas unit) and its **own pool** (the pool account's primary store for that FA — separate balance/accounting per asset).
- Entry points: `add_accepted_gas_fungible_asset(metadata, gas_price)`, `set_gas_fungible_asset_price`, `remove_accepted_gas_fungible_asset` (all governance-gated), plus views (`is_accepted_…`, `accepted_…`, `get_gas_fungible_asset_price`, `gas_fee_in_fa`, pool balance) and events.

**VM wiring (`transaction_validation.move`)**
- Prologue: when a txn elects `gas_fa_coin`, require the FA is accepted and the payer holds enough of it (`gas_used_max × price`).
- Epilogue: charge `gas_used × price` in the FA into its governed gas pool. Wired into **both** the unified epilogue and the legacy `epilogue_gas_payer_extended` / `epilogue_extended` paths, so it works whether or not account abstraction is enabled (the latter matters on Movement, where AA is off).

## Design notes

- **FA-only, by necessity.** The gas asset is identified by an FA metadata address, so charging uses the privileged FA store path. Legacy `Coin<T>` types that aren't FA-migrated (e.g. MOVE on Movement) live in a typed `CoinStore` that no address-keyed path can reach, and runtime coin dispatch would need `ENABLE_FUNCTION_VALUES` (off on Movement). So accepted gas coins must be fungible assets. The native token keeps its existing default gas path.
- **Flat per-FA price.** The fee is `gas_used × gas_price`, with `gas_price` set by governance per FA — deterministic, no oracle/DEX dependency in the gas hot path. (A keeper-updated market rate can layer on top later without touching the epilogue.)
- **Backward compatible.** Additive only — new payload variant, new feature flag, new functions, gated branches. Prologue/epilogue call ABIs are unchanged and behavior is identical to today until `GAS_PAYABLE_FA` is enabled and an FA is accepted.

## Testing

- **Framework Move unit tests** (`governed_gas_pool`, `transaction_context`): registry add/remove, governance authorization, zero-price rejection, per-FA price get/set, `gas_fee_in_fa`, multi-FA pool isolation, deposit-when-not-accepted abort, feature-gate abort. Full suite green.
- **e2e (`e2e-move-tests`):** FA gas routed to its pool (exact `gas_used × price`) on both the unified and legacy fee-payer/regular-sender epilogue paths; unaccepted-FA and insufficient-balance transactions discarded by the prologue; gas charged even on an aborted-but-kept transaction; feature-gating and the `transaction_context` accessor (Some/None/disabled).

## Limitations / follow-ups

- FA-only (see design note); legacy non-FA coins are out of scope on the current Movement config.
- No storage-fee-refund netting for FA payers (APT-refund semantics don't translate).
- Flat governance-set price; no market/oracle pricing yet.
- Lighter coverage for multisig+FA, orderless(nonce)+FA, and simulation paths.
- MISSING: re-distributing the governed gas pool in FA is not implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/movement-network/codesmith/aptos-core/pr/413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789219458&installation_model_id=17568&pr_number=413&repository=movement-network%2Faptos-core&return_to=https%3A%2F%2Fgithub.com%2Fmovement-network%2Faptos-core%2Fpull%2F413&signature=6a05fa5eaecb4b3b4c2ff8b281d70c46727776ae9c45fc0d897ef9d87fb19acd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->