### PR TITLE
[token-objects] fix royalty lookup after rename

### DIFF
--- a/aptos-move/framework/aptos-token-objects/doc/token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/token.md
@@ -1645,6 +1645,13 @@ as that would prohibit transactions to be executed in parallel.
 
 ## Function `royalty`
 
+The royalty published on the token, or, when the token has none of its own, the royalty of
+the collection it was minted into.
+
+The collection is read from the object reference recorded on the token at mint time. It must
+never be re-derived from <code>creator + collection_name</code>: <code><a href="collection.md#0x4_collection_set_name">collection::set_name</a></code> moves the name
+out from under that derivation, which then resolves to a different collection of the same
+creator - paying out its royalty instead - or to no object at all.
 
 
 <pre><code>#[view]
@@ -1658,15 +1665,11 @@ as that would prohibit transactions to be executed in parallel.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="royalty.md#0x4_royalty">royalty</a>&lt;T: key&gt;(<a href="token.md#0x4_token">token</a>: Object&lt;T&gt;): Option&lt;Royalty&gt; <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a> {
-    <a href="token.md#0x4_token_borrow">borrow</a>(&<a href="token.md#0x4_token">token</a>);
+    <b>let</b> <a href="collection.md#0x4_collection">collection</a> = <a href="token.md#0x4_token_borrow">borrow</a>(&<a href="token.md#0x4_token">token</a>).<a href="collection.md#0x4_collection">collection</a>;
     <b>let</b> <a href="royalty.md#0x4_royalty">royalty</a> = <a href="royalty.md#0x4_royalty_get">royalty::get</a>(<a href="token.md#0x4_token">token</a>);
     <b>if</b> (<a href="royalty.md#0x4_royalty">royalty</a>.is_some()) {
         <a href="royalty.md#0x4_royalty">royalty</a>
     } <b>else</b> {
-        <b>let</b> creator = <a href="token.md#0x4_token_creator">creator</a>(<a href="token.md#0x4_token">token</a>);
-        <b>let</b> collection_name = <a href="token.md#0x4_token_collection_name">collection_name</a>(<a href="token.md#0x4_token">token</a>);
-        <b>let</b> collection_address = <a href="collection.md#0x4_collection_create_collection_address">collection::create_collection_address</a>(&creator, &collection_name);
-        <b>let</b> <a href="collection.md#0x4_collection">collection</a> = <a href="../../aptos-framework/doc/object.md#0x1_object_address_to_object">object::address_to_object</a>&lt;<a href="collection.md#0x4_collection_Collection">collection::Collection</a>&gt;(collection_address);
         <a href="royalty.md#0x4_royalty_get">royalty::get</a>(<a href="collection.md#0x4_collection">collection</a>)
     }
 }

--- a/aptos-move/framework/aptos-token-objects/sources/token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/token.move
@@ -682,16 +682,14 @@ module aptos_token_objects::token {
     }
 
     #[view]
+    /// The royalty published on the token, or, when the token has none of its own, the royalty of
+    /// the collection it was minted into.
     public fun royalty<T: key>(token: Object<T>): Option<Royalty> acquires Token {
-        borrow(&token);
+        let collection = borrow(&token).collection;
         let royalty = royalty::get(token);
         if (royalty.is_some()) {
             royalty
         } else {
-            let creator = creator(token);
-            let collection_name = collection_name(token);
-            let collection_address = collection::create_collection_address(&creator, &collection_name);
-            let collection = object::address_to_object<collection::Collection>(collection_address);
             royalty::get(collection)
         }
     }
@@ -1294,6 +1292,145 @@ module aptos_token_objects::token {
         create_token_with_collection_helper(creator, collection, token_name);
 
         assert!(collection::count(collection) == option::some(2), 0);
+    }
+
+    #[test(creator = @0x123)]
+    /// A token without its own royalty reads the royalty of the collection it was minted into, and
+    /// keeps reading it after the collection is renamed. Resolving the collection by re-deriving
+    /// `creator + collection_name` breaks here: nothing is published at the address derived from
+    /// the new name.
+    fun test_collection_royalty_fallback_survives_rename(creator: &signer) acquires Token {
+        let creator_address = signer::address_of(creator);
+        let expected_royalty = royalty::create(5, 100, creator_address);
+
+        let collection_ref = create_collection_with_royalty_helper(
+            creator,
+            string::utf8(b"collection name"),
+            expected_royalty,
+        );
+        let collection = object::object_from_constructor_ref<Collection>(&collection_ref);
+        let mutator_ref = collection::generate_mutator_ref(&collection_ref);
+
+        let token_ref = create_token_without_royalty_helper(creator, collection, string::utf8(b"token name"));
+        let token = object::object_from_constructor_ref<Token>(&token_ref);
+        assert!(royalty(token) == option::some(expected_royalty), 0);
+
+        collection::set_name(&mutator_ref, string::utf8(b"renamed collection name"));
+        assert!(royalty(token) == option::some(expected_royalty), 1);
+    }
+
+    #[test(creator = @0x123)]
+    /// Renaming a collection onto the name of another collection by the same creator must not
+    /// repoint the renamed collection's tokens at the other collection's royalty. After the rename,
+    /// `create_collection_address(creator, collection_name(token))` is exactly the other
+    /// collection's address, so resolving the collection by name pays out the wrong royalty - and
+    /// does so even when the original collection's royalty was published as immutable.
+    fun test_collection_royalty_not_repointed_by_name_collision(creator: &signer) acquires Token {
+        let creator_address = signer::address_of(creator);
+        let original_name = string::utf8(b"collection name");
+        let other_collection_name = string::utf8(b"other collection name");
+
+        let expected_royalty = royalty::create(5, 100, creator_address);
+        let collection_ref = create_collection_with_royalty_helper(creator, original_name, expected_royalty);
+        let collection = object::object_from_constructor_ref<Collection>(&collection_ref);
+        let mutator_ref = collection::generate_mutator_ref(&collection_ref);
+
+        // A second collection by the same creator, paying a different royalty to a different payee.
+        let other_royalty = royalty::create(99, 100, @0xbad);
+        create_collection_with_royalty_helper(creator, other_collection_name, other_royalty);
+
+        let token_ref = create_token_without_royalty_helper(creator, collection, string::utf8(b"token name"));
+        let token = object::object_from_constructor_ref<Token>(&token_ref);
+
+        collection::set_name(&mutator_ref, other_collection_name);
+
+        // The name-derived address now points at the other collection rather than at this token's.
+        let derived_address = collection::create_collection_address(&creator_address, &collection_name(token));
+        assert!(derived_address != object::object_address(&collection), 0);
+        assert!(royalty::get(object::address_to_object<Collection>(derived_address)) == option::some(other_royalty), 1);
+
+        let actual_royalty = royalty(token).destroy_some();
+        assert!(actual_royalty == expected_royalty, 2);
+        assert!(royalty::payee_address(&actual_royalty) == creator_address, 3);
+        assert!(royalty::numerator(&actual_royalty) == 5, 4);
+    }
+
+    #[test(creator = @0x123)]
+    /// A royalty published on the token itself wins over the collection's, before and after a rename.
+    fun test_token_royalty_takes_precedence_over_collection(creator: &signer) acquires Token {
+        let creator_address = signer::address_of(creator);
+        let collection_royalty = royalty::create(5, 100, creator_address);
+        let token_royalty = royalty::create(10, 100, @0xa11ce);
+
+        let collection_ref = create_collection_with_royalty_helper(
+            creator,
+            string::utf8(b"collection name"),
+            collection_royalty,
+        );
+        let collection = object::object_from_constructor_ref<Collection>(&collection_ref);
+        let mutator_ref = collection::generate_mutator_ref(&collection_ref);
+
+        let token_ref = create_named_token_object(
+            creator,
+            collection,
+            string::utf8(b"token description"),
+            string::utf8(b"token name"),
+            option::some(token_royalty),
+            string::utf8(b"uri"),
+        );
+        let token = object::object_from_constructor_ref<Token>(&token_ref);
+        assert!(royalty(token) == option::some(token_royalty), 0);
+
+        collection::set_name(&mutator_ref, string::utf8(b"renamed collection name"));
+        assert!(royalty(token) == option::some(token_royalty), 1);
+    }
+
+    #[test(creator = @0x123)]
+    /// Neither the token nor its collection carries a royalty: the lookup reports none rather than
+    /// aborting, both before and after a rename.
+    fun test_royalty_absent_survives_rename(creator: &signer) acquires Token {
+        let collection_ref = create_fixed_collection(creator, string::utf8(b"collection name"), 5);
+        let collection = object::object_from_constructor_ref<Collection>(&collection_ref);
+        let mutator_ref = collection::generate_mutator_ref(&collection_ref);
+
+        let token_ref = create_token_without_royalty_helper(creator, collection, string::utf8(b"token name"));
+        let token = object::object_from_constructor_ref<Token>(&token_ref);
+        assert!(royalty(token).is_none(), 0);
+
+        collection::set_name(&mutator_ref, string::utf8(b"renamed collection name"));
+        assert!(royalty(token).is_none(), 1);
+    }
+
+    #[test_only]
+    fun create_collection_with_royalty_helper(
+        creator: &signer,
+        collection_name: String,
+        royalty: Royalty,
+    ): ConstructorRef {
+        collection::create_fixed_collection(
+            creator,
+            string::utf8(b"collection description"),
+            5,
+            collection_name,
+            option::some(royalty),
+            string::utf8(b"collection uri"),
+        )
+    }
+
+    #[test_only]
+    fun create_token_without_royalty_helper(
+        creator: &signer,
+        collection: Object<Collection>,
+        token_name: String,
+    ): ConstructorRef {
+        create_named_token_object(
+            creator,
+            collection,
+            string::utf8(b"token description"),
+            token_name,
+            option::none(),
+            string::utf8(b"uri"),
+        )
     }
 
     #[test_only]


### PR DESCRIPTION
## Description

`token::royalty` falls back to the collection's royalty when a token carries none of its own. It picked that collection by re-deriving `collection::create_collection_address(creator, collection_name)`. Collection names are mutable via `collection::set_name`, which moves the name out from under that derivation, so after any rename the lookup no longer resolves to the token's own collection. Two consequences, both reachable:

1. **The view aborts.** If no collection of that creator holds the new name, `object::address_to_object` aborts with `EOBJECT_DOES_NOT_EXIST` for every token in the collection. `royalty` is a `#[view]`, and marketplaces call it to compute payouts — see `compute_royalty` in `aptos-move/move-examples/marketplace/sources/listing.move`, which calls `tokenv2::royalty(listing.object)` directly. Sales of any renamed collection break, unrecoverably.

2. **Royalty is misdirected.** If the creator already holds a second collection under that name, the derivation lands on *that* collection and the token pays out its royalty. This defeats immutability: a royalty published without a `royalty::MutatorRef` cannot be edited, but renaming repoints which royalty is read at all.

The fix reads the `Object<Collection>` recorded on the token at mint time (`Token.collection`) rather than re-deriving it. That field is written once at creation and is unaffected by renames. Folding the read into the existing `borrow` also preserves the pre-existing `ETOKEN_DOES_NOT_EXIST` guard ordering, so a non-token object still aborts before any royalty is read.

### Note on the threat model

A related patch upstream (aptos-labs/aptos-core#20385) describes this as a third-party "shadow collection" attack, where an outside attacker registers a same-named collection at the derived address. That is not possible. `create_collection_address(creator, name)` is `object::create_object_address(creator, name)`, and `Collection.creator` is always `signer::address_of` of the account that published the named object — so the derived address always sits in the legitimate creator's own named-object space, which no other account can publish into. The reachable failure modes are the two above; the second requires only the creator's own two collections, no attacker account.

### Scope

`create_common` (`token.move`) and `aptos_token::collection_object` also derive collections by name, but there the *caller* supplies the name — they are lookup-by-name APIs, and `collection::set_name`'s doc comment already states that contract. Changing them would alter public API semantics rather than fix a bug, so they are left alone.

## How Has This Been Tested?

Four regression tests added to `aptos-token-objects/sources/token.move`. Run with:

```
RUST_MIN_STACK=134217728 cargo test -p aptos-framework --test move_unit_test move_token_objects_unit_tests
```

| Test | Before the fix | After |
|---|---|---|
| `test_collection_royalty_fallback_survives_rename` | abort `393218` (`EOBJECT_DOES_NOT_EXIST`) | PASS |
| `test_collection_royalty_not_repointed_by_name_collision` | abort `2` — token reported 99% to `@0xbad` | PASS |
| `test_royalty_absent_survives_rename` | abort `393218` | PASS |
| `test_token_royalty_takes_precedence_over_collection` | PASS (token royalty short-circuits) | PASS |

The first three fail against the old lookup; the fourth is a guard against over-correcting. The collision test additionally asserts that the name-derived address really does resolve to the other collection and really does hold its royalty, so it pins the mechanism rather than just the symptom.

Full `aptos-token-objects` suite after the fix: **87 passed, 0 failed**.

## Key Areas to Review

- Whether preserving the `ETOKEN_DOES_NOT_EXIST`-before-`royalty::get` ordering matters to any caller. `let collection = borrow(&token).collection;` keeps the old behaviour, where the bare `borrow(&token);` ran first.
- Behaviour change for already-renamed collections on chain: `royalty()` currently aborts for them and will start returning the original collection's royalty. That is the intended fix, but it does change observed values for any collection that was renamed onto a sibling's name.

## Type of Change
- [x] Bug fix
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Aptos Framework

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/movement-network/codesmith/aptos-core/pr/416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789830545&installation_model_id=17568&pr_number=416&repository=movement-network%2Faptos-core&return_to=https%3A%2F%2Fgithub.com%2Fmovement-network%2Faptos-core%2Fpull%2F416&signature=2287343a02faf56acb9a24172f9c367d64040ad4667b34874d20c607e7721347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->